### PR TITLE
Remove unused entries from `common_win.gypi`

### DIFF
--- a/src/gyp/common_win.gypi
+++ b/src/gyp/common_win.gypi
@@ -43,11 +43,6 @@
     # Visual C++ Runtime Version.
     'vcruntime_ver%': '',
 
-    # Extra headers and libraries for Visual C++.
-    'msvs_includes%': [],
-    'msvs_libs_x86%': [],
-    'msvs_libs_x64%': [],
-
     'conditions': [
       # https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
       ['MSVS_VERSION=="2015"', {
@@ -131,24 +126,10 @@
               '/bigobj',
             ],
           },
-          'VCLibrarianTool': {
-            'AdditionalLibraryDirectories': [
-              '<@(msvs_libs_x86)',
-            ],
-            'AdditionalLibraryDirectories!': [
-              '<@(msvs_libs_x64)',
-            ],
-          },
           'VCLinkerTool': {
             'TargetMachine': '<(win_target_machine_x86)',
             'AdditionalOptions': [
               '/SAFESEH',
-            ],
-            'AdditionalLibraryDirectories': [
-              '<@(msvs_libs_x86)',
-            ],
-            'AdditionalLibraryDirectories!': [
-              '<@(msvs_libs_x64)',
             ],
             'EnableUAC': 'true',
             'UACExecutionLevel': '0',  # level="asInvoker"
@@ -175,22 +156,8 @@
               '/bigobj',
             ],
           },
-          'VCLibrarianTool': {
-            'AdditionalLibraryDirectories': [
-              '<@(msvs_libs_x64)',
-            ],
-            'AdditionalLibraryDirectories!': [
-              '<@(msvs_libs_x86)',
-            ],
-          },
           'VCLinkerTool': {
             'TargetMachine': '<(win_target_machine_x64)',
-            'AdditionalLibraryDirectories': [
-              '<@(msvs_libs_x64)',
-            ],
-            'AdditionalLibraryDirectories!': [
-              '<@(msvs_libs_x86)',
-            ],
           },
         },
       },
@@ -332,7 +299,6 @@
       '<@(absl_include_dirs)',
       '<(abs_depth)',
       '<(SHARED_INTERMEDIATE_DIR)',
-      '<@(msvs_includes)',
       '<(third_party_dir)/wil/include',
     ],
     'msvs_configuration_attributes': {


### PR DESCRIPTION
## Description
This is a trivial code cleanup commit to remove unused entries from `common_win.gypi`.

There must be no behavior change in the final artifacts.

## Issue IDs

 * N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 23H2
 - Steps:
   1. You can still build Mozc for Windows with GYP
