### PR TITLE
Always build Qt host tools for the host CPU architecture in `build_qt.py` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ MODULE.bazel.lock
 # third_party dirs and cache dir checked out by update_deps.py
 /src/third_party/ninja/
 /src/third_party/qt/
+/src/third_party/qt_host/
 /src/third_party/qt_src/
 /src/third_party/wix/
 /src/third_party_cache/


### PR DESCRIPTION
## Description
Starting from Qt 6.8.0 it seems that Qt host tools need to be specified via `QT_HOST_PATH` when running configure when cross compiling. To adopt such a requirement, Qt6 will be built as follows with this commit.

 1. Build Qt host tools first with statically linking to Qt libraries.
 2. Build Qt for the target architecture with the above bootstrapping Qt host tools.
 3. Copy Qt host tools into `third_party/qt/`

Note that the above approach is not limited to macOS. In practice we can now build Qt6 for non-host CPU architecture even on Windows.

There must be no behavior change in the final artifacts.

Closes #1121.

## Issue IDs

 * https://github.com/google/mozc/issues/1121

## Steps to test new behaviors (if any)
 - OS: Windows 11 23H2 ARM64 environment
 - Steps:
   1. Checkout Mozc
   2. `python .\build_tools\update_deps.py`
   3. `python build_tools/build_qt.py --release --confirm_license`

## Additional context
Add any other context about the pull request here.
