### PR TITLE
Enable Linux desktop build on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,34 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+sudo: false
+
 os:
+  - linux
   - osx
 
-language: objective-c
+language: cpp
+
+compiler: clang
+
+addons:
+  apt:
+    packages:
+    - clang-3.4
+    - libglib2.0-dev
+    - libgtk2.0-dev
+    - libibus-1.0-dev
+    - libqt4-dev
+    - libxcb-xfixes0-dev
+    - pkg-config
+
+install:
+  - if [ $TRAVIS_OS_NAME == linux ]; then git -C src/third_party clone https://chromium.googlesource.com/chromium/tools/depot_tools.git; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then export PATH="$PATH":`pwd`/src/third_party/depot_tools; fi
 
 script:
   - cd ./src
-  - GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt
-  - python build_mozc.py build -c Release mac/mac.gyp:GoogleJapaneseInput mac/mac.gyp:gen_launchd_confs
+  - if [ $TRAVIS_OS_NAME == linux ]; then python build_mozc.py gyp; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then python build_mozc.py build -c Release package; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then python build_mozc.py build -c Release mac/mac.gyp:GoogleJapaneseInput mac/mac.gyp:gen_launchd_confs; fi

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ OpenSource project originates from
 Build Status
 ------------
 
-|Android |Windows |OS X |Linux |NaCl |
-|:------:|:------:|:---:|:----:|:---:|
-|N/A     |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |N/A |N/A |
+|Android |Windows |OS X + Linux |NaCl |
+|:------:|:------:|:-----------:|:---:|
+|N/A     |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |N/A |
 
 What's Mozc?
 ------------

--- a/src/docker/fedora21/Dockerfile
+++ b/src/docker/fedora21/Dockerfile
@@ -34,7 +34,7 @@ RUN yum -y update
 ## Common packages for linux build environment
 RUN yum install -y clang libstdc++-static python git curl bzip2 unzip
 ## Packages for linux desktop version
-RUN yum install -y ibus-devel glib2-devel qt-devel zinnia-tomoe-ja gtk2-devel libxcb-devel
+RUN yum install -y ibus-devel glib2-devel qt-devel gtk2-devel libxcb-devel
 ## Packages for Android
 RUN yum install -y java-1.7.0-openjdk-devel jsr-305 ant glibc.i686 glibc-devel.i686 libstdc++.i686 ncurses-devel.i686 zlib-devel.i686 zip
 ## For emacsian

--- a/src/docker/ubuntu14.04/Dockerfile
+++ b/src/docker/ubuntu14.04/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update
 ## Common packages for linux build environment
 RUN apt install -y clang python pkg-config git curl bzip2 unzip make
 ## Packages for linux desktop version
-RUN apt install -y libibus-1.0-dev libdbus-1-dev libglib2.0-dev libqt4-dev tegaki-zinnia-japanese libgtk2.0-dev libxcb-xfixes0-dev
+RUN apt install -y libibus-1.0-dev libglib2.0-dev libqt4-dev libgtk2.0-dev libxcb-xfixes0-dev
 ## Packages for Android
 RUN apt install -y --no-install-recommends openjdk-7-jdk openjdk-7-jre-headless libjsr305-java ant libc6:i386 libstdc++6:i386 libncurses5:i386 zlib1g:i386 zip
 ## Packages for NaCl


### PR DESCRIPTION
[Multi-OS Feature](http://docs.travis-ci.com/user/multi-os/) in [Travis-CI](https://travis-ci.org) enables us to build both OS X and Linux with a single `.travis.yml`.  Being able to make sure that Linux build is green is something we have long wanted.