### PR TITLE
To reduce the version differences of modules between WORKSPACE.bazel and MODULE.bazel.

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -172,7 +172,12 @@ cc_library(
 
 bzl_library(
     name = "build_defs_bzl",
-    srcs = ["build_defs.bzl"],
+    srcs = [
+        "build_defs.bzl",
+    ] + select({
+        "//bazel/cc_target_os:oss_macos": [ "macos.bzl", ],
+        "//bazel/cc_target_os:oss_android": [ "android.bzl", ],
+    }),
     test_size = "small",
     visibility = ["//:__subpackages__"],
     deps = [
@@ -180,8 +185,10 @@ bzl_library(
         "//bazel:run_build_tool_bzl",
         "//bazel:stubs.bzl",
         "//devtools/build_cleaner/skylark:build_defs_lib",
-        "@build_bazel_rules_apple//apple:macos",
-    ],
+    ] + select({
+        "//bazel/cc_target_os:oss_macos": [ "@build_bazel_rules_apple//apple:macos", ],
+        "//conditions:default": [],
+    }),
 )
 
 bzl_library(

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -31,7 +31,6 @@ local_path_override(
     path = "third_party/gtest",
 )
 
-
 # platforms: 0.0.10 2024-04-26
 # https://github.com/bazelbuild/platforms/
 bazel_dep(
@@ -53,6 +52,15 @@ bazel_dep(
     version = "0.34.0",
 )
 
+
+# proto rules
+# https://github.com/bazelbuild/rules_proto
+bazel_dep(
+    name = "rules_proto",
+    version = "6.0.0",
+)
+
+
 # Bazel macOS build (3.5.1 2024-04-09)
 # Note, versions after 3.5.1 result a build failure of universal binary.
 # https://github.com/bazelbuild/rules_apple
@@ -67,6 +75,19 @@ bazel_dep(
     name = "apple_support",
     version = "1.16.0",
     repo_name = "build_bazel_apple_support",
+)
+
+# Swift rules
+# https://github.com/bazelbuild/rules_swift
+bazel_dep(
+    name = "rules_swift",
+    version = "1.18.0",
+    repo_name = "build_bazel_rules_swift",
+)
+single_version_override(
+    module_name = "rules_swift",
+    version = "1.18.0",
+    patches = ["@//bazel:swift_extras.patch"],
 )
 
 # Java rules (7.9.0 2024-08-13)

--- a/src/WORKSPACE.bazel
+++ b/src/WORKSPACE.bazel
@@ -38,7 +38,7 @@ load(
     "http_archive",
     "http_file",
 )
-load("@//:config.bzl", "MACOS_QT_PATH", "SHA256_ZIP_CODE_KEN_ALL", "SHA256_ZIP_CODE_JIGYOSYO")
+load("@//:config.bzl", "SHA256_ZIP_CODE_KEN_ALL", "SHA256_ZIP_CODE_JIGYOSYO")
 load("@//bazel:pkg_config_repository.bzl", "pkg_config_repository")
 
 
@@ -55,7 +55,6 @@ http_archive(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-
 # Bazel Python rules (0.34.0 2024-07-04)
 http_archive(
     name = "rules_python",
@@ -67,13 +66,20 @@ load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
 
 
-# Java rules (7.9.0 2024-08-13)
-# https://github.com/bazelbuild/rules_java
-http_archive(
-    name = "rules_java",
-    sha256 = "41131de4417de70b9597e6ebd515168ed0ba843a325dc54a81b92d7af9a7b3ea",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.9.0/rules_java-7.9.0.tar.gz"],
-)
+# oss_macos or oss_android
+load("//:build_defs.bzl", "macos_deps", "android_deps")
+_impl = select({
+    "//bazel/cc_target_os:oss_macos": [ macos_deps(), ],
+    "//bazel/cc_target_os:oss_android": [ android_deps(), ],
+    "//conditions:default": [],
+})
+
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+select({
+    "//bazel/cc_target_os:oss_macos": [ bazel_features_deps() ],
+    "//conditions:default": [],
+})
 
 
 # Abseil
@@ -98,78 +104,6 @@ protobuf_deps()
 local_repository(
     name = "com_google_googletest",
     path = "third_party/gtest",
-)
-
-
-# Bazel macOS build (3.5.1 2024-04-09)
-# Note, versions after 3.5.1 result a build failure of universal binary.
-# https://github.com/bazelbuild/rules_apple
-http_archive(
-    name = "build_bazel_rules_apple",
-    sha256 = "b4df908ec14868369021182ab191dbd1f40830c9b300650d5dc389e0b9266c8d",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz",
-)
-load(
-    "@build_bazel_rules_apple//apple:repositories.bzl",
-    "apple_rules_dependencies",
-)
-apple_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:repositories.bzl",
-    "swift_rules_dependencies",
-)
-swift_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:extras.bzl",
-    "swift_rules_extra_dependencies",
-)
-swift_rules_extra_dependencies()
-
-load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
-)
-apple_support_dependencies()
-
-
-# Android NDK setup (0.1.2 2024-07-23)
-http_archive(
-    name = "rules_android_ndk",
-    sha256 = "65aedff0cd728bee394f6fb8e65ba39c4c5efb11b29b766356922d4a74c623f5",
-    strip_prefix = "rules_android_ndk-0.1.2",
-    url = "https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.2/rules_android_ndk-v0.1.2.tar.gz",
-)
-# Check the ANDROID_NDK_HOME envvar, if it is specified set up NDK as follows
-#   load("@rules_android_ndk//:rules.bzl", "android_ndk_repository")
-#   android_ndk_repository(name="androidndk")
-# If it is empty, do nothing.
-load("@//bazel:android_repository.bzl", "android_repository")
-android_repository(name = "android_repository")
-load("@android_repository//:setup.bzl", "android_ndk_setup")
-android_ndk_setup()
-
-
-# Android SDK rules (0.5.1 2024-08-06)
-# https://github.com/bazelbuild/rules_android
-http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "b1599e4604c1594a1b0754184c5e50f895a68f444d1a5a82b688b2370d990ba0",
-    strip_prefix = "rules_android-0.5.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.5.1.tar.gz"],
-)
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
-android_sdk_repository(
-    name = "androidsdk",
-)
-
-
-# Placeholder of rules_android for the compatibility with Bzlmod.
-new_local_repository(
-    name = "rules_android",
-    path = "bazel",
-    build_file_content = "",
 )
 
 
