### PR TITLE
Enable Android build on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,16 @@ addons:
     - pkg-config
     - libc6:i386
     - libstdc++6:i386
+    - openjdk-7-jdk
+    - openjdk-7-jre-headless
+    - ant
+    - libncurses5:i386
+    - libjsr305-java
+    - zlib1g:i386
+    - zip
 
 env:
+  - TARGET_PLATFORM=Android
   - TARGET_PLATFORM=Linux
   - TARGET_PLATFORM=NaCl
   - TARGET_PLATFORM=Mac
@@ -61,9 +69,19 @@ install:
   - if [ $TRAVIS_OS_NAME == linux ]; then unset CC; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then unset CXX; fi
   - if [ $TARGET_PLATFORM == NaCl ]; then cd src/third_party && curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip && cd nacl_sdk && ./naclsdk install pepper_40 && cd ../../../; fi
+  - if [ $TARGET_PLATFORM == Android ]; then cd src/third_party && curl -L http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin -O && chmod u+x android-ndk-r10e-linux-x86_64.bin && ./android-ndk-r10e-linux-x86_64.bin > /dev/null && rm android-ndk-r10e-linux-x86_64.bin && curl -L http://dl.google.com/android/android-sdk_r24.1.2-linux.tgz | tar -zx && cd ../../; fi
+  - if [ $TARGET_PLATFORM == Android ]; then export ANDROID_NDK_HOME=`pwd`/src/third_party/android-ndk-r10e ; fi
+  - if [ $TARGET_PLATFORM == Android ]; then export ANDROID_HOME=`pwd`/src/third_party/android-sdk-linux ; fi
+  - if [ $TARGET_PLATFORM == Android ]; then export PATH="$PATH":${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_NDK_HOME}; fi
+  - if [ $TARGET_PLATFORM == Android ]; then echo y | android update sdk --all --force --no-ui --filter android-22; fi
+  - if [ $TARGET_PLATFORM == Android ]; then echo y | android update sdk --all --force --no-ui --filter build-tools-22.0.0; fi
+  - if [ $TARGET_PLATFORM == Android ]; then echo y | android update sdk --all --force --no-ui --filter extra-android-support; fi
+  - if [ $TARGET_PLATFORM == Android ]; then echo y | android update sdk --all --force --no-ui --filter platform-tool; fi
 
 script:
   - cd ./src
+  - if [ $TARGET_PLATFORM == Android ]; then python build_mozc.py gyp --target_platform=Android; fi
+  - if [ $TARGET_PLATFORM == Android ]; then python build_mozc.py build -c Release package; fi
   - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py gyp --target_platform=Linux; fi
   - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py build -c Release package; fi
   - if [ $TARGET_PLATFORM == NaCl ]; then python build_mozc.py gyp --target_platform=NaCl --nacl_sdk_root=`pwd`/third_party/nacl_sdk/pepper_40; fi
@@ -75,6 +93,8 @@ matrix:
   exclude:
   - os: linux
     env: TARGET_PLATFORM=Mac
+  - os: osx
+    env: TARGET_PLATFORM=Android
   - os: osx
     env: TARGET_PLATFORM=Linux
   - os: osx

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ OpenSource project originates from
 Build Status
 ------------
 
-|Android |Windows |OS X + Linux + NaCl |
-|:------:|:------:|:------------------:|
-|N/A     |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |
+|Android + OS X + Linux + NaCl |Windows |
+|:----------------------------:|:------:|
+[![Build Status](https://travis-ci.org/google/mozc.svg?branch=master)](https://travis-ci.org/google/mozc) |[![Build status](https://ci.appveyor.com/api/projects/status/1rvmtp7f80jv7ehf/branch/master?svg=true)](https://ci.appveyor.com/project/google/mozc/branch/master) |
 
 What's Mozc?
 ------------

--- a/src/android/resources/resources.gyp
+++ b/src/android/resources/resources.gyp
@@ -153,7 +153,7 @@
             'dummy_make_symbolic_link',
           ],
           'action': [
-            'ln', '-r', '-s', '-f',
+            'ln', '-s', '-f',
             '<(sdk_resources_dir)/res',
             'res',
           ],

--- a/src/android/resources/resources.gyp
+++ b/src/android/resources/resources.gyp
@@ -38,7 +38,7 @@
     # GYP's 'copies' rule cannot copy a whole directory recursively, so we use
     # our own script to copy files.
     'copy_file': ['python', '../../build_tools/copy_file.py'],
-    'shared_intermediate_mozc_dir': '<(SHARED_INTERMEDIATE_DIR)/',
+    'shared_intermediate_mozc_dir': '<(SHARED_INTERMEDIATE_DIR)',
     'static_resources_dir': '<(abs_depth)/android/static_resources',
     'sdk_resources_dir': '<(shared_intermediate_mozc_dir)/android/resources',
   },

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2124
+BUILD=2125
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2125
+BUILD=2126
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
With this CL, we are finally able to run continuous builds for all the supported platforms (Android, Linux desktop, NaCl, OS X, and Windows).
