### PR TITLE
Update dictionary_prediction_aggregator.cc

### DIFF
--- a/src/prediction/dictionary_prediction_aggregator.cc
+++ b/src/prediction/dictionary_prediction_aggregator.cc
@@ -41,7 +41,6 @@
 #include <utility>
 #include <vector>
 
-#include "ngram/neg_log_prob.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/match.h"


### PR DESCRIPTION
The "ngram/neg_log_prob.h" header listed in src/prediction/dictionary_prediction_aggregator.cc does not exist.

## Description
The "ngram/neg_log_prob.h" header listed in src/prediction/dictionary_prediction_aggregator.cc does not exist.

## Issue IDs

## Steps to test new behaviors (if any)
 bazel build --config oss_linux --compilation_mode opt package

## Additional context
