### PR TITLE
Apply `buildifier` to existing files

### DIFF
--- a/src/bazel/BUILD.qt.bazel
+++ b/src/bazel/BUILD.qt.bazel
@@ -1,5 +1,8 @@
-load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_dynamic_framework_import")
+load(
+    "@build_bazel_rules_apple//apple:apple.bzl",
+    "apple_dynamic_framework_import",
+)
+
 package(
     default_visibility = ["//visibility:public"],
 )
@@ -11,42 +14,42 @@ package(
 cc_library(
     name = "qt_mac_core",
     hdrs = glob(["lib/QtCore.framework/Headers/*"]),
-    includes = [
-      "lib/QtCore.framework/Headers",
-      "lib/QtCore.framework/Headers/QtCore",
-    ],
     include_prefix = "QtCore",
+    includes = [
+        "lib/QtCore.framework/Headers",
+        "lib/QtCore.framework/Headers/QtCore",
+    ],
     strip_include_prefix = "lib/QtCore.framework/Headers",
 )
 
 cc_library(
     name = "qt_mac_gui",
     hdrs = glob(["lib/QtGui.framework/Headers/*"]),
-    includes = [
-      "lib/QtGui.framework/Headers",
-      "lib/QtGui.framework/Headers/QtGui",
-    ],
     include_prefix = "QtGui",
+    includes = [
+        "lib/QtGui.framework/Headers",
+        "lib/QtGui.framework/Headers/QtGui",
+    ],
     strip_include_prefix = "lib/QtGui.framework/Headers",
 )
 
 cc_library(
     name = "qt_mac_widgets",
     hdrs = glob(["lib/QtWidgets.framework/Headers/*"]),
-    includes = [
-      "lib/QtWidgets.framework/Headers",
-      "lib/QtWidgets.framework/Headers/QtWidgets",
-    ],
     include_prefix = "QtWidgets",
+    includes = [
+        "lib/QtWidgets.framework/Headers",
+        "lib/QtWidgets.framework/Headers/QtWidgets",
+    ],
     strip_include_prefix = "lib/QtWidgets.framework/Headers",
 )
 
 cc_library(
     name = "qt_mac",
     deps = [
-      ":qt_mac_core",
-      ":qt_mac_gui",
-      ":qt_mac_widgets",
+        ":qt_mac_core",
+        ":qt_mac_gui",
+        ":qt_mac_widgets",
     ],
 )
 

--- a/src/bazel/BUILD.qt_win.bazel
+++ b/src/bazel/BUILD.qt_win.bazel
@@ -25,7 +25,7 @@ cc_library(
         ],
     }),
     hdrs = glob([
-        "include"
+        "include",
     ]),
     includes = [
         "include",


### PR DESCRIPTION
## Description
Before we start applying lint checks for `BUILD.bazel` and `*.bzl` files in GitHub Actions, this commit aims to fix existing lint errors by actually applying [`buildifier`](https://github.com/bazelbuild/buildtools/blob/main/buildifier/README.md) locally.

This is just a style fix in build files. There must be no observable behavior change in artifacts.

## Issue IDs

  * https://github.com/google/mozc/issues/1089

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows
 - Steps:
   1. `git clone https://github.com/google/mozc.git`
   2. `go install github.com/bazelbuild/buildtools/buildifier@latest`
   3. `buildifier --mode=diff -r .`
