### PR TITLE
Add build setup in PowerShell

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -27,6 +27,12 @@ out_win\Release\Mozc64.msi
 
 Hint: You can also download `Mozc64.msi` from GitHub Actions. Check [Build with GitHub Actions](#build-with-github-actions) for details.
 
+If you are using PowerShell, please run the following command instead of `vcvarsamd64_x86.bat`.
+
+```pwsh
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1"  -HostArch amd64 -Arch x86 -SkipAutomaticLocation
+```
+
 ## Setup
 
 ### System Requirements
@@ -83,6 +89,12 @@ to execute the setup command like this.
 
 ```
 "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
+```
+
+If you are using PowerShell, the setup command is the following instead (the above command has no effect):
+
+```pwsh
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1"  -HostArch amd64 -Arch x86 -SkipAutomaticLocation
 ```
 
 ### Build Qt


### PR DESCRIPTION
## Description
A clear and concise description of this pull request.

`vcvarsamd64_x86.bat` is only for CMD.
If you are using PowerShell, you should use `Launch-VsDevShell.ps1` instead.
This PR adds how to use `Launch-VsDevShell.ps1` instead of `vcvarsamd64_x86.bat` to `docs\build_mozc_in_windows.md`.

## Issue IDs
Issue and/or discussion IDs related to this pull request.

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows
 - Steps:
   1. See `docs\build_mozc_in_windows.md`
   2. Build (or check VS build environment at least)
     - `(gcm cl).path` (PowerShell) / `where cl` (CMD)

## Additional context
Add any other context about the pull request here.
