### PR TITLE
Prevent renderer from crashing by invalid coordinates

### DIFF
--- a/src/renderer/qt/qt_window_manager.cc
+++ b/src/renderer/qt/qt_window_manager.cc
@@ -417,7 +417,15 @@ bool QtWindowManager::ShouldShowInfolistWindow(
 
 Rect QtWindowManager::GetMonitorRect(int x, int y) {
   QPoint point{x, y};
-  return GetRect(QGuiApplication::screenAt(point)->geometry());
+  const QScreen *screen = QGuiApplication::screenAt(point);
+  if (screen == nullptr) {
+    // (x, y) does not belong to any screen. Fall back to the primary screen.
+    // TODO: Return the nearest monitor rect instead.
+    // c.f. GetWorkingAreaFromPointImpl in win32_renderer_util.cc.
+    return GetRect(QGuiApplication::primaryScreen()->geometry());
+  }
+
+  return GetRect(screen->geometry());
 }
 
 void QtWindowManager::UpdateInfolistWindow(


### PR DESCRIPTION
## Description
An application might send invalid coordinate which do not belong to any screen. This fixes a nullptr access by falling back to the primary screen in a such case.

## Issue IDs
N/A

## Modified code locations
src/renderer/qt/qt_window_manager.cc

## Confirmation of the acceptable code locations
Check https://github.com/google/mozc/blob/master/CONTRIBUTING.md and
confirm whether all modified files are acceptable for pull requests.

"Yes"

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Linux
 - Steps:
   1. Open gEdit
   2. Move the window so that its cursor go out of screen
   3. Type keys and convert
   4. The Renderer does not crash

## Additional context
N/A
