### PR TITLE
Support 'icon_prop_key' entry in ibus-mozc.

### DIFF
--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2312
+BUILD=2313
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.

--- a/src/unix/ibus/gen_mozc_xml.py
+++ b/src/unix/ibus/gen_mozc_xml.py
@@ -56,45 +56,6 @@ IBUS_COMPONENT_PROPS = {
     'textdomain': 'ibus-mozc',
 }
 
-# Information to generate <engines> part of mozc.xml.
-IBUS_ENGINE_COMMON_PROPS = {
-    'description': '%(product_name)s (Japanese Input Method)',
-    'language': 'ja',
-    'icon': '%(ibus_mozc_icon_path)s',
-    'rank': '80',
-}
-
-# Information to generate <engines> part of mozc.xml for IBus 1.5 or later.
-IBUS_1_5_ENGINE_COMMON_PROPS = {
-    'description': '%(product_name)s (Japanese Input Method)',
-    'language': 'ja',
-    'icon': '%(ibus_mozc_icon_path)s',
-    'rank': '80',
-    'symbol': '&#x3042;',
-}
-
-# A dictionary from platform to engines that are used in the platform. The
-# information is used to generate <engines> part of mozc.xml.
-IBUS_ENGINES_PROPS = {
-    # On Linux, we provide only one engine for the Japanese keyboard layout.
-    'Linux': {
-        # DO NOT change the engine name 'mozc-jp'. The names is referenced by
-        # unix/ibus/mozc_engine.cc.
-        'name': ['mozc-jp'],
-        'longname': ['%(product_name)s'],
-        'layout': ['jp'],
-    },
-    # On Linux (IBus >= 1.5), we use special label 'default' for the keyboard
-    # layout.
-    'Linux-IBus1.5': {
-        # DO NOT change the engine name 'mozc-jp'. The names is referenced by
-        # unix/ibus/mozc_engine.cc.
-        'name': ['mozc-jp'],
-        'longname': ['%(product_name)s'],
-        'layout': ['default'],
-    },
-}
-
 # A dictionary from --branding to a product name which is embedded into the
 # properties above.
 PRODUCT_NAMES = {
@@ -175,10 +136,10 @@ def OutputCpp(param_dict, component, engine_common, engines):
   print CPP_FOOTER % guard_name
 
 
-def IsIBus15OrGreater(options):
-  """Returns True when the version of ibus-1.0 is 1.5 or greater."""
+def CheckIBusVersion(options, minimum_version):
+  """Tests if ibus version is equal to or greater than the given value."""
   command_line = [options.pkg_config_command, '--exists',
-                  'ibus-1.0 >= 1.5.0']
+                  'ibus-1.0 >= %s' % minimum_version]
   return_code = subprocess.call(command_line)
   if return_code == 0:
     return True
@@ -211,24 +172,46 @@ def main():
   setup_arg = []
   setup_arg.append(os.path.join(options.server_dir, 'mozc_tool'))
   setup_arg.append('--mode=config_dialog')
-  if IsIBus15OrGreater(options):
-    # A tentative workaround against IBus 1.5
-    platform = 'Linux-IBus1.5'
-    common_props = IBUS_1_5_ENGINE_COMMON_PROPS
-  else:
-    platform = 'Linux'
-    common_props = IBUS_ENGINE_COMMON_PROPS
 
-  param_dict = {'product_name': PRODUCT_NAMES[options.branding],
-                'ibus_mozc_path': options.ibus_mozc_path,
-                'ibus_mozc_icon_path': options.ibus_mozc_icon_path}
+  param_dict = {
+      'product_name': PRODUCT_NAMES[options.branding],
+      'ibus_mozc_path': options.ibus_mozc_path,
+      'ibus_mozc_icon_path': options.ibus_mozc_icon_path,
+  }
+
+  engine_common_props = {
+      'description': '%(product_name)s (Japanese Input Method)',
+      'language': 'ja',
+      'icon': '%(ibus_mozc_icon_path)s',
+      'rank': '80',
+  }
+
+  # DO NOT change the engine name 'mozc-jp'. The names is referenced by
+  # unix/ibus/mozc_engine.cc.
+  engines_props = {
+      'name': ['mozc-jp'],
+      'longname': ['%(product_name)s'],
+  }
+
+  # IBus 1.5.11 and greater supports 'icon_prop_key'.
+  # See ibus/ibus@23c45b970b195008a54884a1a9d810e7f8b22c5c
+  if CheckIBusVersion(options, '1.5.11'):
+    # Make sure that the property key 'InputMode' matches to the property name
+    # specified to |ibus_property_new| in unix/ibus/property_handler.cc
+    engine_common_props['icon_prop_key'] = 'InputMode'
+
+  if CheckIBusVersion(options, '1.5.0'):
+    engine_common_props['symbol'] = '&#x3042;'
+    engines_props['layout'] = ['default']
+  else:
+    engines_props['layout'] = ['jp']
 
   if options.output_cpp:
-    OutputCpp(param_dict, IBUS_COMPONENT_PROPS, common_props,
-              IBUS_ENGINES_PROPS[platform])
+    OutputCpp(param_dict, IBUS_COMPONENT_PROPS, engine_common_props,
+              engines_props)
   else:
-    OutputXml(param_dict, IBUS_COMPONENT_PROPS, common_props,
-              IBUS_ENGINES_PROPS[platform], setup_arg)
+    OutputXml(param_dict, IBUS_COMPONENT_PROPS, engine_common_props,
+              engines_props, setup_arg)
   return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #344.

Showing a status icon instead of the IME's product icon is a new feature introduced by ibus/ibus@23c45b970b195008a54884a1a9d810e7f8b22c5c and has been available since IBus 1.5.11.  Hence this CL adds ```icon_prop_key``` to ```mozc.xml``` when the IBus version is 1.5.11 or later.

Although supporting new IBus feature is not our goal any more, supporting his feature before we delete ibus-mozc in #287 may help some people.

One thing you should keep in mind is that the version of IBus is checked at build time, not run-time.  This means that if you upgrade IBus from 1.5.10 or prior to 1.5.11 or later then you have to rebuild ```ibus-mozc``` so that ```mozc.xml``` can be updated.