### PR TITLE
Set `Bitness="always32"` for Omaha related reg keys

### DIFF
--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -327,7 +327,7 @@
     </StandardDirectory>
 
     <!-- Write registry keys to make the installer compatible with Omaha. -->
-    <Component Id="OmahaRegister" Directory="TARGETDIR">
+    <Component Id="OmahaRegister" Directory="TARGETDIR" Bitness="always32">
       <RegistryValue Id="OmahaClientRegPv" Root="HKLM" Key="$(var.OmahaClientKey)" Name="pv" Value="$(var.MozcVersion)" Action="write" Type="string" />
       <RegistryValue Id="OmahaClientRegName" Root="HKLM" Key="$(var.OmahaClientKey)" Name="name" Value="Google 日本語入力" Action="write" Type="string" />
       <RegistryValue Id="OmahaClientRegLang" Root="HKLM" Key="$(var.OmahaClientKey)" Name="lang" Value="ja" Action="write" Type="string" />
@@ -348,7 +348,7 @@
       <RegistryValue Id="SysProcsGIMEJaRenderer" Root="HKLM" Key="SYSTEM\CurrentControlSet\Control\Terminal Server\SysProcs" Name="GoogleIMEJaRenderer.exe" Value="0" Action="write" Type="integer" />
     </Component>
 
-    <Component Id="OmahaRegLaunchCmdLine" Permanent="no" Directory="TARGETDIR" Condition="(NOT UPGRADING)">
+    <Component Id="OmahaRegLaunchCmdLine" Permanent="no" Directory="TARGETDIR" Condition="(NOT UPGRADING)" Bitness="always32">
       <RegistryValue Id="OmahaLaunchCmdLineValue" Root="HKLM" Key="$(var.OmahaClientStateKey)" Name="InstallerSuccessLaunchCmdLine" Action="write" Type="string" Value="&quot;[GIMEJaDir]GoogleIMEJaTool.exe&quot; --mode=post_install_dialog" />
     </Component>
 


### PR DESCRIPTION
[Omaha](https://github.com/google/omaha) is still a 32-bit app. Thus registry values need to be placed under `WOW6432Node`.

This is probably a regression in [my previous commit](https://github.com/google/mozc/commit/cbd55566caaf321009b1254bbf45588eeac38e10), which updated WiX version from WiX v3 to WiX v4 (#894).

## Description
Starting from cbd55566caaf321009b1254bbf45588eeac38e10, we explicitly pass `-arch x64` when running `wix` command. As a result, registry entries in `installer_64bit.wxs` are no longer written under `WOW6432Node` unless explicitly specified.

## Issue IDs
#1072

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 23H2
 - Steps:
   1. Build `GoogleJapaneseInput64.msi`
   2. decompile it as `dotnet tool run wix msi GoogleJapaneseInput64.msi`.
   3. Make sure that Omaha related registries have `Bitness="always32"`

