### PR TITLE
Enabling Bazel to recognize packages that do not output cflags through pkg-config.

### DIFF
--- a/src/bazel/pkg_config_repository.bzl
+++ b/src/bazel/pkg_config_repository.bzl
@@ -78,21 +78,14 @@ EXPORTS_FILES_TEMPLATE = """
 exports_files(glob(["libexec/*"]))
 """
 
-def _exec_pkg_config(repo_ctx, flag):
+def _exec_pkg_config(repo_ctx, flags):
     binary = repo_ctx.which("pkg-config")
     if not binary:
         # Using print is not recommended, but this will be a clue to debug build errors in
         # the case of pkg-config is not found.
         print("pkg-config is not found")  # buildifier: disable=print
         return []
-    result = repo_ctx.execute([binary, flag] + repo_ctx.attr.packages)
-
-    # If result.stdout.strip() is empty, pkg-config will be re-executed with
-    # the --keep-system-cflags option added. Typically, -I/usr/include is
-    # returned, enabling bazel to recognize packages as valid even when
-    # pkg-config does not output cflags with standard options.
-    if result.stdout.strip() == "":
-        result = repo_ctx.execute([binary, flag] + ["--keep-system-cflags"] + repo_ctx.attr.packages)
+    result = repo_ctx.execute([binary] + flags + repo_ctx.attr.packages)
     items = result.stdout.strip().split(" ")
     uniq_items = sorted({key: None for key in items}.keys())
     return uniq_items
@@ -107,7 +100,14 @@ def _symlinks(repo_ctx, paths):
         repo_ctx.symlink("/" + path, path)
 
 def _pkg_config_repository_impl(repo_ctx):
-    includes = _exec_pkg_config(repo_ctx, "--cflags-only-I")
+    includes = _exec_pkg_config(repo_ctx, ["--cflags-only-I"])
+
+    # If includes is empty, pkg-config will be re-executed with
+    # the --keep-system-cflags option added. Typically, -I/usr/include is
+    # returned, enabling bazel to recognize packages as valid even when
+    # pkg-config does not output cflags with standard options.
+    if includes[0] == "":
+        includes = _exec_pkg_config(repo_ctx, ["--cflags-only-I", "--keep-system-cflags"])
     includes = [item[len("-I/"):] for item in includes]
     _symlinks(repo_ctx, includes)
     data = {
@@ -116,13 +116,13 @@ def _pkg_config_repository_impl(repo_ctx):
         # https://github.com/bazelbuild/bazel/issues/23127
         "name": repo_ctx.attr.name.replace("~", "+").split("+")[-1],
         "hdrs": _make_strlist([item + "/**" for item in includes]),
-        "copts": _make_strlist(_exec_pkg_config(repo_ctx, "--cflags-only-other")),
+        "copts": _make_strlist(_exec_pkg_config(repo_ctx, ["--cflags-only-other"])),
         "includes": _make_strlist(includes),
-        "linkopts": _make_strlist(_exec_pkg_config(repo_ctx, "--libs-only-l")),
+        "linkopts": _make_strlist(_exec_pkg_config(repo_ctx, ["--libs-only-l"])),
     }
     build_file_data = BUILD_TEMPLATE.format(**data)
 
-    libexecdir = _exec_pkg_config(repo_ctx, "--variable=libexecdir")
+    libexecdir = _exec_pkg_config(repo_ctx, ["--variable=libexecdir"])
     if len(libexecdir) == 1:
         repo_ctx.symlink(libexecdir[0], "libexec")
         build_file_data += EXPORTS_FILES_TEMPLATE

--- a/src/bazel/pkg_config_repository.bzl
+++ b/src/bazel/pkg_config_repository.bzl
@@ -86,6 +86,13 @@ def _exec_pkg_config(repo_ctx, flag):
         print("pkg-config is not found")  # buildifier: disable=print
         return []
     result = repo_ctx.execute([binary, flag] + repo_ctx.attr.packages)
+
+    # If result.stdout.strip() is empty, pkg-config will be re-executed with
+    # the --keep-system-cflags option added. Typically, -I/usr/include is
+    # returned, enabling bazel to recognize packages as valid even when
+    # pkg-config does not output cflags with standard options.
+    if result.stdout.strip() == "":
+        result = repo_ctx.execute([binary, flag] + ["--keep-system-cflags"] + repo_ctx.attr.packages)
     items = result.stdout.strip().split(" ")
     uniq_items = sorted({key: None for key in items}.keys())
     return uniq_items


### PR DESCRIPTION
Enabling Bazel to recognize packages that do not output cflags through pkg-config.

If a package's cflags only contain '-I/usr/include', there will be no output
from 'pkg-config --cflags-only-I'. Therefore, it does not recognize it as a
package. Additionally, the referenced headers (hdrs) become absolute paths
(`"/**"`), which causes Bazel to generate an error.
The glob pattern does not allow absolute paths(`"/**"`) or empty strings("").

This modification allows pkg-config to be re-executed with --keep-system-cflags
if result.stdout.strip() is empty ("").
Typically, -I/usr/include is returned, enabling bazel to recognize packages
as valid even when pkg-config does not output cflags with standard options.

## Description
Currently, when attempting to build fcitx-mozc with Bazel, the output of pkg-config --cflags-only-I is empty. As a result, the hdrs reference becomes an absolute path (/**), causing Bazel to stop due to not finding `@fcitx`.
If we can avoid this error, the build will be possible. Other packages may not have issues at present, but if cflags only includes -I/usr/include, there is a high likelihood of encountering the same type of error.

The bazel command returns an error with the following hdrs:
```
Error in glob: pattern cannot be absolute
```
```
    hdrs = glob([
        "/**"
    ]),
```
```
Error in glob: pattern cannot be empty
```
```
    hdrs = glob([
        ""
    ]),
```

This modification allows pkg-config to be re-executed with --keep-system-cflags if result.stdout.strip() is empty ("").
Typically, -I/usr/include is returned, enabling Bazel to recognize packages that do not output cflags through pkg-config.

## Issue IDs

## Steps to test new behaviors (if any)

## Additional context
