### PR TITLE
refactor(mac): Replace deprecated NS{On,Off}State to NSControlStateValue{On,Off}

### DIFF
--- a/src/mac/ActivatePane/ActivatePane.mm
+++ b/src/mac/ActivatePane/ActivatePane.mm
@@ -293,13 +293,14 @@ static BOOL StoreDefaultConfigWithSendingUsageStats() {
   if (!_alreadyActivated && dir == InstallerDirectionForward) {
     // Make the package visible from i18n system preference
     RegisterGoogleJapaneseInput();
-    if ([_activateCell state] == NSOnState && [_doNotActivateCell state] == NSOffState) {
+    if ([_activateCell state] == NSControlStateValueOn &&
+        [_doNotActivateCell state] == NSControlStateValueOff) {
       // means clicks "next page" when "activate" menu is on
       ActivateGoogleJapaneseInput();
       _alreadyActivated = YES;
     }
 #ifdef GOOGLE_JAPANESE_INPUT_BUILD
-    if (!_hasUsageStatsDB && [_putUsageStatsDB state] == NSOnState) {
+    if (!_hasUsageStatsDB && [_putUsageStatsDB state] == NSControlStateValueOn) {
       StoreDefaultConfigWithSendingUsageStats();
     }
 #endif  // GOOGLE_JAPANESE_INPUT_BUILD

--- a/src/mac/DevConfirmPane/DevConfirmPane.mm
+++ b/src/mac/DevConfirmPane/DevConfirmPane.mm
@@ -47,8 +47,8 @@
 }
 
 - (IBAction)checkBoxClicked:(id)sender {
-  _understandFlag = ([_understandCheckBox state] == NSOnState);
-  _agreeFlag = ([_agreeCheckBox state] == NSOnState);
+  _understandFlag = ([_understandCheckBox state] == NSControlStateValueOn);
+  _agreeFlag = ([_agreeCheckBox state] == NSControlStateValueOn);
   if (_understandFlag && _agreeFlag) {
     [self setNextEnabled:YES];
   } else {
@@ -85,10 +85,10 @@
   }
 
   if (_understandFlag) {
-    [_understandCheckBox setState:NSOnState];
+    [_understandCheckBox setState:NSControlStateValueOn];
   }
   if (_agreeFlag) {
-    [_agreeCheckBox setState:NSOnState];
+    [_agreeCheckBox setState:NSControlStateValueOn];
   }
 
   if (_understandFlag && _agreeFlag) {


### PR DESCRIPTION
## Description

`NSOnState` and `NSOffState` are deprecated since 10.14 and should be replaced by `NSControlStateValueOn` and `NSControlStateValueOff`. It can be migrated safely since Mozc supports macOS 11.0 and later.

## Issue IDs

N/A

## Steps to test new behaviors (if any)

N/A

## Additional context

NSOnState: https://developer.apple.com/documentation/appkit/nsonstate
NSControlStateValueOn: https://developer.apple.com/documentation/appkit/nscontrolstatevalueon
