### PR TITLE
Add protocol-matchers to third_party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "src/third_party/wil"]
 	path = src/third_party/wil
 	url = https://github.com/microsoft/wil.git
+[submodule "src/third_party/protobuf-matchers"]
+	path = src/third_party/protobuf-matchers
+	url = https://github.com/inazarenko/protobuf-matchers.git

--- a/src/WORKSPACE.bazel
+++ b/src/WORKSPACE.bazel
@@ -58,6 +58,11 @@ local_repository(
     path = "third_party/gtest",
 )
 
+# GMock matchers for protocol buffers
+local_repository(
+    name = "com_github_protobuf_matchers",
+    path = "third_party/protobuf-matchers",
+)
 
 # Bazel macOS build (1.1.3 2022-11-10)
 # https://github.com/bazelbuild/rules_apple/


### PR DESCRIPTION

## Description
Preparing to migrate //testing:testing_util to the external library that comes with more features and is well tested.

## Issue IDs
#824

## Modified code locations
- .gitmodules
- src/third_party/protobuf-matchers

## Confirmation of the acceptable code locations
Yes

## Steps to test new behaviors (if any)
n/a

## Additional context
Actual migration will follow.