### PR TITLE
(mozc.el) Fix overlay not displaying in emacs

### DIFF
--- a/src/unix/emacs/mozc.el
+++ b/src/unix/emacs/mozc.el
@@ -661,7 +661,7 @@ This hack could be moved to mozc-posn-at-x-y in a future version."
   "Return the width of WINDOW in pixel.
 WINDOW defaults to the selected window."
   (let ((rect (window-inside-pixel-edges window)))
-    (- (third rect) (first rect))))
+    (- (nth 2 rect) (nth 0 rect))))
 
 (defun mozc-header-line-height ()
   "Return the height of the header line.


### PR DESCRIPTION
The candidate overlay does not display in emacs even if `mozc-candidate-style` is set to `overlay`, and falls back to `echo-area`. This happens due to the non-existence in Elisp of the shorthands `first` and `third` for list manipulation at the relevant places.

Switching to using `nth` resolves the problem.