### PR TITLE
Remove obsolete build options from `.bazelrc`

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -65,6 +65,4 @@ build:windows_env --noincompatible_enable_cc_toolchain_resolution
 # Android specific options
 build:android_env --copt "-DOS_ANDROID"
 build:android_env --build_tag_filters=-noandroid
-build:android_env --experimental_enable_android_migration_apis
-build:android_env --experimental_google_legacy_api
 test:android_env  --test_tag_filters=-noandroid


### PR DESCRIPTION
## Description
This commit removes the following bazel options that were originally 699c2ce5b7d92476199e9a6ba1d83414c3558016 to support bzlmod for Android (#1002).

 - `experimental_enable_android_migration_apis`
 - `experimental_google_legacy_api`

As far as we can see with Bazel 7.4.0, building Mozc with Bazel just succeeds without the above two options in all the supported platforms.

Closes #1117.

## Issue IDs

 * https://github.com/google/mozc/issues/1117

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Make sure that all the GitHub Actions succeed with this commit.
