### PR TITLE
Attempt to fix #317 (2nd try)

### DIFF
--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2242
+BUILD=2243
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/session/session_handler_scenario_test.cc
+++ b/src/session/session_handler_scenario_test.cc
@@ -116,9 +116,13 @@ class SessionHandlerScenarioTest : public SessionHandlerTestBase,
     last_output_->Clear();
   }
 
+  void SyncDataToStorage() {
+    EXPECT_TRUE(engine_->GetUserDataManager()->WaitForSyncerForTest());
+  }
+
   void ClearUserPrediction() {
     EXPECT_TRUE(client_->ClearUserPrediction());
-    EXPECT_TRUE(engine_->GetUserDataManager()->WaitForSyncerForTest());
+    SyncDataToStorage();
   }
 
   void ClearUsageStats() {
@@ -362,6 +366,8 @@ TEST_P(SessionHandlerScenarioTest, TestImpl) {
       // Skip an empty or comment line.
       continue;
     }
+
+    SyncDataToStorage();
 
     columns.clear();
     Util::SplitStringUsing(line_text, "\t", &columns);


### PR DESCRIPTION
```UserHistoryPredictor``` does not predict candidates if syncer is working. At least we should call ```UserHistoryPredictor::WaitForSyncerForTest()``` for each command on ```SessionHandlerScenarioTest```.

Note that this is test only change.  Nothing is changed in production binaries.