### PR TITLE
Spelling Fix in Find Dialogue GUI

### DIFF
--- a/src/gui/dictionary_tool/dictionary_tool_en.qtts
+++ b/src/gui/dictionary_tool/dictionary_tool_en.qtts
@@ -38,7 +38,7 @@
     </message>
     <message>
         <location filename="find_dialog.ui" line="68"/>
-        <source>Cacnel</source>
+        <source>Cancel</source>
         <translation></translation>
     </message>
 </context>

--- a/src/gui/dictionary_tool/dictionary_tool_ja.qtts
+++ b/src/gui/dictionary_tool/dictionary_tool_ja.qtts
@@ -38,7 +38,7 @@
     </message>
     <message>
         <location filename="find_dialog.ui" line="68"/>
-        <source>Cacnel</source>
+        <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
 </context>

--- a/src/gui/dictionary_tool/find_dialog.ui
+++ b/src/gui/dictionary_tool/find_dialog.ui
@@ -96,7 +96,7 @@
      <item row="2" column="3">
       <widget class="QPushButton" name="CancelpushButton">
        <property name="text">
-        <string>Cacnel</string>
+        <string>Cancel</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Basically a spelling fix for the GUI.
![スクリーンショット_2021-11-11_19-37-51](https://user-images.githubusercontent.com/61252570/141286697-0f02998e-d277-4385-a9d8-8cf9edb4e68e.png)
Yes, I am fully aware that `src/gui/` is **not** listed as a valid file for pull requests at this time for Google; this request was made to shed a small candlelight for a simple misspell within the sourcecode in case anyone would like to take notice when forking. 