### PR TITLE
Rename InitGoogle to mozc::InitMozc.

### DIFF
--- a/src/base/base.gyp
+++ b/src/base/base.gyp
@@ -106,6 +106,7 @@
         'flags.cc',
         'hash.cc',
         'init.cc',
+        'init_mozc.cc',
         'japanese_util_rule.cc',
         'logging.cc',
         'mmap.cc',

--- a/src/base/cpu_stats_main.cc
+++ b/src/base/cpu_stats_main.cc
@@ -27,13 +27,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/cpu_stats.h"
-
 #include <iostream>
 #include <memory>
 #include <string>
 
+#include "base/cpu_stats.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/port.h"
 #include "base/thread.h"
 #include "base/util.h"
@@ -60,7 +60,7 @@ class DummyThread : public mozc::Thread {
 }  // namespace
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   std::unique_ptr<DummyThread[]> threads;
 

--- a/src/base/encryptor_main.cc
+++ b/src/base/encryptor_main.cc
@@ -27,12 +27,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/encryptor.h"
-
 #include <iostream>
 #include <string>
+
+#include "base/encryptor.h"
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/mmap.h"
 #include "base/util.h"
@@ -61,7 +62,7 @@ string Escape(const string &buf) {
 }  // namespace
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (!FLAGS_iv.empty()) {
     CHECK_EQ(16, FLAGS_iv.size()) << "iv size must be 16 byte";

--- a/src/base/flags.h
+++ b/src/base/flags.h
@@ -34,6 +34,7 @@
 
 
 #include <string>
+
 #include "base/port.h"
 
 namespace mozc_flags {
@@ -49,18 +50,15 @@ class FlagRegister {
                const void *default_storage,
                int shorttpe,
                const char *help);
-  virtual ~FlagRegister();
+  ~FlagRegister();
+
  private:
   Flag *flag_;
 };
 
-uint32 ParseCommandLineFlags(int *argc, char*** argv,
-                             bool remove_flags);
-}  // mozc_flags
+uint32 ParseCommandLineFlags(int *argc, char*** argv, bool remove_flags);
 
-void InitGoogle(const char *arg0,
-                int *argc, char ***argv,
-                bool remove_flags);
+}  // mozc_flags
 
 #define DEFINE_VARIABLE(type, shorttype, name, value, help) \
 namespace mozc_flags_fL##shorttype { \

--- a/src/base/init_mozc.h
+++ b/src/base/init_mozc.h
@@ -27,44 +27,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <iostream>  // NOLINT
-#include <sstream>
+#ifndef MOZC_BASE_INIT_MOZC_H_
+#define MOZC_BASE_INIT_MOZC_H_
 
-#include "base/flags.h"
-#include "base/init_mozc.h"
-#include "composer/internal/composition.h"
-#include "composer/table.h"
+namespace mozc {
 
-DEFINE_string(table, "system://romanji-hiragana.tsv",
-              "preedit conversion table file.");
+// Initializes all the modules, such as flags and logging.
+void InitMozc(const char *arg0, int *argc, char ***argv, bool remove_flags);
 
+}  // namespace mozc
 
-int main(int argc, char **argv) {
-  mozc::InitMozc(argv[0], &argc, &argv, false);
-
-  mozc::composer::Table table;
-  table.LoadFromFile(FLAGS_table.c_str());
-
-  mozc::composer::Composition composition(&table);
-
-  string command;
-  string result;
-  size_t pos = 0;
-
-  while (getline(cin, command)) {
-    char initial = command[0];
-    if (initial == '-' || (initial >= '0' && initial <= '9')) {
-      stringstream ss;
-      int delta;
-      ss << command;
-      ss >> delta;
-      pos += delta;
-    } else if (initial == '!') {
-      pos = composition.DeleteAt(pos);
-    } else {
-      pos = composition.InsertAt(pos, command);
-    }
-    composition.GetString(&result);
-    cout << result << " : " << pos << endl;
-  }
-}
+#endif  // MOZC_BASE_INIT_MOZC_H_

