### PR TITLE
Deprecate '--jobs' ('-j') option in build_mozc.py

### DIFF
--- a/src/build_mozc.py
+++ b/src/build_mozc.py
@@ -537,11 +537,6 @@ def ParseBuildOptions(args=None, values=None):
   """Parses command line options for the build command."""
   parser = optparse.OptionParser(usage='Usage: %prog build [options]')
   AddCommonOptions(parser)
-  if IsLinux():
-    default_build_concurrency = GetNumberOfProcessors() * 2
-    parser.add_option('--jobs', '-j', dest='jobs',
-                      default=('%d' % default_build_concurrency),
-                      metavar='N', help='run build jobs in parallel')
   parser.add_option('--configuration', '-c', dest='configuration',
                     default='Debug', help='specify the build configuration.')
 
@@ -566,11 +561,6 @@ def ParseRunTestsOptions(args=None, values=None):
   parser = optparse.OptionParser(
       usage='Usage: %prog runtests [options] [test_targets] [-- build options]')
   AddCommonOptions(parser)
-  if IsLinux():
-    default_build_concurrency = GetNumberOfProcessors() * 2
-    parser.add_option('--jobs', '-j', dest='jobs',
-                      default=('%d' % default_build_concurrency),
-                      metavar='N', help='run build jobs in parallel')
   default_test_jobs = GetNumberOfProcessors()
   parser.add_option('--test_jobs', dest='test_jobs', type='int',
                     default=default_test_jobs,
@@ -1005,8 +995,7 @@ def BuildOnLinux(options, targets, unused_original_directory_name):
   short_basename = GetBuildShortBaseName(options,
                                          GetMozcVersion().GetTargetPlatform())
   make_command = ninja
-  build_args = ['-j %s' % options.jobs,
-                '-C', '%s/%s' % (short_basename, options.configuration)]
+  build_args = ['-C', '%s/%s' % (short_basename, options.configuration)]
   RunOrDie([make_command] + build_args + target_names)
 
 

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2155
+BUILD=2156
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
Historically we introduced ```--jobs``` (```-j```) option to ```build_mozc.py``` to allow developers to specify build concurrency, and the option was available for all the platforms (Windows, OS X, and Linux).

However, determining a good default build concurrency is indeed a hard problem.  After a while, we ended up deprecating ```--jobs``` in Windows and OS X build, and let build systems decide how and when available CPU cores should be used to build instead.

With this CL, ```--jobs``` option is deprecated even in Linux build, which means that the option in question is finally removed completely.

If you want to have control of build concurrency for some reasons, you should consider to intercept the build system command (e.g. ```ninja``` for Windows and Linux builds) with your own command wrapper, for instance by tweaking ```PATH``` environment variable.  Once ```build_mozc.py``` starts kicking your build command wrapper rather than the real build command, you should be able to do whatever you want (e.g., specifying build-system dependent options for finer control of build concurrency.

No behavior change in production binaries is intended.

BUG=
TEST=unittest
REF_BUG=
REF_CL=106276549