@@ -213,33 +147,11 @@ pkg_config_repository(
   packages = ["Qt6Core", "Qt6Gui", "Qt6Widgets"],
 )
 
-# Qt for macOS
-load("@//bazel:qt_mac_repository.bzl", "qt_mac_repository")
-qt_mac_repository(
-  name = "qt_mac",
-  default_path = MACOS_QT_PATH,  # can be replaced with MOZC_QT_PATH envvar.
-)
-
 # Qt for Windows
 new_local_repository(
     name = "qt_win",
     build_file = "@//bazel:BUILD.qt_win.bazel",
     path = "third_party/qt",
-)
-
-# Google Toolbox for Mac
-# https://github.com/google/google-toolbox-for-mac
-# We just need UnitTesting, so strip to the directory and skip dependencies.
-GTM_GIT_SHA="8fbaae947b87c1e66c0934493168fc6d583ed889"
-http_archive(
-    name = "google_toolbox_for_mac",
-    urls = [
-        "https://github.com/google/google-toolbox-for-mac/archive/%s.zip" % GTM_GIT_SHA
-    ],
-    strip_prefix = "google-toolbox-for-mac-%s/UnitTesting" % GTM_GIT_SHA,
-    build_file = "@//bazel:BUILD.google_toolbox_for_mac.bazel",
-    patches = ["@//:google_toolbox_for_mac.patch"],
-    patch_args = ["-p2"],
 )
 
 # Material icons
@@ -311,3 +223,10 @@ http_archive(
     sha256 = SHA256_ZIP_CODE_JIGYOSYO,
     url = "https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip",
 )
+
+
+load("//:macos.bzl", "apple_dependencies")
+select({
+    "//bazel/cc_target_os:oss_macos": [apple_dependencies()],
+    "//conditions:default": [],
+})

--- a/src/WORKSPACE.bazel
+++ b/src/WORKSPACE.bazel
@@ -67,6 +67,15 @@ load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()
 
 
+# Java rules (7.9.0 2024-08-13)
+# https://github.com/bazelbuild/rules_java
+http_archive(
+    name = "rules_java",
+    sha256 = "41131de4417de70b9597e6ebd515168ed0ba843a325dc54a81b92d7af9a7b3ea",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.9.0/rules_java-7.9.0.tar.gz"],
+)
+
+
 # Abseil
 # https://abseil.io/docs/cpp/quickstart#set-up-a-bazel-workspace-to-work-with-abseil
 local_repository(
@@ -92,12 +101,13 @@ local_repository(
 )
 
 
-# Bazel macOS build (3.8.0 2024-08-10)
-# https://github.com/bazelbuild/rules_apple/
+# Bazel macOS build (3.5.1 2024-04-09)
+# Note, versions after 3.5.1 result a build failure of universal binary.
+# https://github.com/bazelbuild/rules_apple
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "62847b3f444ce514ae386704a119ad7b29fa6dfb65a38bff4ae239f2389a0429",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/3.8.0/rules_apple.3.8.0.tar.gz",
+    sha256 = "b4df908ec14868369021182ab191dbd1f40830c9b300650d5dc389e0b9266c8d",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz",
 )
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
@@ -141,24 +151,25 @@ load("@android_repository//:setup.bzl", "android_ndk_setup")
 android_ndk_setup()
 
 
