### PR TITLE
Fix build failure caused by 1ed31197ff736715ce51f.

### DIFF
--- a/src/base/crash_report_handler_mac.mm
+++ b/src/base/crash_report_handler_mac.mm
@@ -42,7 +42,7 @@ namespace mozc {
 // The reference count for GoogleBreakpad
 int g_reference_count = 0;
 
-GoogleBreakpadRef g_breakpad = NULL;
+GoogleBreakpadRef g_breakpad = nullptr;
 #endif  // GOOGLE_JAPANESE_INPUT_BUILD
 
 bool CrashReportHandler::Initialize(bool check_address) {
@@ -50,7 +50,7 @@ bool CrashReportHandler::Initialize(bool check_address) {
   ++g_reference_count;
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
   NSDictionary *plist = [[NSBundle mainBundle] infoDictionary];
-  if (1 == g_reference_count && NULL != plist && NULL == g_breakpad) {
+  if (g_reference_count == 1 && plist != nullptr && g_breakpad == nullptr) {
     g_breakpad = GoogleBreakpadCreate(plist);
     [pool release];
     return true;
@@ -63,9 +63,9 @@ bool CrashReportHandler::Initialize(bool check_address) {
 bool CrashReportHandler::Uninitialize() {
 #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
   --g_reference_count;
-  if (0 == g_reference_count && NULL != g_breakpad) {
+  if (g_reference_count == 0 && g_breakpad != nullptr) {
     GoogleBreakpadRelease(g_breakpad);
-    g_breakpad = NULL;
+    g_breakpad = nullptr;
     return true;
   }
 #endif  // GOOGLE_JAPANESE_INPUT_BUILD

--- a/src/base/mac_util.mm
+++ b/src/base/mac_util.mm
@@ -61,10 +61,10 @@ const char kProjectPrefix[] =
 #endif
 
 // Returns the reference of prelauncher login item.
-// If the prelauncher login item does not exist this function returns NULL.
+// If the prelauncher login item does not exist this function returns nullptr.
 // Otherwise you must release the reference.
 LSSharedFileListItemRef GetPrelauncherLoginItem() {
-  LSSharedFileListItemRef prelauncher_item = NULL;
+  LSSharedFileListItemRef prelauncher_item = nullptr;
   scoped_cftyperef<CFURLRef> url(
     CFURLCreateFromFileSystemRepresentation(
         kCFAllocatorDefault, kPrelauncherPath,
@@ -72,23 +72,23 @@ LSSharedFileListItemRef GetPrelauncherLoginItem() {
   if (!url.get()) {
     LOG(ERROR) << "CFURLCreateFromFileSystemRepresentation error:"
                << " Cannot create CFURL object.";
-    return NULL;
+    return nullptr;
   }
 
   scoped_cftyperef<LSSharedFileListRef> login_items(
       LSSharedFileListCreate(
-          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL));
+          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, nullptr));
   if (!login_items.get()) {
     LOG(ERROR) << "LSSharedFileListCreate error: Cannot get the login items.";
-    return NULL;
+    return nullptr;
   }
 
   scoped_cftyperef<CFArrayRef> login_items_array(
-      LSSharedFileListCopySnapshot(login_items.get(), NULL));
+      LSSharedFileListCopySnapshot(login_items.get(), nullptr));
   if (!login_items_array.get()) {
     LOG(ERROR) << "LSSharedFileListCopySnapshot error:"
                << " Cannot get the login items.";
-    return NULL;
+    return nullptr;
   }
 
   for(CFIndex i = 0; i < CFArrayGetCount(login_items_array.get()); ++i) {
@@ -98,15 +98,15 @@ LSSharedFileListItemRef GetPrelauncherLoginItem() {
     if (!item) {
       LOG(ERROR) << "CFArrayGetValueAtIndex error:"
                  << " Cannot get the login item.";
-      return NULL;
+      return nullptr;
     }
 
-    CFURLRef item_url_ref = NULL;
-    if (LSSharedFileListItemResolve(item, 0, &item_url_ref, NULL) == noErr) {
+    CFURLRef item_url_ref = nullptr;
+    if (LSSharedFileListItemResolve(item, 0, &item_url_ref, nullptr) == noErr) {
       if (!item_url_ref) {
         LOG(ERROR) << "LSSharedFileListItemResolve error:"
                    << " Cannot get the login item url.";
-        return NULL;
+        return nullptr;
       }
       if (CFEqual(item_url_ref, url.get())) {
         prelauncher_item = item;
@@ -261,7 +261,7 @@ string MacUtil::GetSerialNumber() {
 bool MacUtil::StartLaunchdService(const string &service_name,
                                   pid_t *pid) {
   int dummy_pid = 0;
-  if (pid == NULL) {
+  if (pid == nullptr) {
     pid = &dummy_pid;
   }
   const string label = GetLabelForSuffix(service_name);
@@ -273,7 +273,7 @@ bool MacUtil::StartLaunchdService(const string &service_name,
                           LAUNCH_KEY_STARTJOB);
   launch_data_t result_data = launch_msg(start_renderer_command);
   launch_data_free(start_renderer_command);
-  if (result_data == NULL) {
+  if (result_data == nullptr) {
     LOG(ERROR) << "Failed to launch the specified service";
     return false;
   }
@@ -287,7 +287,7 @@ bool MacUtil::StartLaunchdService(const string &service_name,
                           LAUNCH_KEY_GETJOB);
   launch_data_t renderer_info = launch_msg(get_renderer_info);
   launch_data_free(get_renderer_info);
-  if (renderer_info == NULL) {
+  if (renderer_info == nullptr) {
     LOG(ERROR) << "Unexpected error: launchd doesn't return the data "
                << "for the service.";
     return false;
@@ -295,7 +295,7 @@ bool MacUtil::StartLaunchdService(const string &service_name,
 
   launch_data_t pid_data = launch_data_dict_lookup(
       renderer_info, LAUNCH_JOBKEY_PID);
-  if (pid_data == NULL) {
+  if (pid_data == nullptr) {
     LOG(ERROR) <<
         "Unexpected error: launchd response doesn't have PID";
     launch_data_free(renderer_info);
@@ -309,7 +309,7 @@ bool MacUtil::StartLaunchdService(const string &service_name,
 bool MacUtil::CheckPrelauncherLoginItemStatus() {
   scoped_cftyperef<LSSharedFileListItemRef> prelauncher_item(
       GetPrelauncherLoginItem());
-  return (prelauncher_item.get() != NULL);
+  return (prelauncher_item.get() != nullptr);
 }
 
 void MacUtil::RemovePrelauncherLoginItem() {
@@ -322,7 +322,7 @@ void MacUtil::RemovePrelauncherLoginItem() {
   }
   scoped_cftyperef<LSSharedFileListRef> login_items(
       LSSharedFileListCreate(
-          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL));
+          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, nullptr));
   if (!login_items.get()) {
     LOG(ERROR) << "LSSharedFileListCreate error: Cannot get the login items.";
     return;
@@ -336,7 +336,7 @@ void MacUtil::AddPrelauncherLoginItem() {
   }
   scoped_cftyperef<LSSharedFileListRef> login_items(
       LSSharedFileListCreate(
-          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL));
+          kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, nullptr));
   if (!login_items.get()) {
     LOG(ERROR) << "LSSharedFileListCreate error: Cannot get the login items.";
     return;
@@ -353,8 +353,8 @@ void MacUtil::AddPrelauncherLoginItem() {
   }
   scoped_cftyperef<LSSharedFileListItemRef> new_item(
       LSSharedFileListInsertItemURL(
-          login_items.get(), kLSSharedFileListItemLast, NULL, NULL, url.get(),
-          NULL, NULL));
+          login_items.get(), kLSSharedFileListItemLast, nullptr, nullptr, url.get(),
+          nullptr, nullptr));
   if (!new_item.get()) {
     LOG(ERROR) << "LSSharedFileListInsertItemURL error:"
                << " Cannot insert the prelauncher to the login items.";

--- a/src/mac/ActivatePane/ActivatePane.mm
+++ b/src/mac/ActivatePane/ActivatePane.mm
@@ -53,7 +53,7 @@ static NSString *const kSourceID = @"org.mozc.inputmethod.Japanese";
 // Load the installed Google Japanese Input to the system.
 static void RegisterGoogleJapaneseInput() {
   CFURLRef installedLocationURL = CFURLCreateFromFileSystemRepresentation(
-      NULL,  kInstalledLocation, strlen((const char *)kInstalledLocation), NO);
+      nullptr, kInstalledLocation, strlen((const char *)kInstalledLocation), NO);
   if (installedLocationURL) {
     TISRegisterInputSource(installedLocationURL);
   }
@@ -62,7 +62,7 @@ static void RegisterGoogleJapaneseInput() {
 // Put modes of Google Japanese Input at the list of pull-down menu
 // for IMEs, and make it as the default IME.
 static void ActivateGoogleJapaneseInput() {
-  CFArrayRef sourceList = TISCreateInputSourceList(NULL, true);
+  CFArrayRef sourceList = TISCreateInputSourceList(nullptr, true);
   for (int i = 0; i < CFArrayGetCount(sourceList); ++i) {
     TISInputSourceRef inputSource = (TISInputSourceRef)(CFArrayGetValueAtIndex(
         sourceList, i));
@@ -94,7 +94,7 @@ static void LoadLaunchdPlistFiles() {
 // Called at the initialization of this module.
 static BOOL IsAlreadyActive() {
   BOOL isActive = NO;
-  CFArrayRef sourceList = TISCreateInputSourceList(NULL, true);
+  CFArrayRef sourceList = TISCreateInputSourceList(nullptr, true);
   for (int i = 0; i < CFArrayGetCount(sourceList); ++i) {
     TISInputSourceRef inputSource = (TISInputSourceRef)(CFArrayGetValueAtIndex(
         sourceList, i));
@@ -178,7 +178,7 @@ static BOOL StoreDefaultConfigWithSendingUsageStats() {
     if (![fileManager createDirectoryAtPath:googlePath
                 withIntermediateDirectories:YES
                                  attributes:defaultAttributes
-                                      error:NULL]) {
+                                      error:nullptr]) {
       [pool drain];
       return NO;
     }
@@ -193,7 +193,7 @@ static BOOL StoreDefaultConfigWithSendingUsageStats() {
     if (![fileManager createDirectoryAtPath:japaneseInputPath
                 withIntermediateDirectories:YES
                                  attributes:japaneseInputAttributes
-                                      error:NULL]) {
+                                      error:nullptr]) {
       [pool drain];
       return NO;
     }

--- a/src/mac/GoogleJapaneseInputController.mm
+++ b/src/mac/GoogleJapaneseInputController.mm
@@ -75,13 +75,13 @@ using mozc::MacProcess;
 
 namespace {
 // set of bundle IDs of applications on which Mozc should not open urls.
-const set<string> *gNoOpenLinkApps = NULL;
+const set<string> *gNoOpenLinkApps = nullptr;
 // The mapping from the CompositionMode enum to the actual id string
 // of composition modes.
-const map<CompositionMode, NSString *> *gModeIdMap = NULL;
-const set<string> *gNoSelectedRangeApps = NULL;
-const set<string> *gNoDisplayModeSwitchApps = NULL;
-const set<string> *gNoSurroundingTextApps = NULL;
+const map<CompositionMode, NSString *> *gModeIdMap = nullptr;
+const set<string> *gNoSelectedRangeApps = nullptr;
+const set<string> *gNoDisplayModeSwitchApps = nullptr;
+const set<string> *gNoSurroundingTextApps = nullptr;
 
 // TODO(horo): This value should be get from system configuration.
 //  DoubleClickInterval can be get from NSEvent (MacOSX ver >= 10.6)
@@ -98,7 +98,7 @@ NSString *GetLabelForSuffix(const string &suffix) {
 }
 
 CompositionMode GetCompositionMode(NSString *modeID) {
-  if (modeID == NULL) {
+  if (modeID == nullptr) {
     LOG(ERROR) << "modeID could not be initialized.";
     return mozc::commands::DIRECT;
   }
@@ -146,7 +146,7 @@ CompositionMode GetCompositionMode(NSString *modeID) {
 
 bool IsBannedApplication(const set<string>* bundleIdSet,
                          const string& bundleId) {
-  return bundleIdSet == NULL || bundleId.empty() ||
+  return bundleIdSet == nullptr || bundleId.empty() ||
       bundleIdSet->find(bundleId) != bundleIdSet->end();
 }
 }  // anonymous namespace
@@ -217,7 +217,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
     if (!candidateController_->Activate()) {
       LOG(ERROR) << "Cannot activate renderer";
       delete candidateController_;
-      candidateController_ = NULL;
+      candidateController_ = nullptr;
     }
     [self setupClientBundle:inputClient];
     [self setupCapability];
@@ -432,7 +432,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
     [self commitText:output.result().value().c_str() client:sender];
   }
   if ([composedString_ length] > 0) {
-    [self updateComposedString:NULL];
+    [self updateComposedString:nullptr];
     [self clearCandidates];
   }
 }
@@ -472,7 +472,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
 }
 
 - (void)switchDisplayMode {
-  if (gModeIdMap == NULL) {
+  if (gModeIdMap == nullptr) {
     LOG(ERROR) << "gModeIdMap is not initialized correctly.";
     return;
   }
@@ -490,7 +490,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
 }
 
 - (void)commitText:(const char *)text client:(id)sender {
-  if (text == NULL) {
+  if (text == nullptr) {
     return;
   }
 
@@ -579,7 +579,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
 }
 
 - (void)processOutput:(const mozc::commands::Output *)output client:(id)sender {
-  if (output == NULL) {
+  if (output == nullptr) {
     return;
   }
   if (!output->consumed()) {
@@ -708,14 +708,14 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
   // If the last and the current composed string length is 0,
   // we don't call updateComposition.
   if (([composedString_ length] == 0) &&
-      ((preedit == NULL || preedit->segment_size() == 0))) {
+      ((preedit == nullptr || preedit->segment_size() == 0))) {
     return;
   }
 
   [composedString_
     deleteCharactersInRange:NSMakeRange(0, [composedString_ length])];
   cursorPosition_ = NSNotFound;
-  if (preedit != NULL) {
+  if (preedit != nullptr) {
     cursorPosition_ = preedit->cursor();
     for (size_t i = 0; i < preedit->segment_size(); ++i) {
       NSDictionary *highlightAttributes =
@@ -757,7 +757,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
   command.set_type(SessionCommand::SUBMIT);
   mozcClient_->SendCommand(command, &output);
   [self clearCandidates];
-  [self updateComposedString:NULL];
+  [self updateComposedString:nullptr];
 }
 
 - (id)composedString:(id)sender {
@@ -837,7 +837,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
 }
 
 - (void)updateCandidates:(const Output *)output {
-  if (output == NULL) {
+  if (output == nullptr) {
     [self clearCandidates];
     return;
   }
@@ -1049,7 +1049,7 @@ bool IsBannedApplication(const set<string>* bundleIdSet,
 }
 
 - (void)outputResult:(mozc::commands::Output *)output {
-  if (output == NULL || !output->has_result()) {
+  if (output == nullptr || !output->has_result()) {
     return;
   }
   [self commitText:output->result().value().c_str() client:[self client]];

--- a/src/mac/GoogleJapaneseInputController_test.mm
+++ b/src/mac/GoogleJapaneseInputController_test.mm
@@ -420,10 +420,10 @@ BOOL SendKeyEvent(unsigned short keyCode,
 }
 
 TEST_F(GoogleJapaneseInputControllerTest, UpdateComposedString) {
-  // If preedit is NULL, it still calls setMarkedText, with an empty string.
+  // If preedit is nullptr, it still calls setMarkedText, with an empty string.
   NSMutableAttributedString *expected =
       [[[NSMutableAttributedString alloc] initWithString:@""] autorelease];
-  [controller_ updateComposedString:NULL];
+  [controller_ updateComposedString:nullptr];
   EXPECT_TRUE([expected
                 isEqualToAttributedString:[controller_ composedString:nil]]);
 
@@ -474,7 +474,7 @@ TEST_F(GoogleJapaneseInputControllerTest, ClearCandidates) {
 
 TEST_F(GoogleJapaneseInputControllerTest, UpdateCandidates) {
   // When output is null, same as ClearCandidate
-  [controller_ updateCandidates:NULL];
+  [controller_ updateCandidates:nullptr];
   // Run the runloop so "delayedUpdateCandidates" can be called
   [[NSRunLoop currentRunLoop]
       runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];

--- a/src/mac/KeyCodeMap.mm
+++ b/src/mac/KeyCodeMap.mm
@@ -67,7 +67,7 @@ static const unichar kYenMark = 0xA5;
   CallOnce(&kOnceForKanaMap, InitKanaMap);
   CallOnce(&kOnceForSpecialKeyMap, InitSpecialKeyMap);
   CallOnce(&kOnceForSpecialCharMap, InitSpecialCharMap);
-  if (kSpecialKeyMap == NULL) {
+  if (kSpecialKeyMap == nullptr) {
     self = nil;
     return self;
   }

--- a/src/mac/KeyCodeMap_test.mm
+++ b/src/mac/KeyCodeMap_test.mm
@@ -64,7 +64,7 @@ class KeyCodeMapTest : public testing::Test {
 
   bool CreateKeyEvent(NSString *characters, NSString *unmodCharacters,
                       int flags, uint16 keyCode, KeyEvent *mozcKeyEvent) {
-    if (mozcKeyEvent == NULL) {
+    if (mozcKeyEvent == nullptr) {
       return false;
     }
 

--- a/src/mac/Uninstaller/Uninstaller.mm
+++ b/src/mac/Uninstaller/Uninstaller.mm
@@ -66,7 +66,7 @@ bool GetPrevilegeRights(AuthorizationRef *auth) {
   AuthorizationFlags authFlags = kAuthorizationFlagDefaults;
 
   status = AuthorizationCreate(
-      NULL, kAuthorizationEmptyEnvironment, authFlags, auth);
+      nullptr, kAuthorizationEmptyEnvironment, authFlags, auth);
   if (status != errAuthorizationSuccess) {
     return status;
   }
@@ -76,14 +76,14 @@ bool GetPrevilegeRights(AuthorizationRef *auth) {
     return false;
   }
 
-  AuthorizationItem item = {kAuthorizationRightExecute, 0, NULL, 0};
+  AuthorizationItem item = {kAuthorizationRightExecute, 0, nullptr, 0};
   AuthorizationRights rights = {1, &item};
 
   authFlags = kAuthorizationFlagDefaults |
       kAuthorizationFlagInteractionAllowed |
       kAuthorizationFlagPreAuthorize |
       kAuthorizationFlagExtendRights;
-  status = AuthorizationCopyRights(*auth, &rights, NULL, authFlags, NULL);
+  status = AuthorizationCopyRights(*auth, &rights, nullptr, authFlags, nullptr);
 
   return status == errAuthorizationSuccess;
 }
@@ -94,27 +94,27 @@ bool OpenUninstallSurvey() {
 
 bool DeleteFiles(const AuthorizationRef &auth) {
   const char *kRmPath = "/bin/rm";
-  const char *rmArgs[] = {"-rf", NULL, NULL};
+  const char *rmArgs[] = {"-rf", nullptr, nullptr};
 #ifdef GOOGLE_JAPANESE_INPUT_BUILD
   const char *kRemovePaths[] = {
     "/Library/Input Methods/GoogleJapaneseInput.app",
     "/Library/LaunchAgents/com.google.inputmethod.Japanese.Converter.plist",
     "/Library/LaunchAgents/com.google.inputmethod.Japanese.Renderer.plist",
     "/Applications/GoogleJapaneseInput.localized",
-    NULL};
+    nullptr};
 #else  // GOOGLE_JAPANESE_INPUT_BUILD
   const char *kRemovePaths[] = {
     "/Library/Input Methods/Mozc.app",
     "/Library/LaunchAgents/org.mozc.inputmethod.Japanese.Converter.plist",
     "/Library/LaunchAgents/org.mozc.inputmethod.Japanese.Renderer.plist",
     "/Applications/Mozc",
-    NULL};
+    nullptr};
 #endif // GOOGLE_JAPANESE_INPUT_BUILD
-  for (int i = 0; kRemovePaths[i] != NULL; ++i) {
+  for (int i = 0; kRemovePaths[i] != nullptr; ++i) {
     rmArgs[1] = kRemovePaths[i];
     OSStatus status = AuthorizationExecuteWithPrivileges(
         auth, kRmPath, kAuthorizationFlagDefaults,
-        const_cast<char * const *>(rmArgs), NULL);
+        const_cast<char * const *>(rmArgs), nullptr);
     if (status != errAuthorizationSuccess) {
       NSLog(@"Failed to remove path: %s", kRemovePaths[i]);
       return false;
@@ -127,19 +127,19 @@ bool UnregisterKeystoneTicket(const AuthorizationRef &auth) {
   const char *kKsadminPath = "/Library/Google/GoogleSoftwareUpdate/"
       "GoogleSoftwareUpdate.bundle/Contents/MacOS/ksadmin";
   const char *kKsadminArgs[] =
-      {"--delete", "--productid", "com.google.JapaneseIME", NULL};
+      {"--delete", "--productid", "com.google.JapaneseIME", nullptr};
   OSStatus status = AuthorizationExecuteWithPrivileges(
       auth, kKsadminPath, kAuthorizationFlagDefaults,
-      const_cast<char * const *>(kKsadminArgs), NULL);
+      const_cast<char * const *>(kKsadminArgs), nullptr);
   return status == errAuthorizationSuccess;
 }
 
 bool RunReboot(const AuthorizationRef &auth) {
   // TODO(mukai): Use OS-specific API instead of calling reboot command.
   const char *rebootPath = "/sbin/reboot";
-  char * args[] = {NULL};
+  char * args[] = {nullptr};
   OSStatus status = AuthorizationExecuteWithPrivileges(
-      auth, rebootPath, kAuthorizationFlagDefaults, args, NULL);
+      auth, rebootPath, kAuthorizationFlagDefaults, args, nullptr);
   return status == errAuthorizationSuccess;
 }
 }  // anonymous namespace

--- a/src/mac/generate_mapping.py
+++ b/src/mac/generate_mapping.py
@@ -68,21 +68,21 @@ class Mapping(object):
 // than KeyCodeMap.mm
 
 namespace {
-static map<%(key_type)s, %(result_type)s> *k%(mapname)s = NULL;
-static map<%(key_type)s, %(result_type)s> *k%(mapname)sShift = NULL;
+static map<%(key_type)s, %(result_type)s> *k%(mapname)s = nullptr;
+static map<%(key_type)s, %(result_type)s> *k%(mapname)sShift = nullptr;
 static once_t kOnceFor%(mapname)s = MOZC_ONCE_INIT;
 void Init%(mapname)s() {
-  if (k%(mapname)s != NULL || k%(mapname)sShift != NULL) {
+  if (k%(mapname)s != nullptr || k%(mapname)sShift != nullptr) {
     return;
   }
   k%(mapname)s = new(nothrow)map<%(key_type)s, %(result_type)s>;
-  if (k%(mapname)s == NULL) {
+  if (k%(mapname)s == nullptr) {
     return;
   }
   k%(mapname)sShift = new(nothrow)map<%(key_type)s, %(result_type)s>;
-  if (k%(mapname)sShift == NULL) {
+  if (k%(mapname)sShift == nullptr) {
     delete k%(mapname)s;
-    k%(mapname)s = NULL;
+    k%(mapname)s = nullptr;
     return;
   }
 """ % {'key_type': self._key_type,

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2152
+BUILD=2153
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/net/http_client_mac.mm
+++ b/src/net/http_client_mac.mm
@@ -55,7 +55,7 @@
   if (self == nil) {
     return nil;
   }
-  if (NULL != output_string_) {
+  if (output_string_ != nullptr) {
     output_string_->clear();
   }
   request_ = request;
@@ -77,7 +77,7 @@
     LOG(WARNING) << "too long data max_data_size=" << max_data_size_;
   }
 
-  if (output_string_ != NULL) {
+  if (output_string_ != nullptr) {
     VLOG(2) << "Recived: " << size << " bytes to std::string";
     output_string_->append((const char*)buf, size);
   }
@@ -235,7 +235,7 @@ bool MacHTTPRequestHandler::Request(HTTPMethodType type,
   // The default HTTP method is “GET”.
   if (type == HTTP_POST) {
     [request setHTTPMethod:@"POST"];
-    if (post_data != NULL) {
+    if (post_data != nullptr) {
       // The framework will automatically add the content type and
       // content length, but we put it explicitly just in case.
       NSString *length = [NSString stringWithFormat:@"%zd", post_size];

--- a/src/renderer/mac/CandidateView.mm
+++ b/src/renderer/mac/CandidateView.mm
@@ -57,7 +57,7 @@ using mozc::CallOnce;
 // TODO(mukai): integrate and share the code among Win and Mac.
 
 namespace {
-const NSImage *g_LogoImage = NULL;
+const NSImage *g_LogoImage = nullptr;
 int g_column_minimum_width = 0;
 once_t g_OnceForInitializeStyle = MOZC_ONCE_INIT;
 
@@ -487,7 +487,7 @@ const char *Inspect(id obj) {
 - (void)mouseUp:(NSEvent *)event {
   mozc::Point localPos = MacViewUtil::ToPoint(
       [self convertPoint:[event locationInWindow] fromView:nil]);
-  if (command_sender_ == NULL) {
+  if (command_sender_ == nullptr) {
     return;
   }
   if (candidates_.candidate_size() < tableLayout_->number_of_rows()) {

--- a/src/renderer/mac/CandidateWindow.mm
+++ b/src/renderer/mac/CandidateWindow.mm
@@ -44,7 +44,7 @@ namespace renderer {
 namespace mac {
 
 CandidateWindow::CandidateWindow()
-    : command_sender_(NULL) {
+    : command_sender_(nullptr) {
 }
 
 CandidateWindow::~CandidateWindow() {

--- a/src/renderer/mac/InfolistWindow.mm
+++ b/src/renderer/mac/InfolistWindow.mm
@@ -72,7 +72,7 @@ namespace mac {
 namespace {
 bool SendUsageStatsEvent(client::SendCommandInterface *command_sender,
                          const SessionCommand::UsageStatsEvent &event) {
-  if (command_sender == NULL) {
+  if (command_sender == nullptr) {
     return false;
   }
   SessionCommand command;
@@ -84,8 +84,8 @@ bool SendUsageStatsEvent(client::SendCommandInterface *command_sender,
 }  // anonymous namespace
 
 InfolistWindow::InfolistWindow()
-    : lasttimer_(NULL),
-      command_sender_(NULL) {
+    : lasttimer_(nullptr),
+      command_sender_(nullptr) {
  timer_handler_.reset([[InfolistWindowTimerHandler alloc]
      initWithInfolistWindow:this]);
 }

--- a/src/renderer/mac/mac_server.mm
+++ b/src/renderer/mac/mac_server.mm
@@ -56,14 +56,13 @@ OSStatus EventHandler(EventHandlerCallRef handlerCallRef,
 }
 
 MacServer::MacServer(int argc, const char **argv)
-    : controller_(NULL),
-      argc_(argc),
+    : argc_(argc),
       argv_(argv) {
-  pthread_cond_init(&event_, NULL);
+  pthread_cond_init(&event_, nullptr);
   EventHandlerUPP handler = ::NewEventHandlerUPP(EventHandler);
   EventTypeSpec spec[] = { { kEventClassApplication, 0 } };
   ::InstallEventHandler(GetApplicationEventTarget(), handler,
-                        arraysize(spec), spec, this, NULL);
+                        arraysize(spec), spec, this, nullptr);
 }
 
 bool MacServer::AsyncExecCommand(string *proto_message) {
@@ -74,8 +73,8 @@ bool MacServer::AsyncExecCommand(string *proto_message) {
   }
   delete proto_message;
 
-  EventRef event_ref = NULL;
-  ::CreateEvent(NULL, kEventClassApplication, 0, 0,
+  EventRef event_ref = nullptr;
+  ::CreateEvent(nullptr, kEventClassApplication, 0, 0,
               kEventAttributeNone, &event_ref);
   ::PostEventToQueue(::GetMainEventQueue(), event_ref, kEventPriorityHigh);
   ::ReleaseEvent(event_ref);


### PR DESCRIPTION
It turns out that OS X build failures after 1ed31197ff736715ce51f0f852625e7fee2d2632 are real. Basically this is the same to #224.  We must not pass ```NULL``` to ```std::unique_ptr```.