### PR TITLE
Fix a runtime crash in Mozc for Android.

### DIFF
--- a/src/android/android.gyp
+++ b/src/android/android.gyp
@@ -576,6 +576,7 @@
       'product_dir': '<(abs_android_dir)/libs/<(abi)',
       'dependencies': [
         '../base/base.gyp:base',
+        '../base/base.gyp:jni_proxy',
         '../dictionary/dictionary.gyp:dictionary',
         '../engine/engine.gyp:engine_factory',
         '../session/session.gyp:session',

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2287
+BUILD=2288
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/net/net.gyp
+++ b/src/net/net.gyp
@@ -83,11 +83,6 @@
                 'http_client_pepper.cc',
               ],
             }],
-            ['target_platform=="Android"', {
-              'dependencies': [
-                '../base/base.gyp:jni_proxy'
-              ],
-            }],
           ],
         }, {  # blanding!=GoogleJapaneseInput
           'sources': [


### PR DESCRIPTION
This closes #345 that was introduced by 9cd4d36d2d51968bfad369fc6ee7703594007aef.
