### PR TITLE
fix(about_dialog): Always use black color for window texts

### DIFF
--- a/src/gui/about_dialog/about_dialog.cc
+++ b/src/gui/about_dialog/about_dialog.cc
@@ -92,6 +92,7 @@ AboutDialog::AboutDialog(QWidget *parent)
   setWindowModality(Qt::NonModal);
   QPalette window_palette;
   window_palette.setColor(QPalette::Window, QColor(255, 255, 255));
+  window_palette.setColor(QPalette::WindowText, QColor(0, 0, 0));
   setPalette(window_palette);
   setAutoFillBackground(true);
   std::string version_info = "(" + Version::GetMozcVersion() + ")";


### PR DESCRIPTION
## Description

Updated the QPalette in AboutDialog.app to display texts in black colour even if dark mode is enabled on the environment.

I am really noob of Qt/C++ stack; please let me know if I am missing something to do or doing wrong.

## Issue IDs
Closes #897 

## Steps to test new behaviors (if any)
 - OS: Any environment that dark mode is supported by Qt
 - Steps:
   1. Open the about dialog
   2. Confirm that texts in the window is written in black color

|Before|After|
|---|---|
|<img width="602" alt="image" src="https://github.com/google/mozc/assets/12772118/edc0c7d7-fe9e-4afe-81b6-18a5d768c5cc">|<img width="602" alt="image" src="https://github.com/google/mozc/assets/12772118/c4c93b4c-2725-43f6-9644-ef2268d052b3">|

## Additional context
Tested on macOS 14.4 Sonoma, Arm64, M1 Max, Mac Studio (2022).
