### PR TITLE
Disallow Mozc to be installed on ARM64 Windows

### DIFF
--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -63,6 +63,11 @@
     <Launch Condition="Privileged" Message="Google 日本語入力をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="GoogleJapaneseInput.cab" EmbedCab="yes" CompressionLevel="high" />
 
+    <Property Id="PROCESSOR_ARCHITECTURE">
+      <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
+    </Property>
+    <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です。" />
+
     <!-- Set Add/Remove Program Icon -->
     <Icon Id="add_remove_program_icon.ico" SourceFile="$(var.AddRemoveProgramIconPath)" />
     <Property Id="ARPPRODUCTICON" Value="add_remove_program_icon.ico" />

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -64,6 +64,11 @@
     <Launch Condition="Privileged" Message="Mozc をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="Mozc.cab" EmbedCab="yes" CompressionLevel="high" />
 
+    <Property Id="PROCESSOR_ARCHITECTURE">
+      <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
+    </Property>
+    <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />
+
     <!-- Set Add/Remove Program Icon -->
     <Icon Id="add_remove_program_icon.ico" SourceFile="$(var.AddRemoveProgramIconPath)" />
     <Property Id="ARPPRODUCTICON" Value="add_remove_program_icon.ico" />


### PR DESCRIPTION
## Description
Before Mozc becomes available to ARM64 processes in Windows, let's disallow `Mozc64.msi` to be installed into ARM64 Windows machines to avoid unnecessary user confusions.

Note that this commit only blocks the initial installation. There is no behavior change for those who have already installed Mozc into their ARM64 Windows environments. This means that both the following operations continue to be allowed.

 * Upgrading from a previous version of Mozc on an ARM64 Windows environment
 * Uninstalling Mozc on an ARM64 Windows environment

Closes #1127.

## Issue IDs

 * https://github.com/google/mozc/issues/1127

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 23H2
 - Steps:
   1. Try to install `Mozc64.msi`
   2. It fails with a dialog message with "ARM64 環境へのインストールは未対応です。"
