### PR TITLE
Build Mozc on Fedora 23 in Docker.

### DIFF
--- a/doc/build_mozc_in_docker.md
+++ b/doc/build_mozc_in_docker.md
@@ -16,14 +16,15 @@ sudo docker build --rm -t $USER/mozc_ubuntu14.04 .
 sudo docker run --interactive --tty --rm $USER/mozc_ubuntu14.04
 ```
 
-## Set up Fedora 21 Docker container
-Fedora 21 container is also provided just for your reference.
+## Set up Fedora 23 Docker container
+Fedora 23 container is also provided just for your reference.
 
+Building Mozc for Android is not supported on Fedora 23 due to the lack of OpenJDK 1.7 support.  See [Red Hat Bugzilla – Bug 1190137](https://bugzilla.redhat.com/show_bug.cgi?id=1190137) for details.
 ```
-mkdir fedora21 && cd fedora21
-curl -O https://raw.githubusercontent.com/google/mozc/master/docker/fedora21/Dockerfile
-sudo docker build --rm -t $USER/mozc_fedora21 .
-sudo docker run --interactive --tty --rm $USER/mozc_fedora21
+mkdir fedora23 && cd fedora23
+curl -O https://raw.githubusercontent.com/google/mozc/master/docker/fedora23/Dockerfile
+sudo docker build --rm -t $USER/mozc_fedora23 .
+sudo docker run --interactive --tty --rm $USER/mozc_fedora23
 ```
 
 ### Hint

--- a/docker/fedora23/Dockerfile
+++ b/docker/fedora23/Dockerfile
@@ -27,18 +27,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM fedora:21
+FROM fedora:23
 
 # Package installation
-RUN yum -y update
+RUN dnf -y update
 ## Common packages for linux build environment
-RUN yum install -y clang libstdc++-static python git curl bzip2 unzip
+RUN dnf install -y clang libstdc++-static python git curl bzip2 unzip which
 ## Packages for linux desktop version
-RUN yum install -y ibus-devel glib2-devel qt-devel gtk2-devel libxcb-devel
-## Packages for Android
-RUN yum install -y java-1.7.0-openjdk-devel jsr-305 ant glibc.i686 glibc-devel.i686 libstdc++.i686 ncurses-devel.i686 zlib-devel.i686 zip
+RUN dnf install -y ibus-devel glib2-devel qt-devel gtk2-devel libxcb-devel
+## Packages for NaCl
+RUN dnf install -y glibc.i686
 ## For emacsian
-RUN yum install -y emacs
+RUN dnf install -y emacs
 
 ENV HOME /home/mozc_builder
 RUN useradd --create-home --shell /bin/bash --base-dir /home mozc_builder
@@ -47,17 +47,6 @@ USER mozc_builder
 # SDK setup
 RUN mkdir -p /home/mozc_builder/work
 WORKDIR /home/mozc_builder/work
-
-## Android SDK/NDK
-RUN curl -L http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin -O && chmod u+x android-ndk-r10e-linux-x86_64.bin && ./android-ndk-r10e-linux-x86_64.bin && rm android-ndk-r10e-linux-x86_64.bin
-RUN curl -L http://dl.google.com/android/android-sdk_r24.1.2-linux.tgz | tar -zx
-ENV ANDROID_NDK_HOME /home/mozc_builder/work/android-ndk-r10e
-ENV ANDROID_HOME /home/mozc_builder/work/android-sdk-linux
-ENV PATH $PATH:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_NDK_HOME}
-RUN echo y | android update sdk --all --force --no-ui --filter android-22
-RUN echo y | android update sdk --all --force --no-ui --filter build-tools-22.0.0
-RUN echo y | android update sdk --all --force --no-ui --filter extra-android-support
-RUN echo y | android update sdk --all --force --no-ui --filter platform-tool
 
 ## NaCl SDK
 RUN curl -LO http://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/nacl_sdk.zip && unzip nacl_sdk.zip && rm nacl_sdk.zip

--- a/docker/fedora23/clobber-make-buildenv.sh
+++ b/docker/fedora23/clobber-make-buildenv.sh
@@ -28,4 +28,4 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-docker build --rm -t $USER/mozc_fedora21 .
+docker build --no-cache --rm -t $USER/mozc_fedora23 .

--- a/docker/fedora23/enter-buildenv.sh
+++ b/docker/fedora23/enter-buildenv.sh
@@ -28,4 +28,4 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-docker build --no-cache --rm -t $USER/mozc_fedora21 .
+docker run --interactive --tty --rm $USER/mozc_fedora23

--- a/docker/fedora23/make-buildenv.sh
+++ b/docker/fedora23/make-buildenv.sh
@@ -28,4 +28,4 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-docker run --interactive --tty --rm $USER/mozc_fedora21
+docker build --rm -t $USER/mozc_fedora23 .


### PR DESCRIPTION
Since Fedora 21 will soon enter End Of Life (EOL) status on December 1st, 2015, this CL updates Dockerfile for Fedora to use Fedora 23 instead of Fedora 21.

Note that building Mozc for Android is not supported on Fedora 23 due to the lack of OpenJDK 1.7 support.  See [Red Hat Bugzilla – Bug 1190137](https://bugzilla.redhat.com/show_bug.cgi?id=1190137) for details.

Note also that this Dockerfile is provided just for the reference. Ensuring that Mozc can be built on Fedora 23 is beyond our goal at the moment.