+# Android SDK rules (0.5.1 2024-08-06)
+# https://github.com/bazelbuild/rules_android
+http_archive(
+    name = "build_bazel_rules_android",
+    sha256 = "b1599e4604c1594a1b0754184c5e50f895a68f444d1a5a82b688b2370d990ba0",
+    strip_prefix = "rules_android-0.5.1",
+    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.5.1.tar.gz"],
+)
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+android_sdk_repository(
+    name = "androidsdk",
+)
+
+
 # Placeholder of rules_android for the compatibility with Bzlmod.
 new_local_repository(
     name = "rules_android",
     path = "bazel",
     build_file_content = "",
-)
-
-
-# Android SDK rules (0.1.1 2018-06-15)
-http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-)
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
-android_sdk_repository(
-    name = "androidsdk",
 )
 
 

--- a/src/android.bzl
+++ b/src/android.bzl
@@ -1,0 +1,46 @@
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+android_sdk_repository(
+    name = "androidsdk",
+)
+android_ndk_repository_extension = use_extension(
+    "@rules_android_ndk//:extension.bzl",
+    "android_ndk_repository_extension",
+)
+use_repo(android_ndk_repository_extension, "androidndk")
+register_toolchains("@androidndk//:all")
+
+
+load("@//bazel:android_repository.bzl", "android_repository")
+android_repository(name = "android_repository")
+load("@android_repository//:setup.bzl", "android_ndk_setup")
+android_ndk_setup()
+
+
+# Placeholder of rules_android for the compatibility with Bzlmod.
+new_local_repository(
+    name = "rules_android",
+    path = "bazel",
+    build_file_content = "",
+)
+
+remote_android_extensions = use_extension(
+    "@rules_android//bzlmod_extensions:android_extensions.bzl",
+    "remote_android_tools_extensions",
+)
+use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+register_toolchains(
+"@rules_android//toolchains/android:android_default_toolchain",
+"@rules_android//toolchains/android_sdk:android_sdk_tools",
+)
+android_sdk_repository_extension = use_extension(
+    "@rules_android//rules/android_sdk_repository:rule.bzl",
+    "android_sdk_repository_extension",
+)
+use_repo(android_sdk_repository_extension, "androidsdk")
+register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")
+
+new_local_repository = use_repo_rule(
+    "@bazel_tools//tools/build_defs/repo:local.bzl",
+    "new_local_repository",
+)
+

--- a/src/bazel/qt.bzl
+++ b/src/bazel/qt.bzl
@@ -29,19 +29,17 @@
 
 """Qt build rules."""
 
-load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application")
 load(
     "//:build_defs.bzl",
     "mozc_cc_binary",
     "mozc_cc_library",
     "mozc_select",
 )
-load(
-    "//:config.bzl",
-    "MACOS_BUNDLE_ID_PREFIX",
-    "MACOS_MIN_OS_VER",
-)
+
 load("//bazel:stubs.bzl", "register_extension_info")
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 def mozc_cc_qt_library(name, deps = [], **kwargs):
     mozc_cc_library(
@@ -133,40 +131,3 @@ def mozc_qt_rcc(name, qrc_name, qrc_file, srcs, outs):
             oss_windows = ["@qt_win//:bin/rcc.exe"],
         ),
     )
-
-def mozc_macos_qt_application(name, bundle_name, deps):
-    macos_application(
-        name = name,
-        tags = ["manual", "notap"],
-        additional_contents = mozc_select(
-            default = {},
-            oss = {"@qt_mac//:libqcocoa": "Resources"},
-        ),
-        app_icons = ["//data/images/mac:product_icon.icns"],
-        bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Tool." + bundle_name,
-        bundle_name = bundle_name,
-        infoplists = ["//gui:mozc_tool_info_plist"],
-        minimum_os_version = MACOS_MIN_OS_VER,
-        resources = [
-            "//data/images/mac:candidate_window_logo.tiff",
-            "//gui:qt_conf",
-        ],
-        visibility = [
-            "//:__subpackages__",
-            "//:__subpackages__",
-        ],
-        deps = deps + mozc_select(
-            default = [],
-            oss = [
-                "@qt_mac//:QtCore_mac",
-                "@qt_mac//:QtGui_mac",
-                "@qt_mac//:QtPrintSupport_mac",
-                "@qt_mac//:QtWidgets_mac",
-            ],
-        ),
-    )
-
-register_extension_info(
-    extension = mozc_macos_qt_application,
-    label_regex_for_dep = "{extension_name}",
-)

