### PR TITLE
OSX build does not require Ninja yet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,6 @@ os:
 
 language: objective-c
 
-install:
-  - git -C src/third_party clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  - export PATH="$PATH":`pwd`/src/third_party/depot_tools
-
 script:
   - cd ./src
   - GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt

--- a/doc/build_mozc_in_osx.md
+++ b/doc/build_mozc_in_osx.md
@@ -10,7 +10,6 @@ We only support OS X 10.7 or later intel only.
 Building on Mac requires the following software.
 
   * Xcode
-  * [Ninja](https://github.com/martine/ninja)
 
 If you don't need to run gui tools like about dialog, config dialog, or dictionary tool, you can omit installing Qt.  Candidate window still shows without Qt.  See below for the detailed information.
 


### PR DESCRIPTION
Until #247 is fixed, we don't need to ask people to install Ninja for building OSX binaries.