### PR TITLE
Also check if event of handleEvent:client: is NSNull or not.

### DIFF
--- a/src/mac/GoogleJapaneseInputController.mm
+++ b/src/mac/GoogleJapaneseInputController.mm
@@ -859,7 +859,12 @@ bool IsBannedApplication(const std::set<std::string, std::less<>> *bundleIdSet,
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender {
-  if (event == nullptr) {
+  // NSNull might get passed to this method (as `event`) in certain cases. 
+  // We guard-let this parameter to make sure it is neither NSNull nor nullptr.
+  // Abort processing if it really is.
+  // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/NumbersandValues/Articles/Null.html
+  // https://github.com/google/mozc/issues/735
+  if (event == nullptr || event == [NSNull null]) {
     return NO;
   }
   if ([event type] == NSEventTypeCursorUpdate) {


### PR DESCRIPTION
**Description**
* NSNull might get passed to this method (as `event`) in certain cases. We guard-let this parameter to make sure it is neither NSNull nor nullptr. Abort processing if it really is. 

**Issue IDs**
- https://github.com/google/mozc/issues/735

Note that several code locations are not accepting pull requests yet. See https://github.com/google/mozc/blob/master/CONTRIBUTING.md for details. Just file an issue at https://github.com/google/mozc/issues with your prototype if you hit this limitation.

**Steps to test new behaviors (if any)**
N/A

**Additional context**
Reference:  https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/NumbersandValues/Articles/Null.html