### PR TITLE
Revert "Remove an obsolete workaround from `.bazelrc`"

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -65,6 +65,12 @@ test:macos_env   --test_tag_filters=-nomac
 build:windows_env --build_tag_filters=-nowin
 test:windows_env   --test_tag_filters=-nowin
 
+# A temporary workaround to make "mozc_win_build_rule" work.
+# Note that "incompatible_enable_cc_toolchain_resolution" is now enabled by
+# default. See https://github.com/bazelbuild/bazel/issues/7260
+# TODO: Re-enable "incompatible_enable_cc_toolchain_resolution"
+build:windows_env --noincompatible_enable_cc_toolchain_resolution
+
 # Android specific options
 build:android_env --copt "-DOS_ANDROID"
 build:android_env --build_tag_filters=-noandroid


### PR DESCRIPTION
## Description
This reverts commit de7615fd0739a3c949edb47caef495290a023740.

It turns out that `--cpu` command line option will be silently ignored with Bazel 7.0 and later unless `--noincompatible_enable_cc_toolchain_resolution` option is specified. Otherwise `mozc_tip32.dll` will be built as a 64-bit executable.

This is a temporary workaround until until we fully migrate to `--platforms` command line option.

This commit only affects Windows build with Bazel. Other build configurations such as GYP build on Windows are not affected.

Closes #1102

## Issue IDs

 * https://github.com/google/mozc/issues/1102

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 23H2
 - Steps:
   1. Build Mozc and install `Mozc64.msi`
   2. Make sure that `mozc_tip32.dll` is built as a 32-bit executable.
