### PR TITLE
Enable NaCl build on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,35 @@ addons:
     - libqt4-dev
     - libxcb-xfixes0-dev
     - pkg-config
+    - libc6:i386
+    - libstdc++6:i386
+
+env:
+  - TARGET_PLATFORM=Linux
+  - TARGET_PLATFORM=NaCl
+  - TARGET_PLATFORM=Mac
 
 install:
   - if [ $TRAVIS_OS_NAME == linux ]; then git -C src/third_party clone https://chromium.googlesource.com/chromium/tools/depot_tools.git; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then export PATH="$PATH":`pwd`/src/third_party/depot_tools; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then unset CC; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then unset CXX; fi
+  - if [ $TARGET_PLATFORM == NaCl ]; then cd src/third_party && curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip && cd nacl_sdk && ./naclsdk install pepper_40 && cd ../../../; fi
 
 script:
   - cd ./src
-  - if [ $TRAVIS_OS_NAME == linux ]; then python build_mozc.py gyp; fi
-  - if [ $TRAVIS_OS_NAME == linux ]; then python build_mozc.py build -c Release package; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then python build_mozc.py build -c Release mac/mac.gyp:GoogleJapaneseInput mac/mac.gyp:gen_launchd_confs; fi
+  - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py gyp --target_platform=Linux; fi
+  - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py build -c Release package; fi
+  - if [ $TARGET_PLATFORM == NaCl ]; then python build_mozc.py gyp --target_platform=NaCl --nacl_sdk_root=`pwd`/third_party/nacl_sdk/pepper_40; fi
+  - if [ $TARGET_PLATFORM == NaCl ]; then python build_mozc.py build -c Release package; fi
+  - if [ $TARGET_PLATFORM == Mac ]; then GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt; fi
+  - if [ $TARGET_PLATFORM == Mac ]; then python build_mozc.py build -c Release mac/mac.gyp:GoogleJapaneseInput mac/mac.gyp:gen_launchd_confs; fi
+
+matrix:
+  exclude:
+  - os: linux
+    env: TARGET_PLATFORM=Mac
+  - os: osx
+    env: TARGET_PLATFORM=Linux
+  - os: osx
+    env: TARGET_PLATFORM=NaCl

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ OpenSource project originates from
 Build Status
 ------------
 
-|Android |Windows |OS X + Linux |NaCl |
-|:------:|:------:|:-----------:|:---:|
-|N/A     |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |N/A |
+|Android |Windows |OS X + Linux + NaCl |
+|:------:|:------:|:------------------:|
+|N/A     |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |
 
 What's Mozc?
 ------------


### PR DESCRIPTION
[Build Matrix](http://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) Feature in Travis-CI enables us to build both Linux desktop build and NaCl Mozc build with a single `.travis.yml`. Being able to make sure that NaCl build is green is something we have long wanted.