--- a/src/base/mac_util_main.cc
+++ b/src/base/mac_util_main.cc
@@ -27,12 +27,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/mac_util.h"
-
 #include <string>
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
+#include "base/mac_util.h"
 #include "base/util.h"
 
 DEFINE_bool(label_for_suffix, false,
@@ -56,7 +56,7 @@ DEFINE_string(service_name, "", "The service name to be launched");
 using mozc::MacUtil;
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_label_for_suffix) {
     cout << MacUtil::GetLabelForSuffix(FLAGS_suffix) << endl;

--- a/src/base/password_manager_main.cc
+++ b/src/base/password_manager_main.cc
@@ -27,14 +27,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/password_manager.h"
-
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
+#include "base/password_manager.h"
 #include "base/util.h"
 
 int main(int argc,char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   string password;
   if (!mozc::PasswordManager::GetPassword(&password)) {
     LOG(INFO) << "GetPassword failed";

--- a/src/base/process_main.cc
+++ b/src/base/process_main.cc
@@ -27,18 +27,18 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/process.h"
-
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
+#include "base/process.h"
 
 DEFINE_string(open_browser, "", "URL");
 DEFINE_string(spawn_process, "", "path");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   if (!FLAGS_open_browser.empty()) {
     if (!mozc::Process::OpenBrowser(FLAGS_open_browser)) {
       LOG(INFO) << "Failed to open: " << FLAGS_open_browser;

--- a/src/base/process_mutex_main.cc
+++ b/src/base/process_mutex_main.cc
@@ -35,13 +35,14 @@
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 
 DEFINE_int32(sleep_time, 30, "sleep 30 sec");
 DEFINE_string(name, "named_event_test", "name for named event");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::ProcessMutex mutex(FLAGS_name.c_str());
 

--- a/src/base/run_level.h
+++ b/src/base/run_level.h
@@ -52,11 +52,11 @@ class RunLevel {
   // return the runlevel of current process
   // NOTE:
   // DO NOT USE logging library inside this method,
-  // since GetRunLevel() is called  before InitGoogle().
+  // since GetRunLevel() is called  before mozc::InitMozc().
   // Logging stream and flags may not be initialized.
   // Also, make sure that the code inside this function
   // never raises any exceptions. Exception handler is installed
-  // inside InitGoogle().
+  // inside mozc::InitMozc().
   static RunLevelType GetRunLevel(RunLevel::RequestType type);
 
   static bool IsValidClientRunLevel() {

--- a/src/base/run_level_main.cc
+++ b/src/base/run_level_main.cc
@@ -27,13 +27,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/run_level.h"
-
 #include <iostream>
 #include <string>
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
+#include "base/run_level.h"
 
 DEFINE_bool(server, false, "server mode");
 DEFINE_bool(client, false, "client mode");
@@ -41,7 +41,7 @@ DEFINE_bool(client, false, "client mode");
 // This is a simple command line tool
 // too check RunLevel class
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::RunLevel::RequestType type = mozc::RunLevel::SERVER;
 

--- a/src/base/stopwatch_main.cc
+++ b/src/base/stopwatch_main.cc
@@ -27,18 +27,18 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "base/stopwatch.h"
-
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
+#include "base/stopwatch.h"
 #include "base/util.h"
 
 DEFINE_int32(sleep_time, 1000, "sleep time");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::Stopwatch stopwatch;
   stopwatch.Start();

--- a/src/base/text_converter_compiler.cc
+++ b/src/base/text_converter_compiler.cc
@@ -33,6 +33,7 @@
 #include "base/double_array.h"
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/util.h"
 #include "third_party/darts/v0_32/darts.h"
@@ -134,7 +135,7 @@ static void Compile(const string &files,
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   mozc::Compile(FLAGS_input, FLAGS_output);
   return 0;
 }

--- a/src/chrome/nacl/nacl_session_handler.cc
+++ b/src/chrome/nacl/nacl_session_handler.cc
@@ -40,6 +40,7 @@
 
 #include "base/clock.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/mutex.h"
 #include "base/pepper_file_util.h"
@@ -470,12 +471,12 @@ class NaclSessionHandlerModule : public pp::Module {
 namespace pp {
 
 Module *CreateModule() {
-  // We use dummy argc and argv to call InitGoogle().
+  // We use dummy argc and argv to call mozc::InitMozc().
   int argc = 1;
   char argv0[] = "NaclModule";
   char *argv_body[] = {argv0, NULL};
   char **argv = argv_body;
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   return new mozc::session::NaclSessionHandlerModule();
 }

--- a/src/client/client_performance_test_main.cc
+++ b/src/client/client_performance_test_main.cc
@@ -31,11 +31,12 @@
 #include <cmath>
 #include <iostream>  // NOLINT
 #include <iterator>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/singleton.h"
@@ -365,7 +366,7 @@ class Conversion : public TestScenarioInterface {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   vector<mozc::TestScenarioInterface *> tests;
   vector<mozc::Result *> results;

--- a/src/client/client_quality_test_main.cc
+++ b/src/client/client_quality_test_main.cc
@@ -35,6 +35,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/multifile.h"
 #include "base/port.h"
@@ -200,7 +201,7 @@ double CalculateMean(const vector<double>& scores) {
 
 
 int main(int argc, char* argv[]) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   mozc::client::Client client;
   if (!FLAGS_server_path.empty()) {

--- a/src/client/client_scenario_test_main.cc
+++ b/src/client/client_scenario_test_main.cc
@@ -39,6 +39,7 @@
 #include "base/file_stream.h"
 #include "base/file_util.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/system_util.h"
@@ -169,7 +170,7 @@ int Loop(istream *input) {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (!FLAGS_profile_dir.empty()) {
     mozc::FileUtil::CreateDirectory(FLAGS_profile_dir);

--- a/src/client/client_stress_test_main.cc
+++ b/src/client/client_stress_test_main.cc
@@ -40,6 +40,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/util.h"
@@ -61,7 +62,7 @@ DEFINE_bool(test_testsendkey, true, "test TestSendKey");
 DECLARE_bool(logtostderr);
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   FLAGS_logtostderr = true;
 

--- a/src/client/ping_server_main.cc
+++ b/src/client/ping_server_main.cc
@@ -30,12 +30,13 @@
 #include <iostream>  // NOLINT
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "client/client.h"
 
 // Simple command line tool to ping mozc server
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   mozc::client::Client client;
 
   if (client.PingServer()) {

--- a/src/client/server_launcher_main.cc
+++ b/src/client/server_launcher_main.cc
@@ -30,6 +30,7 @@
 #include <iostream>  // NOLINT
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "client/client.h"
 
@@ -38,7 +39,7 @@ DEFINE_bool(shutdown, false,
 
 // simple command line tool to launch mozc server
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   mozc::client::Client client;
 
   if (FLAGS_shutdown) {

--- a/src/composer/composer_main.cc
+++ b/src/composer/composer_main.cc
@@ -27,13 +27,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "composer/composer.h"
-
 #include <iostream>  // NOLINT
 #include <memory>
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
+#include "composer/composer.h"
 #include "composer/composition_interface.h"
 #include "composer/table.h"
 #include "protocol/commands.pb.h"
@@ -45,7 +45,7 @@ DEFINE_string(table, "system://romanji-hiragana.tsv",
 using ::mozc::commands::Request;
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::composer::Table table;
   table.LoadFromFile(FLAGS_table.c_str());

--- a/src/composer/internal/converter_main.cc
+++ b/src/composer/internal/converter_main.cc
@@ -31,6 +31,7 @@
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "composer/internal/converter.h"
 #include "composer/table.h"
 
@@ -38,7 +39,7 @@ DEFINE_string(table, "system://romanji-hiragana.tsv",
               "preedit conversion table file.");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::composer::Table table;
   table.LoadFromFile(FLAGS_table.c_str());

--- a/src/converter/converter_main.cc
+++ b/src/converter/converter_main.cc
@@ -35,6 +35,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/number_util.h"
 #include "base/port.h"
@@ -377,7 +378,7 @@ bool ExecCommand(const ConverterInterface &converter,
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (!FLAGS_user_profile_dir.empty()) {
     mozc::SystemUtil::SetUserProfileDirectory(FLAGS_user_profile_dir);

--- a/src/converter/quality_regression_main.cc
+++ b/src/converter/quality_regression_main.cc
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/util.h"
 #include "converter/quality_regression_util.h"
 #include "engine/engine_factory.h"
@@ -45,7 +46,7 @@ using mozc::EngineInterface;
 using mozc::quality_regression::QualityRegressionUtil;
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   std::unique_ptr<EngineInterface> engine(EngineFactory::Create());
   QualityRegressionUtil util(engine->GetConverter());

--- a/src/data_manager/chromeos/gen_chromeos_segmenter_bitarray_main.cc
+++ b/src/data_manager/chromeos/gen_chromeos_segmenter_bitarray_main.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "converter/gen_segmenter_bitarray.h"
 
 namespace {
@@ -37,7 +38,7 @@ namespace {
 DEFINE_string(output, "", "header filename for chromeos segmenter");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   mozc::SegmenterBitarrayGenerator::GenerateBitarray(
       kLSize, kRSize, &IsBoundaryInternal, FLAGS_output);
   return 0;

--- a/src/data_manager/oss/gen_oss_segmenter_bitarray_main.cc
+++ b/src/data_manager/oss/gen_oss_segmenter_bitarray_main.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "converter/gen_segmenter_bitarray.h"
 
 namespace {
@@ -37,7 +38,7 @@ namespace {
 DEFINE_string(output, "", "header filename for google segmenter");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   mozc::SegmenterBitarrayGenerator::GenerateBitarray(
       kLSize, kRSize, &IsBoundaryInternal, FLAGS_output);
   return 0;

--- a/src/data_manager/packed/gen_packed_data_light_main_template.cc
+++ b/src/data_manager/packed/gen_packed_data_light_main_template.cc
@@ -30,6 +30,7 @@
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/version.h"
 #include "converter/boundary_struct.h"
@@ -43,8 +44,8 @@ DEFINE_string(output, "", "Output data file name");
 namespace mozc {
 namespace {
 
-#include "data_manager/@DIR@/user_pos_data.h"
 #include "data_manager/@DIR@/pos_matcher_data.h"
+#include "data_manager/@DIR@/user_pos_data.h"
 
 }  // namespace
 
@@ -62,7 +63,7 @@ bool OutputData(const string &file_path) {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_output.empty()) {
     LOG(FATAL) << "output flag is needed";

--- a/src/data_manager/packed/gen_packed_data_main_template.cc
+++ b/src/data_manager/packed/gen_packed_data_main_template.cc
@@ -30,13 +30,14 @@
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/version.h"
 #include "converter/boundary_struct.h"
 #include "data_manager/packed/system_dictionary_data_packer.h"
-#include "dictionary/suffix_dictionary_token.h"
 #include "dictionary/pos_group.h"
 #include "dictionary/pos_matcher.h"
+#include "dictionary/suffix_dictionary_token.h"
 #include "dictionary/user_pos.h"
 #include "rewriter/correction_rewriter.h"
 #include "rewriter/counter_suffix.h"
@@ -53,19 +54,19 @@ DEFINE_bool(use_gzip, false, "use gzip");
 namespace mozc {
 namespace {
 
-#include "data_manager/@DIR@/user_pos_data.h"
-#include "data_manager/@DIR@/pos_matcher_data.h"
-#include "data_manager/@DIR@/pos_group_data.h"
 #include "data_manager/@DIR@/boundary_data.h"
-#include "data_manager/@DIR@/suffix_data.h"
-#include "data_manager/@DIR@/reading_correction_data.h"
-#include "data_manager/@DIR@/segmenter_data.h"
+#include "data_manager/@DIR@/embedded_collocation_data.h"
 #include "data_manager/@DIR@/embedded_collocation_suppression_data.h"
-#include "data_manager/@DIR@/suggestion_filter_data.h"
 #include "data_manager/@DIR@/embedded_connection_data.h"
 #include "data_manager/@DIR@/embedded_dictionary_data.h"
-#include "data_manager/@DIR@/embedded_collocation_data.h"
+#include "data_manager/@DIR@/pos_group_data.h"
+#include "data_manager/@DIR@/pos_matcher_data.h"
+#include "data_manager/@DIR@/reading_correction_data.h"
+#include "data_manager/@DIR@/segmenter_data.h"
+#include "data_manager/@DIR@/suffix_data.h"
+#include "data_manager/@DIR@/suggestion_filter_data.h"
 #include "data_manager/@DIR@/symbol_rewriter_data.h"
+#include "data_manager/@DIR@/user_pos_data.h"
 #ifndef NO_USAGE_REWRITER
 #include "rewriter/usage_rewriter_data.h"
 #endif  // NO_USAGE_REWRITER
@@ -128,7 +129,7 @@ bool OutputData(const string &file_path) {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_output.empty()) {
     LOG(FATAL) << "output flag is needed";

--- a/src/data_manager/testing/gen_mock_segmenter_bitarray_main.cc
+++ b/src/data_manager/testing/gen_mock_segmenter_bitarray_main.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "converter/gen_segmenter_bitarray.h"
 
 namespace {
@@ -37,7 +38,7 @@ namespace {
 DEFINE_string(output, "", "header filename for mock segmenter");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   mozc::SegmenterBitarrayGenerator::GenerateBitarray(
       kLSize, kRSize, &IsBoundaryInternal, FLAGS_output);
   return 0;

--- a/src/dictionary/gen_system_dictionary_data_main.cc
+++ b/src/dictionary/gen_system_dictionary_data_main.cc
@@ -41,6 +41,7 @@
 #include "base/codegen_bytearray_stream.h"
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/util.h"
 #include "data_manager/testing/mock_user_pos_manager.h"
 #include "data_manager/user_pos_manager.h"
@@ -93,7 +94,7 @@ void GetInputFileName(const string &input_file,
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   string system_dictionary_input, reading_correction_input;
   mozc::GetInputFileName(FLAGS_input,

--- a/src/dictionary/user_dictionary_importer_main.cc
+++ b/src/dictionary/user_dictionary_importer_main.cc
@@ -27,15 +27,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <string>
 #include <iostream>
+#include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "dictionary/user_dictionary_importer.h"
 #include "protocol/user_dictionary_storage.pb.h"
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::user_dictionary::UserDictionary user_dic;
   mozc::UserDictionaryImporter::ImportFromMSIME(&user_dic);

--- a/src/gui/about_dialog/about_dialog_main.cc
+++ b/src/gui/about_dialog/about_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunAboutDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunAboutDialog(argc, argv);
 }

--- a/src/gui/administration_dialog/administration_dialog_main.cc
+++ b/src/gui/administration_dialog/administration_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunAdministrationDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunAdministrationDialog(argc, argv);
 }

--- a/src/gui/character_pad/character_palette_main.cc
+++ b/src/gui/character_pad/character_palette_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunCharacterPalette(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunCharacterPalette(argc, argv);
 }

--- a/src/gui/character_pad/hand_writing_main.cc
+++ b/src/gui/character_pad/hand_writing_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunHandWriting(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunHandWriting(argc, argv);
 }

--- a/src/gui/config_dialog/config_dialog_main.cc
+++ b/src/gui/config_dialog/config_dialog_main.cc
@@ -30,11 +30,12 @@
 // The main function of configure dialog for Mozc.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunConfigDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunConfigDialog(argc, argv);
 }

--- a/src/gui/confirmation_dialog/confirmation_dialog_main.cc
+++ b/src/gui/confirmation_dialog/confirmation_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunConfirmationDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunConfirmationDialog(argc, argv);
 }

--- a/src/gui/dictionary_tool/dictionary_tool_main.cc
+++ b/src/gui/dictionary_tool/dictionary_tool_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunDictionaryTool(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunDictionaryTool(argc, argv);
 }

--- a/src/gui/error_message_dialog/error_message_dialog_main.cc
+++ b/src/gui/error_message_dialog/error_message_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunErrorMessageDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunErrorMessageDialog(argc, argv);
 }

--- a/src/gui/post_install_dialog/post_install_dialog_main.cc
+++ b/src/gui/post_install_dialog/post_install_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunPostInstallDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunPostInstallDialog(argc, argv);
 }

--- a/src/gui/set_default_dialog/set_default_dialog_main.cc
+++ b/src/gui/set_default_dialog/set_default_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunSetDefaultDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunSetDefaultDialog(argc, argv);
 }

--- a/src/gui/tool/mozc_tool_libmain.cc
+++ b/src/gui/tool/mozc_tool_libmain.cc
@@ -43,6 +43,7 @@
 #include "base/crash_report_handler.h"
 #include "base/file_util.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/password_manager.h"
 #include "base/run_level.h"
@@ -100,11 +101,11 @@ int RunMozcTool(int argc, char *argv[]) {
        "--fromenv=mode,error_type,confirmation_type,register_prelauncher");
   int new_argc = 2;
   char **new_argv = tmp.get();
-  InitGoogle(new_argv[0], &new_argc, &new_argv, false);
+  mozc::InitMozc(new_argv[0], &new_argc, &new_argv, false);
   delete [] tmp[0];
   delete [] tmp[1];
 #else  // OS_MACOSX
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 #endif  // OS_MACOSX
 
 #ifdef OS_MACOSX

--- a/src/gui/word_register_dialog/word_register_dialog_main.cc
+++ b/src/gui/word_register_dialog/word_register_dialog_main.cc
@@ -28,11 +28,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/winmain.h"
 
 int RunWordRegisterDialog(int argc, char *argv[]);
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   return RunWordRegisterDialog(argc, argv);
 }

--- a/src/ipc/ipc_main.cc
+++ b/src/ipc/ipc_main.cc
@@ -27,17 +27,17 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ipc/ipc.h"
-
 #include <cstring>
 #include <iostream>  // NOLINT
 #include <string>
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/thread.h"
+#include "ipc/ipc.h"
 
 DEFINE_string(server_address, "ipc_test", "");
 DEFINE_bool(test, false, "automatic test mode");
@@ -96,7 +96,7 @@ class EchoServerThread: public Thread {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_test) {
     mozc::EchoServer con(FLAGS_server_address, 10, 1000);

--- a/src/ipc/ipc_path_manager_main.cc
+++ b/src/ipc/ipc_path_manager_main.cc
@@ -27,14 +27,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ipc/ipc_path_manager.h"
-
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/util.h"
+#include "ipc/ipc_path_manager.h"
 
 DEFINE_bool(client, false, "client mode");
 DEFINE_bool(server, false, "server mode");
@@ -42,7 +42,7 @@ DEFINE_string(name, "test", "ipc name");
 
 // command line tool to check the behavior of IPCPathManager
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::IPCPathManager *manager =
       mozc::IPCPathManager::GetIPCPathManager(FLAGS_name);

--- a/src/ipc/named_event_main.cc
+++ b/src/ipc/named_event_main.cc
@@ -27,13 +27,13 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ipc/named_event.h"
-
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
+#include "ipc/named_event.h"
 
 DEFINE_bool(listener, true, "listener mode");
 DEFINE_bool(notifier, false, "notifier mode");
@@ -42,7 +42,7 @@ DEFINE_int32(pid, -1, "process id");
 DEFINE_string(name, "named_event_test", "name for named event");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_notifier) {
     mozc::NamedEventNotifier notifier(FLAGS_name.c_str());

--- a/src/ipc/process_watch_dog_main.cc
+++ b/src/ipc/process_watch_dog_main.cc
@@ -27,16 +27,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "ipc/process_watch_dog.h"
-
 #include <iostream>  // NOLINT
 #include <string>
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/util.h"
+#include "ipc/process_watch_dog.h"
 
 DEFINE_int32(timeout, -1, "set timeout");
 
@@ -50,7 +50,7 @@ class TestProcessWatchDog : public ProcessWatchDog {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::TestProcessWatchDog dog;
 

--- a/src/mac/Uninstaller/Uninstaller_main.mm
+++ b/src/mac/Uninstaller/Uninstaller_main.mm
@@ -32,10 +32,11 @@
 #import "DialogsController.h"
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 
 int main(int argc, char *argv[]) {
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   DialogsController *dialogs = [[[DialogsController alloc] init] autorelease];
   [NSBundle loadNibNamed:@"Dialogs" owner:dialogs];

--- a/src/mac/main.mm
+++ b/src/mac/main.mm
@@ -39,6 +39,7 @@
 #include "base/const.h"
 #include "base/crash_report_handler.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/run_level.h"
 #include "client/client.h"
@@ -55,7 +56,7 @@ int main(int argc, char *argv[]) {
     mozc::CrashReportHandler::Initialize(false);
   }
 #endif
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   IMKServer *imkServer = [GoogleJapaneseInputServer getServer];
   if (!imkServer) {

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2167
+BUILD=2168
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/net/http_client_main.cc
+++ b/src/net/http_client_main.cc
@@ -27,14 +27,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "net/http_client.h"
-
 #include <iostream>  // NOLINT
 #include <string>
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/port.h"
+#include "net/http_client.h"
 #include "net/proxy_manager.h"
 
 DEFINE_string(url, "", "url");
@@ -48,7 +48,7 @@ DEFINE_bool(include_header, false, "include header in output");
 DEFINE_bool(use_proxy, true, "use the proxy or not");
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::HTTPClient::Option option;
   option.include_header = FLAGS_include_header;

--- a/src/prediction/gen_suggestion_filter_main.cc
+++ b/src/prediction/gen_suggestion_filter_main.cc
@@ -35,6 +35,7 @@
 #include "base/file_stream.h"
 #include "base/flags.h"
 #include "base/hash.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/util.h"
 #include "storage/existence_filter.h"
@@ -68,7 +69,7 @@ using mozc::storage::ExistenceFilter;
 // read per-line word list and generate
 // bloom filter in raw byte array or header file format
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   if ((FLAGS_input.empty() ||
        FLAGS_output.empty()) && argc > 2) {

--- a/src/renderer/mozc_renderer_main.cc
+++ b/src/renderer/mozc_renderer_main.cc
@@ -35,19 +35,20 @@
 
 #include "base/crash_report_handler.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/run_level.h"
 #include "base/system_util.h"
 #include "base/util.h"
 #include "config/stats_config_util.h"
 
 #ifdef OS_WIN
-#include "base/winmain.h"
 #include "base/win_util.h"
+#include "base/winmain.h"
 #include "renderer/win32/win32_server.h"
 #elif defined(OS_MACOSX)
+#include "renderer/mac/CandidateController.h"
 #include "renderer/mac/mac_server.h"
 #include "renderer/mac/mac_server_send_command.h"
-#include "renderer/mac/CandidateController.h"
 #elif defined(ENABLE_GTK_RENDERER)
 #include "renderer/renderer_client.h"
 #include "renderer/table_layout.h"
@@ -96,7 +97,7 @@ int main(int argc, char *argv[]) {
   if (mozc::config::StatsConfigUtil::IsEnabled()) {
     mozc::CrashReportHandler::Initialize(false);
   }
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   int result_code = 0;
 

--- a/src/rewriter/gen_collocation_data_main.cc
+++ b/src/rewriter/gen_collocation_data_main.cc
@@ -42,6 +42,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "rewriter/gen_existence_data.h"
 
@@ -88,7 +89,7 @@ void Convert() {
 }  // namespace mozc
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   if (FLAGS_collocation_data.empty() && argc > 1) {
     FLAGS_collocation_data = argv[1];

--- a/src/rewriter/gen_collocation_suppression_data_main.cc
+++ b/src/rewriter/gen_collocation_suppression_data_main.cc
@@ -45,6 +45,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/util.h"
 #include "rewriter/gen_existence_data.h"
@@ -103,7 +104,7 @@ void Convert() {
 }  // namespace mozc
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   LOG(INFO) << FLAGS_suppression_data;
 

--- a/src/rewriter/gen_symbol_rewriter_dictionary_main.cc
+++ b/src/rewriter/gen_symbol_rewriter_dictionary_main.cc
@@ -33,16 +33,17 @@
 //    --ordering_rule=ordering_rule_file
 //    --input=input.tsv --output=output_header
 
+#include <algorithm>
 #include <climits>
 #include <map>
-#include <vector>
 #include <set>
 #include <string>
-#include <algorithm>
+#include <vector>
 
 #include "base/file_stream.h"
 #include "base/file_util.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/util.h"
 #include "rewriter/dictionary_generator.h"
@@ -197,7 +198,7 @@ void MakeDictionary(const string &symbol_dictionary_file,
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
 
   if ((FLAGS_input.empty() ||
        FLAGS_sorting_table.empty() ||

--- a/src/rewriter/gen_usage_rewriter_dictionary_main.cc
+++ b/src/rewriter/gen_usage_rewriter_dictionary_main.cc
@@ -42,6 +42,7 @@
 
 #include "base/file_stream.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/util.h"
 
@@ -293,7 +294,7 @@ void Convert() {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   mozc::Convert();
   return 0;
 }

--- a/src/rewriter/rewriter_interface.h
+++ b/src/rewriter/rewriter_interface.h
@@ -86,7 +86,6 @@ class RewriterInterface {
   RewriterInterface() {}
 };
 
-
 }  // namespace mozc
 
 #endif  // MOZC_REWRITER_REWRITER_INTERFACE_H_

--- a/src/server/mozc_rpc_server_main.cc
+++ b/src/server/mozc_rpc_server_main.cc
@@ -48,6 +48,7 @@ using ssize_t = SSIZE_T;
 #include <vector>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/number_util.h"
 #include "base/singleton.h"
 #include "base/system_util.h"
@@ -357,7 +358,7 @@ class ScopedWSAData {
 }  // namespace mozc
 
 int main(int argc, char *argv[]) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::ScopedWSAData wsadata;
 

--- a/src/server/mozc_server.cc
+++ b/src/server/mozc_server.cc
@@ -40,6 +40,7 @@
 #include "base/crash_report_handler.h"
 #include "base/flags.h"
 #include "base/init.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/process_mutex.h"
 #include "base/run_level.h"
@@ -76,10 +77,10 @@ REGISTER_MODULE_SHUTDOWN_HANDLER(shutdown_session,
 
 namespace server {
 
-void InitGoogleAndMozcServer(const char *arg0,
-                             int *argc,
-                             char ***argv,
-                             bool remove_flags) {
+void InitMozcAndMozcServer(const char *arg0,
+                           int *argc,
+                           char ***argv,
+                           bool remove_flags) {
   mozc::SystemUtil::DisableIME();
 
   // Big endian is not supported. The storage for user history is endian
@@ -92,8 +93,8 @@ void InitGoogleAndMozcServer(const char *arg0,
   ::SetProcessShutdownParameters(0x100, SHUTDOWN_NORETRY);
 #endif
 
-  // call GetRunLevel before InitGoogle().
-  // InitGoogle() will do all static initialization and may access
+  // call GetRunLevel before mozc::InitMozc().
+  // mozc::InitMozc() will do all static initialization and may access
   // local resources.
   const mozc::RunLevel::RunLevelType run_level =
       mozc::RunLevel::GetRunLevel(mozc::RunLevel::SERVER);
@@ -106,7 +107,7 @@ void InitGoogleAndMozcServer(const char *arg0,
   if (mozc::config::StatsConfigUtil::IsEnabled()) {
     mozc::CrashReportHandler::Initialize(false);
   }
-  InitGoogle(arg0, argc, argv, remove_flags);
+  mozc::InitMozc(arg0, argc, argv, remove_flags);
 
   if (run_level == mozc::RunLevel::RESTRICTED) {
     VLOG(1) << "Mozc server starts with timeout mode";

--- a/src/server/mozc_server.h
+++ b/src/server/mozc_server.h
@@ -35,10 +35,10 @@
 namespace mozc {
 namespace server {
 
-void InitGoogleAndMozcServer(const char *arg0,
-                             int *argc,
-                             char ***argv,
-                             bool remove_flags);
+void InitMozcAndMozcServer(const char *arg0,
+                           int *argc,
+                           char ***argv,
+                           bool remove_flags);
 
 class MozcServer {
  public:

--- a/src/server/mozc_server_main.cc
+++ b/src/server/mozc_server_main.cc
@@ -32,7 +32,7 @@
 #include "server/mozc_server.h"
 
 int main(int argc, char* argv[]) {
-  mozc::server::InitGoogleAndMozcServer(argv[0], &argc, &argv, false);
+  mozc::server::InitMozcAndMozcServer(argv[0], &argc, &argv, false);
 
   const int return_value = mozc::server::MozcServer::Run();
   mozc::server::MozcServer::Finalize();

--- a/src/session/session_client_main.cc
+++ b/src/session/session_client_main.cc
@@ -34,6 +34,7 @@
 #include "base/file_stream.h"
 #include "base/file_util.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/system_util.h"
@@ -86,7 +87,7 @@ void Loop(istream *input, ostream *output) {
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   std::unique_ptr<mozc::InputFileStream> input_file;
   std::unique_ptr<mozc::OutputFileStream> output_file;
   istream *input = NULL;

--- a/src/session/session_server_main.cc
+++ b/src/session/session_server_main.cc
@@ -31,6 +31,7 @@
 #include <cstdio>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "protocol/commands.pb.h"
 #include "session/session_server.h"
 
@@ -55,7 +56,7 @@ void SendCommand(SessionServer *server,
 }  // namespace mozc
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   mozc::SessionServer server;
   mozc::commands::Input input;

--- a/src/storage/existence_filter_main.cc
+++ b/src/storage/existence_filter_main.cc
@@ -27,19 +27,19 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "storage/existence_filter.h"
-
 #include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/util.h"
+#include "storage/existence_filter.h"
 
 using mozc::storage::ExistenceFilter;
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   int n = 500;
   int m = ExistenceFilter::MinFilterSizeInBytesForErrorRate(0.01, n);

--- a/src/storage/lru_cache_main.cc
+++ b/src/storage/lru_cache_main.cc
@@ -27,16 +27,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "storage/lru_cache.h"
-
-#include <string>
 #include <iostream>  // NOLINT
+#include <string>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/util.h"
+#include "storage/lru_cache.h"
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   mozc::storage::LRUCache<string, string> cache(5);
 
   string line;

--- a/src/storage/lru_storage_main.cc
+++ b/src/storage/lru_storage_main.cc
@@ -27,13 +27,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "storage/lru_storage.h"
-
 #include <string>
 
 #include "base/logging.h"
 #include "base/port.h"
 #include "base/util.h"
+#include "storage/lru_storage.h"
 
 DEFINE_bool(create_db, false, "initialize database");
 DEFINE_string(file, "test.db", "");
@@ -42,7 +41,7 @@ DEFINE_int32(size, 10, "size");
 using mozc::storage::LRUStorage;
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   if (FLAGS_create_db) {
     CHECK(LRUStorage::CreateStorageFile(

--- a/src/testing/base/internal/gtest_main.cc
+++ b/src/testing/base/internal/gtest_main.cc
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "testing/base/public/googletest.h"
 #include "testing/base/public/gunit.h"
 
@@ -40,7 +41,7 @@
 int main(int argc, char **argv) {
   // TODO(yukawa, team): Implement b/2805528 so that you can specify any option
   // given by gunit.
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
   mozc::InitTestFlags();
   testing::InitGoogleTest(&argc, argv);
 

--- a/src/testing/base/public/nacl_mock_module.cc
+++ b/src/testing/base/public/nacl_mock_module.cc
@@ -40,9 +40,10 @@
 #include <cstring>
 #include <memory>
 
-#include "base/port.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/pepper_file_util.h"
+#include "base/port.h"
 #include "net/http_client_pepper.h"
 #include "testing/base/public/googletest.h"
 #include "testing/base/public/gunit.h"
@@ -136,7 +137,7 @@ Module* CreateModule() {
   char argv0[] = "NaclModule";
   char *argv_body[] = {argv0, NULL};
   char **argv = argv_body;
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   testing::InitGoogleTest(&argc, argv);
 
   return new NaclTestModule();

--- a/src/unix/emacs/mozc_emacs_helper.cc
+++ b/src/unix/emacs/mozc_emacs_helper.cc
@@ -27,12 +27,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "unix/emacs/mozc_emacs_helper_lib.h"
-
 #include <cstdio>
 #include <iostream>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/protobuf/descriptor.h"
 #include "base/protobuf/message.h"
@@ -42,6 +41,7 @@
 #include "config/config_handler.h"
 #include "protocol/commands.pb.h"
 #include "unix/emacs/client_pool.h"
+#include "unix/emacs/mozc_emacs_helper_lib.h"
 
 DEFINE_bool(suppress_stderr, false,
             "Discards all the output to stderr.");
@@ -127,7 +127,7 @@ void ProcessLoop() {
 
 
 int main(int argc, char **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   if (FLAGS_suppress_stderr) {
 #ifdef OS_WIN
     const char path[] = "NUL";

--- a/src/unix/ibus/main.cc
+++ b/src/unix/ibus/main.cc
@@ -27,9 +27,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cstddef>
 #include <cstdio>
 
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/logging.h"
 #include "base/version.h"
 #include "unix/ibus/main.h"
@@ -123,7 +125,7 @@ void InitIBusComponent(bool executed_by_ibus_daemon) {
 }  // namespace
 
 int main(gint argc, gchar **argv) {
-  InitGoogle(argv[0], &argc, &argv, true);
+  mozc::InitMozc(argv[0], &argc, &argv, true);
   ibus_init();
   InitIBusComponent(FLAGS_ibus);
   mozc::ibus::MozcEngine::InitConfig(g_config);

--- a/src/win32/broker/mozc_broker_main.cc
+++ b/src/win32/broker/mozc_broker_main.cc
@@ -33,6 +33,7 @@
 
 #include "base/crash_report_handler.h"
 #include "base/flags.h"
+#include "base/init_mozc.h"
 #include "base/system_util.h"
 #ifdef OS_WIN
 #include "base/winmain.h"
@@ -61,7 +62,7 @@ int main(int argc, char *argv[]) {
   if (mozc::config::StatsConfigUtil::IsEnabled()) {
     mozc::CrashReportHandler::Initialize(false);
   }
-  InitGoogle(argv[0], &argc, &argv, false);
+  mozc::InitMozc(argv[0], &argc, &argv, false);
 
   int result = 0;
 #ifdef OS_WIN


### PR DESCRIPTION
Currently ```flags.cc``` defines ```InitGoogle``` in which logging is initialized. This is causing circular dependency between ```logging.cc``` and ```flags.cc```.  This CL addresses the issue.

This CL also renames ```InitGoogle``` to ```mozc::InitMozc``` to make it clear that the function is responsible for initializing only Mozc-related components, and has nothing to do with any other libraries even if they were developed by Google.

BUG=
TEST=unittest
REF_BUG=19010851
REF_CL=85680996,85596766,85688252,85688262,85688306,85689019