### PR TITLE
Build all targets on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ install:
 - git submodule update --init --recursive
 - choco install ninja -version 1.6.0
 build_script:
-- python src\build_mozc.py gyp --noqt
-- ninja -C src\out_win\Release mozc_cache_service mozc_renderer mozc_ime mozc_tip32 mozc_broker32 rewriter composer
+- cd src
+- python build_mozc.py gyp --noqt
+- python build_mozc.py build -c Release package
 test: off


### PR DESCRIPTION
Judging from a test run with this change on AppVeyor, it seems to be possible for AppVeyor to build all the targets for Windows within its timeout (40 min).  Let's enable full build to see how it goes.