### PR TITLE
Remove unused variables.

### DIFF
--- a/src/config/config_handler_test.cc
+++ b/src/config/config_handler_test.cc
@@ -250,8 +250,6 @@ TEST_F(ConfigHandlerTest, SetConfigFileName) {
 // mock file system doesn't have a source file.
 // TODO(hsumita): Enable this test on Android and NaCl.
 TEST_F(ConfigHandlerTest, LoadTestConfig) {
-  const char kPathPrefix[] = "";
-  const char KDataDir[] = "data/test/config";
   // TODO(yukawa): Generate test data automatically so that we can keep
   //     the compatibility among variety of config files.
   // TODO(yukawa): Enumerate test data in the directory automatically.

--- a/src/mozc_version_template.txt
+++ b/src/mozc_version_template.txt
@@ -1,6 +1,6 @@
 MAJOR=2
 MINOR=17
-BUILD=2314
+BUILD=2315
 REVISION=102
 # NACL_DICTIONARY_VERSION is the target version of the system dictionary to be
 # downloaded by NaCl Mozc.


### PR DESCRIPTION
This is a follow up CL for fbf4031acb671e98957d3b87e57c07a7d04c456d, which forgot to remove unused variables.  No behavior change is intended.