### PR TITLE
Clarify Bazel 8.0 is not yet supported

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: build
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel build --config oss_android package --config release_build
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: bazel build
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel build --config oss_linux package --config release_build
 
@@ -64,5 +66,7 @@ jobs:
 
       - name: bazel test
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel test ... --config oss_linux --build_tests_only -c dbg

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: bazel build
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel build --config oss_macos package --macos_cpus=arm64 --config release_build
 
@@ -103,6 +105,8 @@ jobs:
 
       - name: bazel build
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel build --config oss_macos package --macos_cpus=x86_64 --config release_build
 
@@ -152,6 +156,8 @@ jobs:
 
       - name: bazel build
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel build --config oss_macos package --macos_cpus=x86_64,arm64 --config release_build
 
@@ -201,6 +207,8 @@ jobs:
 
       - name: bazel test
         working-directory: ./src
+        env:
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel test ... --config oss_macos --build_tests_only -c dbg
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -122,6 +122,7 @@ jobs:
         working-directory: .\src
         env:
           ANDROID_NDK_HOME: ""
+          USE_BAZEL_VERSION: "7.4.1"
         run: |
           bazel --bazelrc=windows.bazelrc build --config oss_windows --config release_build package
 

--- a/docker/ubuntu22.04/Dockerfile
+++ b/docker/ubuntu22.04/Dockerfile
@@ -64,6 +64,8 @@ ENV PKG_CONFIG_PATH="/home/mozc_builder/work/mozc/docker/ubuntu22.04/qt6-core-pk
 RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.22.0/bazelisk-linux-amd64 \
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazel \
   && chmod u+x /home/mozc_builder/bin/bazel
+### TODO(https://github.com/google/mozc/issues/1118): Support Bazel 8.0
+ENV USE_BAZEL_VERSION 7.4.1
 
 ## Set up Android SDK and NDK
 ENV ANDROID_HOME /home/mozc_builder/Android/Sdk

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -58,6 +58,8 @@ WORKDIR /home/mozc_builder/work
 RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.22.0/bazelisk-linux-amd64 \
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazel \
   && chmod u+x /home/mozc_builder/bin/bazel
+### TODO(https://github.com/google/mozc/issues/1118): Support Bazel 8.0
+ENV USE_BAZEL_VERSION 7.4.1
 
 ## Set up Android SDK and NDK
 ENV ANDROID_HOME /home/mozc_builder/Android/Sdk

--- a/docs/build_mozc_in_osx.md
+++ b/docs/build_mozc_in_osx.md
@@ -50,6 +50,7 @@ Building on Mac requires the following software.
   * Xcode 13 (macOS 13 SDK) or later
   * ⚠️Xcode Command Line Tools aren't sufficient.
 * [Bazel](https://docs.bazel.build/versions/master/install-os-x.html) for Bazel build
+  * ⚠️ Bazel 8.x is not yet supported ([#1118](https://github.com/google/mozc/issues/1118))
 * Python 3.9 or later with the following pip module.
   * `requests`
 * CMake 3.18.4 or later (to build Qt6)

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -167,6 +167,7 @@ Note that you can specify `--qtdir=` option instead of `--noqt` in GYP phase sin
 Additional requirements:
 
 * [Bazel](https://bazel.build/)
+  * ⚠️ Bazel 8.x is not yet supported ([#1118](https://github.com/google/mozc/issues/1118))
 * [MSYS2](https://github.com/msys2/msys2)
 
 After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run the following command instead of `build_mozc.py`:

--- a/src/.bazelversion
+++ b/src/.bazelversion
@@ -1,5 +1,5 @@
 
-7.3.0
+7.4.1
 # The first liine is intentionally empty to allow any Bazel versions.
-# We have checked the build and tests with Bazel 7.3.0.
+# We have checked the build and tests with Bazel 7.4.1.
 # Remove the first line and use Bazelisk to use the confirmed version.


### PR DESCRIPTION
## Description
As Mozc is not compatible with Bazel 8.0 yet, let's

 * pin Bazel version to Bazel 7.4.1 in GitHub Actions.
 * clarify that Bazel 8.0 is not supported in the build instructions.

## Issue IDs
 * https://github.com/google/mozc/issues/1118

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: All
 - Steps:
   1. Builds on GitHub Actions still succeed