### PR TITLE
Clarify '/CETCOMPAT' is compatible only with x86/x64

### DIFF
--- a/src/gyp/common_win.gypi
+++ b/src/gyp/common_win.gypi
@@ -135,6 +135,9 @@
             'UACExecutionLevel': '0',  # level="asInvoker"
             'UACUIAccess': 'false',    # uiAccess="false"
             'MinimumRequiredVersion': '10.0',
+            'AdditionalOptions': [
+              '/CETCOMPAT',
+            ],
           },
         },
         'msvs_configuration_attributes': {
@@ -158,6 +161,9 @@
           },
           'VCLinkerTool': {
             'TargetMachine': '<(win_target_machine_x64)',
+            'AdditionalOptions': [
+              '/CETCOMPAT',
+            ],
           },
         },
       },
@@ -337,9 +343,6 @@
           'shell32.lib',
           'user32.lib',
           'uuid.lib',
-        ],
-        'AdditionalOptions': [
-          '/CETCOMPAT',
         ],
         'DataExecutionPrevention': '2',        # /NXCOMPAT
         'EnableCOMDATFolding': '2',            # /OPT:ICF


### PR DESCRIPTION
## Description
This follows up to my previous commit (a0133fb07859f9428740e253adcbc606852570f0) for #835.

As a preparation to build Mozc executables for ARM64 (#1130) let's specify it in 'x86_Base' and 'x64_Base' instead of globally defining it, because `/CETCOMPAT` is not compatible with ARM64 builds.

There must be no change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/835
 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 23H2
 - Steps:
   1. Build and install `Mozc64.msi`
   2. `dumpbin /HEADERS "C:\Program Files (x86)\Mozc\mozc_tip32.dll" | findstr "CET compatible"` 
   3. `dumpbin /HEADERS "C:\Program Files (x86)\Mozc\mozc_tip64.dll" | findstr "CET compatible"` 
   4. Confirm `CET compatible` is found.
