### PR TITLE
Make bzlmod repo rules compatible with Bazel 8

### DIFF
--- a/src/bazel/dotnet_tool_repository.bzl
+++ b/src/bazel/dotnet_tool_repository.bzl
@@ -50,7 +50,9 @@ def _dotnet_tool_repo_impl(repo_ctx):
     tool_name = repo_ctx.attr.tool_name
     if not tool_name:
         # In bzlmod, repo_ctx.attr.name has a prefix like "_main~_repo_rules~wix".
-        tool_name = repo_ctx.attr.name.split("~")[-1]
+        # Note also that Bazel 8.0+ uses "+" instead of "~".
+        # https://github.com/bazelbuild/bazel/issues/23127
+        tool_name = repo_ctx.attr.name.replace("~", "+").split("+")[-1]
     version = repo_ctx.attr.version
 
     repo_ctx.execute([

--- a/src/bazel/pkg_config_repository.bzl
+++ b/src/bazel/pkg_config_repository.bzl
@@ -105,7 +105,9 @@ def _pkg_config_repository_impl(repo_ctx):
     _symlinks(repo_ctx, includes)
     data = {
         # In bzlmod, repo_ctx.attr.name has a prefix like "_main~_repo_rules~ibus".
-        "name": repo_ctx.attr.name.split("~")[-1],
+        # Note also that Bazel 8.0+ uses "+" instead of "~".
+        # https://github.com/bazelbuild/bazel/issues/23127
+        "name": repo_ctx.attr.name.replace("~", "+").split("+")[-1],
         "hdrs": _make_strlist([item + "/**" for item in includes]),
         "copts": _make_strlist(_exec_pkg_config(repo_ctx, "--cflags-only-other")),
         "includes": _make_strlist(includes),


### PR DESCRIPTION
## Description
There is an upcoming behavior change in bzlmod `--incompatible_use_plus_in_repo_names`, which changes the separator character in canonical repo names from tilde `~` to plus `+` due to I/O performance issue in Windows.

 * https://github.com/bazelbuild/bazel/issues/23127

The above flag is planned to be enabled by default in Bazel 8.0, which is expected to be released on November 2024. Let's update our custom repository rules so that they can continue working with Bazel 8.0.

## Issue IDs
This is a follow up to
 * https://github.com/google/mozc/issues/1002

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Ubuntu 24.04
 - Steps:
   1. Make sure you are using Bazel 7.3.2.
   2. `bazel build --config oss_linux package --config release_build --incompatible_use_plus_in_repo_names`
   3. Confirm the build succeeds.