--- a/src/bazel/qt_mac.bzl
+++ b/src/bazel/qt_mac.bzl
@@ -1,0 +1,44 @@
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application")
+load(
+    "//:config.bzl",
+    "MACOS_BUNDLE_ID_PREFIX",
+    "MACOS_MIN_OS_VER",
+)
+
+def mozc_macos_qt_application(name, bundle_name, deps):
+    macos_application(
+        name = name,
+        tags = ["manual", "notap"],
+        additional_contents = mozc_select(
+            default = {},
+            oss = {"@qt_mac//:libqcocoa": "Resources"},
+        ),
+        app_icons = ["//data/images/mac:product_icon.icns"],
+        bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Tool." + bundle_name,
+        bundle_name = bundle_name,
+        infoplists = ["//gui:mozc_tool_info_plist"],
+        minimum_os_version = MACOS_MIN_OS_VER,
+        resources = [
+            "//data/images/mac:candidate_window_logo.tiff",
+            "//gui:qt_conf",
+        ],
+        visibility = [
+            "//:__subpackages__",
+            "//:__subpackages__",
+        ],
+        deps = deps + mozc_select(
+            default = [],
+            oss = [
+                "@qt_mac//:QtCore_mac",
+                "@qt_mac//:QtGui_mac",
+                "@qt_mac//:QtPrintSupport_mac",
+                "@qt_mac//:QtWidgets_mac",
+            ],
+        ),
+    )
+
+register_extension_info(
+    extension = mozc_macos_qt_application,
+    label_regex_for_dep = "{extension_name}",
+)
+

