### PR TITLE
Fix resource leak when Thread::Start() is called multiple times.

### DIFF
--- a/src/base/thread.cc
+++ b/src/base/thread.cc
@@ -147,7 +147,10 @@ bool Thread::IsRunning() const {
 }
 
 void Thread::Detach() {
-  state_->handle_.reset(nullptr);
+  if (state_->handle_ != nullptr) {
+    pthread_detach(*state_->handle_);
+    state_->handle_.reset(nullptr);
+  }
 }
 
 void Thread::Join() {

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2313
+BUILD=2314
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
This addresses a native resource leak in #355.
