### PR TITLE
Ignore Super and other modifier keys except for Alt

### DIFF
--- a/src/unix/ibus/key_event_handler.cc
+++ b/src/unix/ibus/key_event_handler.cc
@@ -62,6 +62,18 @@ bool KeyEventHandler::GetKeyEvent(uint keyval, uint keycode, uint modifiers,
   DCHECK(key);
   key->Clear();
 
+  // Ignore key events with modifiers, except for the below;
+  // - Alt (Mod1) - Mozc uses Alt for shortcuts
+  // - NumLock (Mod2) - NumLock shouldn't impact shortcuts
+  // This is needed for handling shortcuts such as Super (Mod4) + Space,
+  // IBus's default for switching input methods.
+  // https://github.com/google/mozc/issues/853
+  constexpr uint kExtraModMask =
+      IBUS_MOD3_MASK | IBUS_MOD4_MASK | IBUS_MOD5_MASK;
+  if (modifiers & kExtraModMask) {
+    return false;
+  }
+
   if (!key_translator_->Translate(keyval, keycode, modifiers, preedit_method,
                                   layout_is_jp, key)) {
     LOG(ERROR) << "Translate failed";

--- a/src/unix/ibus/key_event_handler_test.cc
+++ b/src/unix/ibus/key_event_handler_test.cc
@@ -180,6 +180,13 @@ TEST_F(KeyEventHandlerTest, GetKeyEvent) {
     EXPECT_NO_MODIFIERS_PRESSED();
   }
 
+  { // Ignore Super (Mod4)
+    key.Clear();
+    EXPECT_FALSE(handler_->GetKeyEvent(IBUS_space, kDummyKeycode,
+                                       IBUS_MOD4_MASK, config::Config::ROMAN,
+                                       true, &key));
+  }
+
   // This test fails in current implementation.
   // TODO(hsumita): Enables it.
   /*


### PR DESCRIPTION
## Description

Mozc doesn't know Super and other extra modifier keys except for Alt. For example, "Super + Space" (IBus' default for switching input methods) is recognized as "Space".
    
This change ignores key events that have these extra modifiers to let others handle the events.

## Issue IDs

#853

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Ubuntu 24.04 + Wayland
 - Steps:
   1. Switch to Japanese (Mozc) by pressing Super-Space
   2. Switch to English by pressing Super-Space again
   3. Confirm the switch (before this PR,  a full-width space was inserted instead)

## Additional context
Add any other context about the pull request here.