--- a/src/bazel/swift_extras.patch
+++ b/src/bazel/swift_extras.patch
@@ -1,0 +1,18 @@
+diff --git swift/extras.bzl swift/extras.bzl
+index f163680..ab82f33 100644
+--- swift/extras.bzl
++++ swift/extras.bzl
+@@ -18,11 +18,8 @@ dependencies of the Swift rules.
+ 
+ load("@bazel_features//:deps.bzl", "bazel_features_deps")
+ load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+-load(
+-    "@rules_proto//proto:repositories.bzl",
+-    "rules_proto_dependencies",
+-    "rules_proto_toolchains",
+-)
++load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
++load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+ 
+ def swift_rules_extra_dependencies():
+     """Fetches transitive repositories of the dependencies of `rules_swift`.

--- a/src/gui/about_dialog/BUILD.bazel
+++ b/src/gui/about_dialog/BUILD.bazel
@@ -31,11 +31,13 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
     "mozc_qt_uic",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -103,11 +105,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "about_dialog_main",
-    deps = [":about_dialog_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "about_dialog_macos",
-    bundle_name = "AboutDialog",
     deps = [":about_dialog_main_lib"],
 )

--- a/src/gui/about_dialog/qt_macos.bzl
+++ b/src/gui/about_dialog/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+	"mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "about_dialog_macos",
+    bundle_name = "AboutDialog",
+    deps = [":about_dialog_main_lib"],
+)

--- a/src/gui/config_dialog/BUILD.bazel
+++ b/src/gui/config_dialog/BUILD.bazel
@@ -32,11 +32,13 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
     "mozc_qt_uic",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -241,11 +243,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "config_dialog_main",
-    deps = [":config_dialog_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "config_dialog_macos",
-    bundle_name = "ConfigDialog",
     deps = [":config_dialog_main_lib"],
 )

--- a/src/gui/config_dialog/qt_macos.bzl
+++ b/src/gui/config_dialog/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+    "mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "config_dialog_macos",
+    bundle_name = "ConfigDialog",
+    deps = [":config_dialog_main_lib"],
+)

--- a/src/gui/dictionary_tool/BUILD.bazel
+++ b/src/gui/dictionary_tool/BUILD.bazel
@@ -32,11 +32,13 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
     "mozc_qt_uic",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -198,11 +200,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "dictionary_tool_main",
-    deps = [":dictionary_tool_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "dictionary_tool_macos",
-    bundle_name = "DictionaryTool",
     deps = [":dictionary_tool_main_lib"],
 )

--- a/src/gui/dictionary_tool/qt_macos.bzl
+++ b/src/gui/dictionary_tool/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+	"mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "dictionary_tool_macos",
+    bundle_name = "DictionaryTool",
+    deps = [":dictionary_tool_main_lib"],
+)

--- a/src/gui/error_message_dialog/BUILD.bazel
+++ b/src/gui/error_message_dialog/BUILD.bazel
@@ -31,10 +31,12 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -97,11 +99,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "error_message_dialog_main",
-    deps = [":error_message_dialog_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "error_message_dialog_macos",
-    bundle_name = "ErrorMessageDialog",
     deps = [":error_message_dialog_main_lib"],
 )

--- a/src/gui/error_message_dialog/qt_macos.bzl
+++ b/src/gui/error_message_dialog/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+	"mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "error_message_dialog_macos",
+    bundle_name = "ErrorMessageDialog",
+    deps = [":error_message_dialog_main_lib"],
+)

--- a/src/gui/post_install_dialog/BUILD.bazel
+++ b/src/gui/post_install_dialog/BUILD.bazel
@@ -32,11 +32,13 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
     "mozc_qt_uic",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -113,11 +115,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "post_install_dialog_main",
-    deps = [":post_install_dialog_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "post_install_dialog_macos",
-    bundle_name = "PostInstallDialog",
     deps = [":post_install_dialog_main_lib"],
 )

--- a/src/gui/post_install_dialog/qt_macos.bzl
+++ b/src/gui/post_install_dialog/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+    "mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "post_install_dialog_macos",
+    bundle_name = "PostInstallDialog",
+    deps = [":post_install_dialog_main_lib"],
+)

--- a/src/gui/tool/BUILD.bazel
+++ b/src/gui/tool/BUILD.bazel
@@ -33,8 +33,11 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
 )
+
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 mozc_cc_library(
     name = "prelauncher_lib",
@@ -110,14 +113,3 @@ mozc_cc_qt_binary(
     deps = [":mozc_tool_main_lib"],
 )
 
-mozc_macos_qt_application(
-    name = "mozc_tool_macos",
-    bundle_name = "MozcTool",
-    deps = [":mozc_tool_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "mozc_prelauncher_macos",
-    bundle_name = BRANDING + "Prelauncher",
-    deps = [":mozc_tool_main_lib"],
-)

--- a/src/gui/tool/qt_macos.bzl
+++ b/src/gui/tool/qt_macos.bzl
@@ -1,0 +1,14 @@
+load(
+    "mozc_macos_qt_application",
+)
+mozc_macos_qt_application(
+    name = "mozc_tool_macos",
+    bundle_name = "MozcTool",
+    deps = [":mozc_tool_main_lib"],
+)
+
+mozc_macos_qt_application(
+    name = "mozc_prelauncher_macos",
+    bundle_name = BRANDING + "Prelauncher",
+    deps = [":mozc_tool_main_lib"],
+)

--- a/src/gui/word_register_dialog/BUILD.bazel
+++ b/src/gui/word_register_dialog/BUILD.bazel
@@ -32,11 +32,13 @@ load(
     "//bazel:qt.bzl",
     "mozc_cc_qt_binary",
     "mozc_cc_qt_library",
-    "mozc_macos_qt_application",
     "mozc_qt_moc",
     "mozc_qt_rcc",
     "mozc_qt_uic",
 )
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})
 
 package(
     default_visibility = ["//gui:__subpackages__"],
@@ -117,11 +119,5 @@ mozc_cc_qt_library(
 
 mozc_cc_qt_binary(
     name = "word_register_dialog_main",
-    deps = [":word_register_dialog_main_lib"],
-)
-
-mozc_macos_qt_application(
-    name = "word_register_dialog_macos",
-    bundle_name = "WordRegisterDialog",
     deps = [":word_register_dialog_main_lib"],
 )

--- a/src/gui/word_register_dialog/qt_macos.bzl
+++ b/src/gui/word_register_dialog/qt_macos.bzl
@@ -1,0 +1,9 @@
+load(
+	"mozc_macos_qt_application",
+)
+
+mozc_macos_qt_application(
+    name = "word_register_dialog_macos",
+    bundle_name = "WordRegisterDialog",
+    deps = [":word_register_dialog_main_lib"],
+)

--- a/src/mac/BUILD.bazel
+++ b/src/mac/BUILD.bazel
@@ -29,8 +29,6 @@
 
 load(
     "//:build_defs.bzl",
-    "mozc_macos_application",
-    "mozc_macos_bundle",
     "mozc_objc_library",
     "mozc_objc_test",
     "mozc_py_binary",
@@ -42,7 +40,11 @@ load(
     "MACOS_BUNDLE_ID_PREFIX",
     "MACOS_CODESIGN_IDENTITY",
 )
-
+load(
+    "//:macos.bzl",
+    "mozc_macos_application",
+    "mozc_macos_bundle",
+)
 package(default_visibility = ["//:__subpackages__"])
 
 # BUILD_TYPE_SELECT is treated as a function, but not a string. This cannot be a value of join().

--- a/src/macos.bzl
+++ b/src/macos.bzl
@@ -1,0 +1,157 @@
+load(
+    "//:config.bzl",
+    "BAZEL_TOOLS_PREFIX",
+    "BRANDING",
+    "MACOS_BUNDLE_ID_PREFIX",
+    "MACOS_MIN_OS_VER",
+)
+load(
+    "//:build_defs.bzl",
+    "MOZC_TAGS",
+    "mozc_select",
+    "mozc_infoplist",
+    "mozc_infoplist_strings",
+)
+load("//bazel:run_build_tool.bzl", "mozc_run_build_tool")
+load("//bazel:stubs.bzl", "pytype_strict_binary", "pytype_strict_library", "register_extension_info")
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application", "macos_bundle")
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+def apple_dependencies():
+    apple_rules_dependencies()
+    swift_rules_dependencies()
+    swift_rules_extra_dependencies()
+    apple_support_dependencies()
+
+def mozc_macos_qt_application(name, bundle_name, deps):
+    macos_application(
+        name = name,
+        tags = ["manual", "notap"],
+        additional_contents = mozc_select(
+            default = {},
+            oss = {"@qt_mac//:libqcocoa": "Resources"},
+        ),
+        app_icons = ["//data/images/mac:product_icon.icns"],
+        bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Tool." + bundle_name,
+        bundle_name = bundle_name,
+        infoplists = ["//gui:mozc_tool_info_plist"],
+        minimum_os_version = MACOS_MIN_OS_VER,
+        resources = [
+            "//data/images/mac:candidate_window_logo.tiff",
+            "//gui:qt_conf",
+        ],
+        visibility = [
+            "//:__subpackages__",
+            "//:__subpackages__",
+        ],
+        deps = deps + mozc_select(
+            default = [],
+            oss = [
+                "@qt_mac//:QtCore_mac",
+                "@qt_mac//:QtGui_mac",
+                "@qt_mac//:QtPrintSupport_mac",
+                "@qt_mac//:QtWidgets_mac",
+            ],
+        ),
+    )
+
+register_extension_info(
+    extension = mozc_macos_qt_application,
+    label_regex_for_dep = "{extension_name}",
+)
+
+def _tweak_infoplists(name, infoplists):
+    tweaked_infoplists = []
+    for i, plist in enumerate(infoplists):
+        plist_name = "%s_plist%d" % (name, i)
+        mozc_infoplist(
+            name = plist_name,
+            srcs = [plist],
+            outs = [plist.replace(".plist", "_tweaked.plist")],
+        )
+        tweaked_infoplists.append(plist_name)
+    return tweaked_infoplists
+
+def _tweak_strings(name, strings):
+    tweaked_strings = []
+    for i, string in enumerate(strings):
+        string_name = "%s_string%d" % (name, i)
+        mozc_infoplist_strings(
+            name = string_name,
+            srcs = [string],
+            outs = ["tweaked/" + string],
+        )
+        tweaked_strings.append(string_name)
+    return tweaked_strings
+
+def mozc_macos_application(name, bundle_name, infoplists, strings = [], bundle_id = None, tags = [], **kwargs):
+    """Rule to create .app for macOS.
+
+    Args:
+      name: name for macos_application.
+      bundle_name: bundle_name for macos_application.
+      infoplists: infoplists are tweaked and applied to macos_application.
+      strings: strings are tweaked and applied to macos_application.
+      bundle_id: bundle_id for macos_application.
+      tags: tags for macos_application.
+      **kwargs: other arguments for macos_application.
+    """
+    macos_application(
+        name = name,
+        bundle_id = bundle_id or (MACOS_BUNDLE_ID_PREFIX + "." + bundle_name),
+        bundle_name = bundle_name,
+        infoplists = _tweak_infoplists(name, infoplists),
+        strings = _tweak_strings(name, strings),
+        minimum_os_version = MACOS_MIN_OS_VER,
+        version = "//data/version:version_macos",
+        target_compatible_with = ["@platforms//os:macos"],
+        tags = tags + MOZC_TAGS.MAC_ONLY,
+        **kwargs
+    )
+
+def mozc_macos_bundle(name, bundle_name, infoplists, strings = [], bundle_id = None, tags = [], **kwargs):
+    """Rule to create .bundle for macOS.
+
+    Args:
+      name: name for macos_bundle.
+      bundle_name: bundle_name for macos_bundle.
+      infoplists: infoplists are tweaked and applied to macos_bundle.
+      strings: strings are tweaked and applied to macos_bundle.
+      bundle_id: bundle_id for macos_bundle.
+      tags: tags for macos_bundle.
+      **kwargs: other arguments for macos_bundle.
+    """
+    macos_bundle(
+        name = name,
+        bundle_id = bundle_id or (MACOS_BUNDLE_ID_PREFIX + "." + bundle_name),
+        bundle_name = bundle_name,
+        infoplists = _tweak_infoplists(name, infoplists),
+        strings = _tweak_strings(name, strings),
+        minimum_os_version = MACOS_MIN_OS_VER,
+        version = "//data/version:version_macos",
+        target_compatible_with = ["@platforms//os:macos"],
+        tags = tags + MOZC_TAGS.MAC_ONLY,
+        **kwargs
+    )

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -31,14 +31,12 @@ load(
     "//:build_defs.bzl",
     "mozc_cc_library",
     "mozc_cc_test",
-    "mozc_macos_application",
     "mozc_objc_library",
     "mozc_select",
 )
 load(
     "//:config.bzl",
     "BRANDING",
-    "MACOS_BUNDLE_ID_PREFIX",
 )
 load("//bazel/win32:build_defs.bzl", "features_gdi")
 
@@ -239,81 +237,6 @@ mozc_cc_test(
     ],
 )
 
-# macOS
-mozc_macos_application(
-    name = "mozc_renderer_macos",
-    app_icons = ["//data/images/mac:product_icon.icns"],
-    bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Renderer",
-    bundle_name = BRANDING + "Renderer",
-    infoplists = ["mac/Info.plist"],
-    resources = ["//data/images/mac:candidate_window_logo.tiff"],
-    deps = [":mozc_renderer_main_macos"],
-    # When we support Breakpad, uncomment the following block.
-    # additional_contents = {
-    #     "[Breakpad]" : "Frameworks",
-    # },
-)
-
-mozc_cc_library(
-    name = "mozc_renderer_main_macos",
-    srcs = mozc_select(macos = ["mac/mac_renderer_main.cc"]),
-    deps = [
-        "//renderer:init_mozc_renderer",
-    ] + mozc_select(
-        macos = [":mozc_renderer_lib_macos"],
-    ),
-)
-
-mozc_objc_library(
-    name = "mozc_renderer_lib_macos",
-    srcs = [
-        "mac/CandidateController.mm",
-        "mac/CandidateView.mm",
-        "mac/CandidateWindow.mm",
-        "mac/InfolistView.mm",
-        "mac/InfolistWindow.mm",
-        "mac/RendererBaseWindow.mm",
-        "mac/mac_server.mm",
-        "mac/mac_server_send_command.mm",
-        "mac/mac_view_util.mm",
-    ],
-    hdrs = [
-        "mac/CandidateController.h",
-        "mac/CandidateView.h",
-        "mac/CandidateWindow.h",
-        "mac/InfolistView.h",
-        "mac/InfolistWindow.h",
-        "mac/RendererBaseWindow.h",
-        "mac/mac_server.h",
-        "mac/mac_server_send_command.h",
-        "mac/mac_view_util.h",
-    ],
-    sdk_frameworks = [
-        "Carbon",
-        "Cocoa",
-    ],
-    deps = [
-        ":renderer_interface",
-        ":renderer_server",
-        ":renderer_style_handler",
-        ":table_layout",
-        ":window_util",
-        "//base:const",
-        "//base:coordinates",
-        "//base:util",
-        "//base/mac:mac_util",
-        "//client:client_interface",
-        "//mac:common",
-        "//protocol:candidates_cc_proto",
-        "//protocol:commands_cc_proto",
-        "//protocol:renderer_cc_proto",
-        "@com_google_absl//absl/base",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/synchronization",
-    ],
-)
-
 mozc_cc_library(
     name = "init_mozc_renderer",
     srcs = ["init_mozc_renderer.cc"],
@@ -328,3 +251,7 @@ mozc_cc_library(
         "@com_google_absl//absl/flags:flag",
     ],
 )
+
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})

--- a/src/renderer/qt_macos.bzl
+++ b/src/renderer/qt_macos.bzl
@@ -1,0 +1,82 @@
+load(
+    "mozc_macos_application",
+)
+load(
+    "MACOS_BUNDLE_ID_PREFIX",
+)
+
+# macOS
+mozc_macos_application(
+    name = "mozc_renderer_macos",
+    app_icons = ["//data/images/mac:product_icon.icns"],
+    bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Renderer",
+    bundle_name = BRANDING + "Renderer",
+    infoplists = ["mac/Info.plist"],
+    resources = ["//data/images/mac:candidate_window_logo.tiff"],
+    deps = mozc_select(macos = [":mozc_renderer_main_macos"]),
+    # When we support Breakpad, uncomment the following block.
+    # additional_contents = {
+    #     "[Breakpad]" : "Frameworks",
+    # },
+)
+
+mozc_cc_library(
+    name = "mozc_renderer_main_macos",
+    srcs = mozc_select(macos = ["mac/mac_renderer_main.cc"]),
+    deps = [
+        "//renderer:init_mozc_renderer",
+    ] + mozc_select(
+        macos = [":mozc_renderer_lib_macos"],
+    ),
+)
+
+mozc_objc_library(
+    name = "mozc_renderer_lib_macos",
+    srcs = [
+        "mac/CandidateController.mm",
+        "mac/CandidateView.mm",
+        "mac/CandidateWindow.mm",
+        "mac/InfolistView.mm",
+        "mac/InfolistWindow.mm",
+        "mac/RendererBaseWindow.mm",
+        "mac/mac_server.mm",
+        "mac/mac_server_send_command.mm",
+        "mac/mac_view_util.mm",
+    ],
+    hdrs = [
+        "mac/CandidateController.h",
+        "mac/CandidateView.h",
+        "mac/CandidateWindow.h",
+        "mac/InfolistView.h",
+        "mac/InfolistWindow.h",
+        "mac/RendererBaseWindow.h",
+        "mac/mac_server.h",
+        "mac/mac_server_send_command.h",
+        "mac/mac_view_util.h",
+    ],
+    sdk_frameworks = [
+        "Carbon",
+        "Cocoa",
+    ],
+    deps = [
+        ":renderer_interface",
+        ":renderer_server",
+        ":renderer_style_handler",
+        ":table_layout",
+        ":window_util",
+        "//base:const",
+        "//base:coordinates",
+        "//base:util",
+        "//base/mac:mac_util",
+        "//client:client_interface",
+        "//mac:common",
+        "//protocol:candidates_cc_proto",
+        "//protocol:commands_cc_proto",
+        "//protocol:renderer_cc_proto",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -34,13 +34,11 @@ load(
     "//:build_defs.bzl",
     "mozc_cc_binary",
     "mozc_cc_library",
-    "mozc_macos_application",
     "mozc_select",
 )
 load(
     "//:config.bzl",
     "BRANDING",
-    "MACOS_BUNDLE_ID_PREFIX",
 )
 load("//bazel:stubs.bzl", "windows")
 
@@ -113,15 +111,6 @@ mozc_cc_binary(
     ],
 )
 
-mozc_macos_application(
-    name = "mozc_server_macos",
-    app_icons = ["//data/images/mac:product_icon.icns"],
-    bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Converter",
-    bundle_name = BRANDING + "Converter",
-    infoplists = ["Info.plist"],
-    deps = [":mozc_server_lib"],
-    # When we support Breakpad, uncomment the following block.
-    # additional_contents = {
-    #     "[Breakpad]" : "Frameworks",
-    # },
-)
+_qt_impl = select({
+    "@platforms//os:macos": "qt_macos.bzl",
+})

--- a/src/server/macos.bzl
+++ b/src/server/macos.bzl
@@ -1,0 +1,19 @@
+load(
+	"macos_application",
+)
+load(
+    "MACOS_BUNDLE_ID_PREFIX",
+)
+
+mozc_macos_application(
+    name = "mozc_server_macos",
+    app_icons = ["//data/images/mac:product_icon.icns"],
+    bundle_id = MACOS_BUNDLE_ID_PREFIX + ".Converter",
+    bundle_name = BRANDING + "Converter",
+    infoplists = ["Info.plist"],
+    deps = [":mozc_server_lib"],
+    # When we support Breakpad, uncomment the following block.
+    # additional_contents = {
+    #     "[Breakpad]" : "Frameworks",
+    # },
+)


### PR DESCRIPTION
## Description
There were version differences in external dependency modules when building with the options --noenable_bzlmod (--config workspace) and enable_bzlmod, so we reduced these differences.
Additionally, by separating the Bazel files for qt_macos, we encouraged a decrease in analysis time　during builds on Linux and other platforms.

## Issue IDs

## Steps to test new behaviors (if any)

## Additional context
When specifying --noenable_bzlmod, the build completes even without network access. However, the versions of the required modules are slightly different.

I encountered an issue where I couldn't build without network access due to differences in Bazel versions and switching between enabling and disabling bzlmod. So, I made some adjustments.

When bzlmod is enabled, it seems that remote patches and some modules need to be downloaded. Since bzlmod is enabled by default, network access is essentially required.

```
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> protobuf@_ -> rules_pkg@0.7.0: Error accessing registry https://bcr.bazel.build/: Unknown host: bcr.bazel.build
```

While I believe building would be possible if the repository_cache is sent as is, it seems difficult with the distdir option.
If bzlmod is disabled, it was possible to build more easily without network access by specifying the archive files of necessary modules with the distdir option.

Because the module versions differ between bzlmod and workspace (--noenable_bzlmod), this commit is an attempt to adjust them to be as similar as possible.

However, modifying files in this part might not have been accepted due to policy. If that's the case, please feel free to close it.