### PR TITLE
Enable switching to DIRECT mode using the mouse.

### DIFF
--- a/src/unix/ibus/property_handler.cc
+++ b/src/unix/ibus/property_handler.cc
@@ -452,7 +452,7 @@ void PropertyHandler::ProcessPropertyActivate(IbusEngineWrapper *engine,
 
       const MozcEngineProperty *entry =
           prop.GetData<MozcEngineProperty>(kMozcEnginePropertyKey);
-      if (!entry || !entry->composition_mode) {
+      if (!entry) {
         continue;
       }
       SetCompositionMode(entry->composition_mode);


### PR DESCRIPTION
## Description
This is about addressing the problem where selecting DIRECT with the mouse to switch input modes doesn't work.
    
 In the PropertyHandler::ProcessPropertyActivate function, the processing for DIRECT mode is being skipped. This is because DIRECT=0 as defined in [src/protocol/commands.proto#L51](https://github.com/google/mozc/blob/master/src/protocol/commands.proto#L51), so !entry->composition_mode is evaluated as true.
As a result, while the DIRECT menu item exists, it is not linked to the actual processing that should be executed for DIRECT.

## Issue IDs

## Steps to test new behaviors (if any)
1. Change the input mode to an option different from DIRECT
2. Switch the input mode to DIRECT mode using the mouse.
With the above steps, the input mode does not switch to DIRECT mode.

## Additional context
There is no problem when switching using keyboard keys such as the full-width/half-width key. This is a problem that occurs when switching by mouse click.