### PR TITLE
Fix #1077: Deprecate `Mozc_tsf_ui.log`

### DIFF
--- a/src/win32/tip/tip_text_service.cc
+++ b/src/win32/tip/tip_text_service.cc
@@ -150,7 +150,6 @@ constexpr GUID kTipFunctionProvider = {
 #else  // GOOGLE_JAPANESE_INPUT_BUILD
 
 constexpr char kHelpUrl[] = "https://github.com/google/mozc";
-constexpr char kLogFileName[] = "Mozc_tsf_ui.log";
 constexpr wchar_t kTaskWindowClassName[] =
     L"Mozc Immersive Task Message Window";
 
@@ -511,8 +510,6 @@ class TipTextServiceImpl
     StorePointerForCurrentThread(this);
 
     HRESULT result = E_UNEXPECTED;
-    RegisterLogFileSink(
-        FileUtil::JoinPath(SystemUtil::GetLoggingDirectory(), kLogFileName));
 
     EnsureKanaLockUnlocked();
 


### PR DESCRIPTION
## Description
This is a quick fix for #1077.

While #1077 itself is not the root cause of #1076, merging this commit would also help debugging #1076 with debug builds.

## Issue IDs
#1077

## Steps to test new behaviors
A clear and concise description about how to verify new behaviors.
 - OS: Windows 11 23H2
 - Steps:
   1. Create and install a debug version of `Mozc64.msi`
   2. Build and launch the following app.
   3. Select Mozc
```
#include <windows.h>

int WINAPI wWinMain(HINSTANCE instance_handle, HINSTANCE prev_instance_handle,
                    PWSTR command_line, int command_show) {
  const wchar_t window_class_name[] = L"Test Window Class";
  {
    const WNDCLASS wc = {
        .lpfnWndProc = [](HWND window_handle, UINT message,
                          auto... params) -> LRESULT {
          if (message == WM_DESTROY) {
            ::PostQuitMessage(0);
            return 0;
          }
          return ::DefWindowProc(window_handle, message, params...);
        },
        .hInstance = instance_handle,
        .hbrBackground = (HBRUSH)(COLOR_WINDOW + 1),
        .lpszClassName = window_class_name,
    };
    ::RegisterClass(&wc);
  }

  const HWND window_handle = ::CreateWindowEx(
      0, window_class_name, L"Window Title", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, nullptr, nullptr,
      instance_handle, nullptr);

  if (window_handle == nullptr) {
    return 0;
  }

  ::ShowWindow(window_handle, command_show);

  while (true) {
    MSG message = {};
    if (::GetMessage(&message, nullptr, 0, 0) <= 0) {
      break;
    }
    ::TranslateMessage(&message);
    ::DispatchMessage(&message);
  }

  return 0;
}
```

Without this commit, the app crashes because of the same reason as #856.
