### PR TITLE
Enable unit tests on Travis-CI for Linux desktop and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,12 @@ script:
   - if [ $TARGET_PLATFORM == Android ]; then python build_mozc.py build -c Release package; fi
   - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py gyp --target_platform=Linux; fi
   - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py build -c Release package; fi
+  - if [ $TARGET_PLATFORM == Linux ]; then python build_mozc.py runtests -c Release; fi
   - if [ $TARGET_PLATFORM == NaCl ]; then python build_mozc.py gyp --target_platform=NaCl --nacl_sdk_root=`pwd`/third_party/nacl_sdk/pepper_40; fi
   - if [ $TARGET_PLATFORM == NaCl ]; then python build_mozc.py build -c Release package; fi
   - if [ $TARGET_PLATFORM == Mac ]; then GYP_DEFINES="mac_sdk=10.9 mac_deployment_target=10.8" python build_mozc.py gyp --noqt; fi
   - if [ $TARGET_PLATFORM == Mac ]; then python build_mozc.py build -c Release mac/mac.gyp:GoogleJapaneseInput mac/mac.gyp:gen_launchd_confs; fi
+  - if [ $TARGET_PLATFORM == Mac ]; then python build_mozc.py runtests -c Release; fi
 
 matrix:
   exclude:

--- a/src/mac/GoogleJapaneseInputController_test.mm
+++ b/src/mac/GoogleJapaneseInputController_test.mm
@@ -654,10 +654,7 @@ TEST_F(GoogleJapaneseInputControllerTest, commitText) {
   EXPECT_EQ(1, [mock_client_ getCounter:"insertText:replacementRange:"]);
   EXPECT_TRUE([@"foo" isEqualToString:mock_client_.insertedText]);
   // location has to be cleared after the commit.
-  // Do not use NSNotFound directly in EXPECT_EQ because type checker
-  // gets confused for the comparision of enums.
-  int expected = NSNotFound;
-  EXPECT_EQ(expected, [controller_ replacementRange].location);
+  EXPECT_EQ(NSNotFound, [controller_ replacementRange].location);
 }
 
 TEST_F(GoogleJapaneseInputControllerTest, handleConfig) {

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2126
+BUILD=2127
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
With this CL, each push / PR does is going to be tested with unit tests on Travis-CI for Linux desktop and OSX build.

Note that we don't plan to set up unit tests for Android and NaCl right now because tests for them do not complete in host environment but rather require special environments to run target binaries.

This series of CL does not contain any user-visible behavior change.