### PR TITLE
Make `config1.db` readable from `AppContainer` apps

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -738,7 +738,9 @@ mozc_cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
-    ],
+    ] + mozc_select(
+        windows = ["//base/win32:win_sandbox"],
+    ),
 )
 
 mozc_cc_test(

--- a/src/base/config_file_stream.h
+++ b/src/base/config_file_stream.h
@@ -107,6 +107,10 @@ class ConfigFileStream {
   // Clear all memory:// files.  This is a utility method for testing.
   static void ClearOnMemoryFiles();
 
+#ifdef _WIN32
+  static void FixupFilePermission(absl::string_view filename);
+#endif  // _WIN32
+
  private:
   // This function is deprecated. Use OpenReadText or OpenReadBinary instead.
   // TODO(yukawa): Move this function to anonymous namespace in

--- a/src/base/win32/win_sandbox.h
+++ b/src/base/win32/win_sandbox.h
@@ -185,15 +185,15 @@ class WinSandbox {
       HANDLE effective_token, TokenLevel security_level,
       IntegrityLevel integrity_level);
 
+  enum class AppContainerVisibilityType {
+    kProgramFiles = 0,
+    kConfigFile = 1,
+  };
+
   // Returns true |file_name| already has or is updated to have an ACE
-  // (Access Control Entry) for "All Application Packages" group to have the
-  // following access masks:
-  //   - FILE_READ_DATA
-  //   - FILE_READ_EA
-  //   - FILE_EXECUTE
-  //   - READ_CONTROL
-  //   - SYNCHRONIZE
-  static bool EnsureAllApplicationPackagesPermisssion(zwstring_view file_name);
+  // (Access Control Entry) for "All Application Packages" group.
+  static bool EnsureAllApplicationPackagesPermisssion(
+      zwstring_view file_name, AppContainerVisibilityType type);
 
  protected:
   // Returns SDDL for given |shareble_object_type|.

--- a/src/config/config_handler.cc
+++ b/src/config/config_handler.cc
@@ -53,6 +53,11 @@
 #include "base/vlog.h"
 #include "protocol/config.pb.h"
 
+#ifdef _WIN32
+#include "base/win32/wide_char.h"
+#include "base/win32/win_sandbox.h"
+#endif  // _WIN32
+
 namespace mozc {
 namespace config {
 namespace {
@@ -179,6 +184,9 @@ void ConfigHandlerImpl::SetConfig(const Config &config) {
 
   MOZC_VLOG(1) << "Setting new config: " << filename_;
   ConfigFileStream::AtomicUpdate(filename_, output_config.SerializeAsString());
+#ifdef _WIN32
+  ConfigFileStream::FixupFilePermission(filename_);
+#endif  // _WIN32
 
 #ifdef DEBUG
   std::string debug_content = absl::StrCat(
@@ -308,6 +316,13 @@ Config::SessionKeymap ConfigHandler::GetDefaultKeyMap() {
     return config::Config::MSIME;
   }
 }
+
+#ifdef _WIN32
+// static
+void ConfigHandler::FixupFilePermission() {
+  ConfigFileStream::FixupFilePermission(GetConfigFileName());
+}
+#endif  // _WIN32
 
 }  // namespace config
 }  // namespace mozc

--- a/src/config/config_handler.h
+++ b/src/config/config_handler.h
@@ -86,6 +86,10 @@ class ConfigHandler {
 
   // Get default keymap for each platform.
   static Config::SessionKeymap GetDefaultKeyMap();
+
+#ifdef _WIN32
+  static void FixupFilePermission();
+#endif  // _WIN32
 };
 
 }  // namespace config

--- a/src/win32/base/BUILD.bazel
+++ b/src/win32/base/BUILD.bazel
@@ -53,7 +53,6 @@ mozc_cc_library(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         "//base:system_util",
-        "//client:client_interface",
         "//config:config_handler",
         "//protocol:config_cc_proto",
         "//session:key_info_util",

--- a/src/win32/base/config_snapshot.cc
+++ b/src/win32/base/config_snapshot.cc
@@ -31,8 +31,6 @@
 
 #include <algorithm>
 
-#include "base/win32/win_util.h"
-#include "client/client_interface.h"
 #include "config/config_handler.h"
 #include "protocol/config.pb.h"
 
@@ -40,7 +38,6 @@ namespace mozc {
 namespace win32 {
 namespace {
 
-using ::mozc::client::ClientInterface;
 using ::mozc::config::Config;
 
 constexpr size_t kMaxDirectModeKeys = 128;
@@ -53,25 +50,7 @@ struct StaticConfigSnapshot {
   KeyInformation direct_mode_keys[kMaxDirectModeKeys];
 };
 
-bool GetConfigSnapshotForSandboxedProcess(ClientInterface *client,
-                                          Config *config) {
-  if (client == nullptr) {
-    return false;
-  }
-  // config1.db is likely to be inaccessible from sandboxed processes.
-  // So retrieve the config data from the server process.
-  // CAVEATS: ConfigHandler::GetConfig always returns true even when it fails
-  // to load the config file due to the sandbox. b/10449414
-  if (!client->CheckVersionOrRestartServer()) {
-    return false;
-  }
-  if (!client->GetConfig(config)) {
-    return false;
-  }
-  return true;
-}
-
-StaticConfigSnapshot GetConfigSnapshotForNonSandboxedProcess() {
+StaticConfigSnapshot GetConfigSnapshotImpl() {
   Config config;
   // config1.db should be readable in this case.
   config::ConfigHandler::GetConfig(&config);
@@ -102,26 +81,9 @@ ConfigSnapshot::Info::Info()
       use_mode_indicator(false) {}
 
 // static
-bool ConfigSnapshot::Get(client::ClientInterface *client, Info *info) {
-  // A temporary workaround for b/24793812. Always reload config if the
-  // process is sandboxed.
-  // TODO(yukawa): Cache the result once it succeeds.
-  if (WinUtil::IsProcessSandboxed()) {
-    Config config;
-    if (!GetConfigSnapshotForSandboxedProcess(client, &config)) {
-      return false;
-    }
-    info->use_kana_input = (config.preedit_method() == Config::KANA);
-    info->use_keyboard_to_change_preedit_method =
-        config.use_keyboard_to_change_preedit_method();
-    info->use_mode_indicator = config.use_mode_indicator();
-    info->direct_mode_keys = KeyInfoUtil::ExtractSortedDirectModeKeys(config);
-    return true;
-  }
-
+bool ConfigSnapshot::Get(Info *info) {
   // Note: Thread-safety is not required.
-  static const StaticConfigSnapshot cached_snapshot =
-      GetConfigSnapshotForNonSandboxedProcess();
+  static const StaticConfigSnapshot cached_snapshot = GetConfigSnapshotImpl();
   info->use_kana_input = cached_snapshot.use_kana_input;
   info->use_keyboard_to_change_preedit_method =
       cached_snapshot.use_keyboard_to_change_preedit_method;

--- a/src/win32/base/config_snapshot.h
+++ b/src/win32/base/config_snapshot.h
@@ -35,10 +35,6 @@
 #include "session/key_info_util.h"
 
 namespace mozc {
-namespace client {
-class ClientInterface;
-}  // namespace client
-
 namespace win32 {
 
 class ConfigSnapshot {
@@ -55,7 +51,7 @@ class ConfigSnapshot {
   ConfigSnapshot(const ConfigSnapshot &) = delete;
   ConfigSnapshot &operator=(const ConfigSnapshot &) = delete;
 
-  static bool Get(client::ClientInterface *client, Info *info);
+  static bool Get(Info *info);
 };
 
 }  // namespace win32

--- a/src/win32/custom_action/custom_action.def
+++ b/src/win32/custom_action/custom_action.def
@@ -14,5 +14,6 @@ EXPORTS
     InitialInstallation
     InitialInstallationCommit
     EnableTipProfile
+    FixupConfigFilePermission
     WriteApValue
     WriteApValueRollback

--- a/src/win32/custom_action/custom_action.h
+++ b/src/win32/custom_action/custom_action.h
@@ -76,6 +76,9 @@ UINT __stdcall InitialInstallationCommit(MSIHANDLE msi_handle);
 // Enable TIP profile for the calling user unless it's a service account.
 UINT __stdcall EnableTipProfile(MSIHANDLE msi_handle);
 
+// Update config1.db file access controll to make it readable to AppContainer.
+UINT __stdcall FixupConfigFilePermission(MSIHANDLE msi_handle);
+
 // Saves omaha's ap value for WriteApValue, WriteApValueRollback, and
 // RestoreServiceState.
 // Since they are executed as deferred customs actions and most properties

--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -145,6 +145,7 @@
     <CustomAction Id="InitialInstallation" DllEntry="InitialInstallation" Execute="deferred" Impersonate="no" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
     <CustomAction Id="InitialInstallationCommit" DllEntry="InitialInstallationCommit" Execute="commit" Impersonate="no" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
     <CustomAction Id="EnableTipProfile" DllEntry="EnableTipProfile" Execute="commit" Impersonate="yes" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
+    <CustomAction Id="FixupConfigFilePermission" DllEntry="FixupConfigFilePermission" Execute="commit" Impersonate="yes" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
     <CustomAction Id="HideCancelButton" DllEntry="HideCancelButton" Return="ignore" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
     <CustomAction Id="SaveCustomActionData" DllEntry="SaveCustomActionData" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
     <CustomAction Id="RestoreServiceState" DllEntry="RestoreServiceState" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="GoogleIMEJaInstallerHelper.dll" />
@@ -196,7 +197,8 @@
       <Custom Action="RegisterTIPRollback64" Before="RegisterTIP64" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (VersionNT64) AND (NOT UPGRADING)" />
       <Custom Action="RegisterTIP64" Before="EnsureAllApplicationPackagesPermisssions" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (VersionNT64)" />
       <Custom Action="EnsureAllApplicationPackagesPermisssions" Before="InitialInstallationCommit" Condition="(NOT (REMOVE=&quot;ALL&quot;))" />
-      <Custom Action="InitialInstallationCommit" Before="EnableTipProfile" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
+      <Custom Action="InitialInstallationCommit" Before="FixupConfigFilePermission" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
+      <Custom Action="FixupConfigFilePermission" Before="EnableTipProfile" Condition="NOT (REMOVE=&quot;ALL&quot;)" />
       <Custom Action="EnableTipProfile" Before="InstallFinalize" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
       <!-- show reboot dialog to execute pending file opartions -->
       <?if ($(var.VSConfigurationName) = "Release") ?>

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -126,6 +126,7 @@
     <CustomAction Id="InitialInstallation" DllEntry="InitialInstallation" Execute="deferred" Impersonate="no" BinaryRef="mozc_installer_helper.dll" />
     <CustomAction Id="InitialInstallationCommit" DllEntry="InitialInstallationCommit" Execute="commit" Impersonate="no" BinaryRef="mozc_installer_helper.dll" />
     <CustomAction Id="EnableTipProfile" DllEntry="EnableTipProfile" Execute="commit" Impersonate="yes" BinaryRef="mozc_installer_helper.dll" />
+    <CustomAction Id="FixupConfigFilePermission" DllEntry="FixupConfigFilePermission" Execute="commit" Impersonate="yes" BinaryRef="mozc_installer_helper.dll" />
     <CustomAction Id="HideCancelButton" DllEntry="HideCancelButton" Return="ignore" BinaryRef="mozc_installer_helper.dll" />
     <CustomAction Id="SaveCustomActionData" DllEntry="SaveCustomActionData" BinaryRef="mozc_installer_helper.dll" />
     <CustomAction Id="RestoreServiceState" DllEntry="RestoreServiceState" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="mozc_installer_helper.dll" />
@@ -172,7 +173,8 @@
       <Custom Action="RegisterTIPRollback64" Before="RegisterTIP64" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (VersionNT64) AND (NOT UPGRADING)" />
       <Custom Action="RegisterTIP64" Before="EnsureAllApplicationPackagesPermisssions" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (VersionNT64)" />
       <Custom Action="EnsureAllApplicationPackagesPermisssions" Before="InitialInstallationCommit" Condition="(NOT (REMOVE=&quot;ALL&quot;))" />
-      <Custom Action="InitialInstallationCommit" Before="EnableTipProfile" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
+      <Custom Action="InitialInstallationCommit" Before="FixupConfigFilePermission" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
+      <Custom Action="FixupConfigFilePermission" Before="EnableTipProfile" Condition="NOT (REMOVE=&quot;ALL&quot;)" />
       <Custom Action="EnableTipProfile" Before="InstallFinalize" Condition="(NOT (REMOVE=&quot;ALL&quot;)) AND (NOT UPGRADING)" />
       <!-- show reboot dialog to execute pending file opartions -->
       <?if ($(var.VSConfigurationName) = "Release") ?>

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -436,6 +436,7 @@ mozc_cc_library(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        "//client:client_interface",
         "//protocol:commands_cc_proto",
         "//win32/base:config_snapshot",
         "//win32/base:deleter",

--- a/src/win32/tip/tip_private_context.cc
+++ b/src/win32/tip/tip_private_context.cc
@@ -88,7 +88,7 @@ void TipPrivateContext::EnsureInitialized() {
 
   // Try to reflect the current config to the IME behavior.
   ConfigSnapshot::Info snapshot;
-  if (ConfigSnapshot::Get(state_->client_.get(), &snapshot)) {
+  if (ConfigSnapshot::Get(&snapshot)) {
     auto *behavior = &state_->input_behavior_;
     behavior->prefer_kana_input = snapshot.use_kana_input;
     behavior->use_romaji_key_to_toggle_input_style =

--- a/src/win32/tip/tip_private_context.h
+++ b/src/win32/tip/tip_private_context.h
@@ -34,6 +34,7 @@
 
 #include <memory>
 
+#include "client/client_interface.h"
 #include "protocol/commands.pb.h"
 #include "win32/base/config_snapshot.h"
 #include "win32/base/deleter.h"


### PR DESCRIPTION
## Description
This attempts to avoid the deadlock issue discussed in #1076.

From what I can observe on Windows 11 23H2 (22631.4317), it looks to be dangerous for us to call File I/O Win32 APIs such as `CreateFile` from AppContainer processes unless we are confident that the target file/dir is accessible to the AppContainer process. When such an access is not allowed at the ACL level, the debugger shows that `Windows.Storage.OneCore.dll` tries to forward it to a broker process (e.g. via `Windows.Storage.OneCore.dll!BrokeredCreateFile2`). The issue is that Windows.Storage.OneCore.dll is a WinRT component, which means that just calling `CreateFile()` results in dynamically invoking `RoInitialize()` internally, which can confuse TSF runtime as we have already seen in #856.

To summarize, the safest option is to ensure that the target file/dir is always accessible to AppContainer so that `Windows.Storage.OneCore.dll` will not be involved if the file/dir is opened with `CreateFile()` from `MozcTip{32,64}.dll`.

If this commit is not sufficient to address #1076, we then need to take care of other File I/O APIs such as `CreateDirectoryW()` and `GetFileAttributes()`.

## Issue IDs
#1076.

## Steps to test new behaviors
A clear and concise description about how to verify new behaviors.
 - OS: Windows 11 23H2
 - Steps:
   1. Install a previous version of Mozc.
   2. Open the config dialog then update the config. Then save it.
   3. `cacls %LOCALAPPDATA%Low\Mozc\config1.db`
   4. Create and install `Mozc64.msi` with this commit to update Mozc.
   5. `cacls %LOCALAPPDATA%Low\Mozc\config1.db`

* At the step 3, there is no entry about `ALL APPLICATION PACKAGES`.
* At the step 5, there should be an entry about `ALL APPLICATION PACKAGES` as follows.
```
APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES:(special access:)
                                                       READ_CONTROL
                                                       SYNCHRONIZE
                                                       FILE_GENERIC_READ
                                                       FILE_READ_DATA
                                                       FILE_READ_EA
                                                       FILE_READ_ATTRIBUTES
```
## Steps to test new behaviors
Not yet confirmed to be a valid fix.
