### PR TITLE
Update build_mozc_in_docker.md

### DIFF
--- a/docs/build_mozc_in_docker.md
+++ b/docs/build_mozc_in_docker.md
@@ -32,7 +32,7 @@ Currently, only Ubuntu 20.04 is tested to host the Docker container to build Moz
 
 ```
 curl -O https://raw.githubusercontent.com/google/mozc/master/docker/ubuntu20.04/Dockerfile
-docker build --rm -tag mozc_ubuntu20.04 .
+docker build --rm --tag mozc_ubuntu20.04 .
 docker create --interactive --tty --name mozc_build mozc_ubuntu20.04
 ```
 

--- a/docs/build_mozc_in_docker.md
+++ b/docs/build_mozc_in_docker.md
@@ -10,7 +10,7 @@ and make sure the operations before running them.
 
 ```
 curl -O https://raw.githubusercontent.com/google/mozc/master/docker/ubuntu20.04/Dockerfile
-docker build --rm -tag mozc_ubuntu20.04 .
+docker build --rm --tag mozc_ubuntu20.04 .
 docker create --interactive --tty --name mozc_build mozc_ubuntu20.04
 
 docker start mozc_build


### PR DESCRIPTION
**Description**
There was a typo in one of the command.

**Modified code locations**
 build_mozc_in_docker.md

**Steps to test new behaviors**
Now when following the tutorial to create the build docker, there is no more error.
curl -O https://raw.githubusercontent.com/google/mozc/master/docker/ubuntu20.04/Dockerfile
docker build --rm --tag mozc_ubuntu20.04 .
docker create --interactive --tty --name mozc_build mozc_ubuntu20.04