### PR TITLE
Simplify the Python script by adjusting the Bazel configuration file.

### DIFF
--- a/src/dictionary/BUILD.bazel
+++ b/src/dictionary/BUILD.bazel
@@ -729,6 +729,7 @@ mozc_py_binary(
         "gen_zip_code_seed.py",
         "zip_code_util.py",
     ],
+    imports = ["."],
     visibility = ["//train/zip_code:__subpackages__"],
 )
 

--- a/src/dictionary/gen_zip_code_seed.py
+++ b/src/dictionary/gen_zip_code_seed.py
@@ -35,7 +35,6 @@ r"""Zip code dictionary generator.
  Output lines will be printed as utf-8.
 
  usage:
-   PYTHONPATH="${PYTHONPATH}:<Mozc's src root dir>"  \
      python ./gen_zip_code_seed.py  \
      --zip_code=zip_code.csv --jigyosyo=jigyosyo.csv  \
      > zip_code_seed.tsv
@@ -57,7 +56,7 @@ import re
 import sys
 import unicodedata
 
-from dictionary import zip_code_util
+import zip_code_util
 
 
 ZIP_CODE_LABEL = 'ZIP_CODE'


### PR DESCRIPTION
## Description
The purpose of using 'from dictionary import zip_code_util' is to make it easier to find the location of zip_code_util when called from within the Bazel sandbox, right?

By instructing imports in mozc_py_binary, I think it will be able to find items in the same folder.
And I think when calling the gen_zip_code_seed.py script from the shell, it can be executed without adding the path of Mozc's source root directory(mozc/src/ or $PWD) to PYTHONPATH. 

The zip_code.tsv file is created without any issues using the bazel build command.
```sh
bazel build --config oss_linux --config release_build dictionary:zip_code_data --verbose_failures --sandbox_debug
```
There is no need to specify PYTHONPATH when using it in the shell.
```sh
python ../dictionary/gen_zip_code_seed.py  --zip_code=KEN_ALL.CSV --jigyosyo=JIGYOSYO.CSV > zip_code_seed.tsv
```

## Issue IDs

## Steps to test new behaviors (if any)

## Additional context
