### PR TITLE
Pull GYP e2e928bacd07fead99a18cb08d64cb24e131d3e5.

### DIFF
--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2151
+BUILD=2152
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
With this CL, GYP [cdf037c1](https://chromium.googlesource.com/external/gyp/+/cdf037c1edc0ba3b5d25f8e3973661efe00980cc) will be replaced with [e2e928ba](https://chromium.googlesource.com/external/gyp/+/e2e928bacd07fead99a18cb08d64cb24e131d3e5).

The full list of commits: [cdf037c1..e2e928ba](https://chromium.googlesource.com/external/gyp/+log/cdf037c1edc0ba3b5d25f8e3973661efe00980cc..e2e928bacd07fead99a18cb08d64cb24e131d3e5).

This is just an update on internal build tool.  No behavior change is intended.
