### PR TITLE
Remove needless quotes from case key-list

### DIFF
--- a/src/unix/emacs/mozc.el
+++ b/src/unix/emacs/mozc.el
@@ -395,37 +395,37 @@ Key code and symbols are renamed so that the helper process understands them."
                  (?\b 'backspace)
                  (?\s 'space)
                  (?\d 'backspace)
-                 ('eisu-toggle 'eisu)
-                 ('hiragana-katakana 'kana)
-                 ('next 'pagedown)
-                 ('prior 'pageup)
-                 ('kp-decimal 'decimal)
-                 ('kp-0 'numpad0)
-                 ('kp-1 'numpad1)
-                 ('kp-2 'numpad2)
-                 ('kp-3 'numpad3)
-                 ('kp-4 'numpad4)
-                 ('kp-5 'numpad5)
-                 ('kp-6 'numpad6)
-                 ('kp-7 'numpad7)
-                 ('kp-8 'numpad8)
-                 ('kp-9 'numpad9)
-                 ('kp-delete 'delete)  ; .
-                 ('kp-insert 'insert)  ; 0
-                 ('kp-end 'end)        ; 1
-                 ('kp-down 'down)      ; 2
-                 ('kp-next 'pagedown)  ; 3
-                 ('kp-left 'left)      ; 4
-                 ('kp-begin 'clear)    ; 5
-                 ('kp-right 'right)    ; 6
-                 ('kp-home 'home)      ; 7
-                 ('kp-up 'up)          ; 8
-                 ('kp-prior 'pageup)   ; 9
-                 ('kp-add 'add)
-                 ('kp-subtract 'subtract)
-                 ('kp-multiply 'multiply)
-                 ('kp-divide 'divide)
-                 ('kp-enter 'enter)
+                 (eisu-toggle 'eisu)
+                 (hiragana-katakana 'kana)
+                 (next 'pagedown)
+                 (prior 'pageup)
+                 (kp-decimal 'decimal)
+                 (kp-0 'numpad0)
+                 (kp-1 'numpad1)
+                 (kp-2 'numpad2)
+                 (kp-3 'numpad3)
+                 (kp-4 'numpad4)
+                 (kp-5 'numpad5)
+                 (kp-6 'numpad6)
+                 (kp-7 'numpad7)
+                 (kp-8 'numpad8)
+                 (kp-9 'numpad9)
+                 (kp-delete 'delete)  ; .
+                 (kp-insert 'insert)  ; 0
+                 (kp-end 'end)        ; 1
+                 (kp-down 'down)      ; 2
+                 (kp-next 'pagedown)  ; 3
+                 (kp-left 'left)      ; 4
+                 (kp-begin 'clear)    ; 5
+                 (kp-right 'right)    ; 6
+                 (kp-home 'home)      ; 7
+                 (kp-up 'up)          ; 8
+                 (kp-prior 'pageup)   ; 9
+                 (kp-add 'add)
+                 (kp-subtract 'subtract)
+                 (kp-multiply 'multiply)
+                 (kp-divide 'divide)
+                 (kp-enter 'enter)
                  (t basic-type))))
       (cond
        ;; kana + shift + rest => katakana + rest


### PR DESCRIPTION
**Description**

Remove needless quote from case key-list. This causes byte-compile warnings(as followings) since emacs 29.1. If the key is quoted, it matches against key and `quote`. For example `'eisu-toggle` matches `eisu-toggle` and `quote` symbol.

```
mozc.el:394:25: Warning: Case 'eisu-toggle will match ‘quote’.  If that’s
    intended, write (eisu-toggle quote) instead.  Otherwise, don’t quote
    ‘eisu-toggle’.
mozc.el:394:25: Warning: Case 'hiragana-katakana will match ‘quote’.  If
    that’s intended, write (hiragana-katakana quote) instead.  Otherwise,
    don’t quote ‘hiragana-katakana’.
...
```

**Issue IDs**

**Modified code locations**

- src/unix/emacs/mozc.el

**Confirmation of the acceptable code locations**
Check https://github.com/google/mozc/blob/master/CONTRIBUTING.md and
confirm whether all modified files are acceptable for pull requests.

"Yes"

**Steps to test new behaviors (if any)**

- Install Emacs 29.1 or higher versions
- Byte-compile
- Check if the warnings are gone

**Additional context**

