### PR TITLE
Shutdown `mozc_{server,renderer}.exe` on upgrading

### DIFF
--- a/src/win32/custom_action/custom_action.cc
+++ b/src/win32/custom_action/custom_action.cc
@@ -244,21 +244,19 @@ UINT __stdcall ShutdownServer(MSIHANDLE msi_handle) {
   DEBUG_BREAK_FOR_DEBUGGER();
   std::unique_ptr<mozc::client::ClientInterface> server_client(
       mozc::client::ClientFactory::NewClient());
-  bool server_result = true;
   if (server_client->PingServer()) {
-    server_result = server_client->Shutdown();
+    if (!server_client->Shutdown()) {
+      // This is not fatal as Windows Installer can replace executables even
+      // when they still are running. Just log error then go ahead.
+      LOG_ERROR_FOR_OMAHA();
+    }
   }
   mozc::renderer::RendererClient renderer_client;
-  const bool renderer_result = renderer_client.Shutdown(true);
-  if (!server_result) {
+  if (!renderer_client.Shutdown(true)) {
+    // This is not fatal as Windows Installer can replace executables even when
+    // they are still running. Just log error then go ahead.
     LOG_ERROR_FOR_OMAHA();
-    return ERROR_INSTALL_FAILURE;
   }
-  if (!renderer_result) {
-    LOG_ERROR_FOR_OMAHA();
-    return ERROR_INSTALL_FAILURE;
-  }
-
   return ERROR_SUCCESS;
 }
 

--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -174,7 +174,7 @@
         are currenly running. So the ShutdownServer action
         needs to be callled before the InstallValidate action.
       -->
-      <Custom Action="ShutdownServer" Before="InstallValidate" Condition="(REMOVE=&quot;ALL&quot;) AND (NOT UPGRADINGPRODUCTCODE)" />
+      <Custom Action="ShutdownServer" Before="InstallValidate" />
       <Custom Action="NewerVersionError" After="FindRelatedProducts" Condition="NEWERVERSIONDETECTED" />
       <!--
         RemoveExistingProducts needs to be scheduled between InstallExecute and

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -150,7 +150,7 @@
         are currenly running. So the ShutdownServer action
         needs to be callled before the InstallValidate action.
       -->
-      <Custom Action="ShutdownServer" Before="InstallValidate" Condition="(REMOVE=&quot;ALL&quot;) AND (NOT UPGRADINGPRODUCTCODE)" />
+      <Custom Action="ShutdownServer" Before="InstallValidate" />
       <Custom Action="NewerVersionError" After="FindRelatedProducts" Condition="NEWERVERSIONDETECTED" />
       <!--
         RemoveExistingProducts needs to be scheduled between InstallExecute and


### PR DESCRIPTION
## Description
It would make more sense to shutdown `mozc_server.exe` and `mozc_renderer.exe` not only when uninstalling Mozc but also when upgrading Mozc.

With this commit

 * `ShutdownServer` custom actions will always run
 * Any failure on 'ShutdownServer' will not block installation/upgrading as it is an optional behavior and Windows Installer can proceed even when these processes continue running.

Closes #1092.

## Issue IDs

* https://github.com/google/mozc/issues/1092

## Steps to test new behaviors (if any)
 - OS: Windows 11 23H2
 - Steps:
   1. Install an older version of Mozc
   2. Open some application (e.g. notepad) then select Mozc and type something with Mozc enabled.
   3. Make sure that `mozc_server.exe` and `mozc_renderer.exe` are running.
   4. Double click a newer version of `Mozc64.msi`
   5. Make sure you are not asked to choose whether `mozc_server.exe` and `mozc_renderer.exe` should be restarted to complete the installation.
