### PR TITLE
Generate PDB file from mozc_win32_cc_prod_binary

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -180,6 +180,7 @@ bzl_library(
         "//bazel:run_build_tool_bzl",
         "//bazel:stubs.bzl",
         "//devtools/build_cleaner/skylark:build_defs_lib",
+        "@bazel_skylib//rules:select_file",
         "@build_bazel_rules_apple//apple:macos",
     ],
 )


### PR DESCRIPTION
## Description
While `rules_cc` provides `generate_pdb_file` feature to generate the PDB file, its filename is not hard-coded and not configurable. For instance, if the target name is `mozc_tip32`, then the output pdb file is always assumed to be `mozc_tip32.pdb`. To make it `mozc_tip32.dll.pdb`, the target name must be `mozc_tip32.dll.dll`.

This is why `intermediate_name` is introduced in `mozc_win32_cc_prod_binary`.

There must be no observable change in GYP build and non-Windows bazel builds.

## Issue IDs

 * https://github.com/google/mozc/issues/1108

## Steps to test new behaviors (if any)
 - OS: Windows 11 23H2
 - Steps:
   1. `bazel --bazelrc=windows.bazelrc build --config oss_windows --config release_build //win32/tip:mozc_tip32`
   2. `cp bazel-bin\win32\tip\mozc_tip32.dll .`
   3. `dumpbin /headers mozc_tip32.dll | findstr cv`
   4. Confirm `mozc_tip32.dll.pdb` is in the output.
