### PR TITLE
Switch from gcc to clang to use decltype

### DIFF
--- a/docker/ubuntu20.04/Dockerfile
+++ b/docker/ubuntu20.04/Dockerfile
@@ -69,5 +69,8 @@ RUN mkdir /home/mozc_builder/work/mozc
 # COPY --chown=mozc_builder:mozc_builder src/ /home/mozc_builder/work/mozc/src/
 RUN git clone https://github.com/google/mozc.git -b master --single-branch --recursive
 
+# Use clang instead of gcc to support decltype
+ENV CC=clang CXX=clang++
+
 WORKDIR /home/mozc_builder/work/mozc/src
 ENTRYPOINT bash


### PR DESCRIPTION
Basically porting 5818a11df5ab0addebe5142c160393bb11dc122d to Dockerfile.

**Description**

Mozc's C++ is too "modern" for Ubuntu 20.04's gcc. This commit switches the compilers from gcc to clang to workaround the issue.

**Issue IDs**

5818a11df5ab0addebe5142c160393bb11dc122d

**Modified code locations**
Files/directories of this pull request.
(e.g. src/data/oss/aux_dictionary.tsv, src/renderer/qt/)

```
docker/ubuntu20.04/Dockerfile
```

**Confirmation of the acceptable code locations**
Check https://github.com/google/mozc/blob/master/CONTRIBUTING.md and
confirm whether all modified files are acceptable for pull requests.

Yes

**Steps to test new behaviors (if any)**
A clear and concise description about how to verify new behaviors (if any).
 - OS: Ubuntu 22.04
 - Steps:
   1. Following https://github.com/google/mozc/blob/master/docs/build_mozc_in_docker.md#summary
   2. `docker exec mozc_build bazel build package --config oss_linux -c opt` part doesn't with without this change

**Additional context**
Add any other context about the pull request here.
