### PR TITLE
Build `mozc_tip64.dll` for ARM64 with GYP

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -38,6 +38,12 @@ Building Mozc on Windows requires the following software.
 
   * [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/downloads/#visual-studio-community-2022)
     * [Build Tools for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) should also work
+    * Make sure that the following components are installed.
+      * `Microsoft.VisualStudio.Component.VC.Redist.14.Latest`
+      * `Microsoft.VisualStudio.Component.VC.ATL`
+      * `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`
+      * `Microsoft.VisualStudio.Component.VC.ATL.ARM64`
+      * `Microsoft.VisualStudio.Component.VC.Tools.ARM64`
   * Python 3.9 or later with the following pip modules.
     * `six`
     * `requests`

--- a/src/build_tools/protoc_wrapper.py
+++ b/src/build_tools/protoc_wrapper.py
@@ -85,6 +85,12 @@ def main():
   protoc_path = opts.protoc_command
   if opts.protoc_dir:
     protoc_path = os.path.join(os.path.abspath(opts.protoc_dir), protoc_path)
+    # A hack for ARM64 build with GYP on Windows.
+    #   https://github.com/google/mozc/issues/1130
+    # ARM64 version of protoc.exe does not work on x64 machine, so use x64
+    # version with an assumption that it's already built.
+    if os.name == 'nt' and protoc_path.endswith('_arm64\\protoc.exe'):
+      protoc_path = protoc_path.replace('_arm64\\protoc', '_x64\\protoc')
 
   # The path of proto file should be transformed as a relative path from
   # the project root so that correct relative paths should be embedded into

--- a/src/gyp/common_win.gypi
+++ b/src/gyp/common_win.gypi
@@ -167,6 +167,27 @@
           },
         },
       },
+      'arm64_Base': {
+        'abstract': 1,
+        'msvs_configuration_attributes': {
+          'OutputDirectory': '<(build_base)/$(ConfigurationName)_arm64',
+          'IntermediateDirectory': '<(build_base)/$(ConfigurationName)_arm64/obj/$(ProjectName)',
+        },
+        'msvs_target_platform': 'arm64',
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'AdditionalOptions': [
+              '/bigobj',
+            ],
+          },
+          'VCLinkerTool': {
+            'ImageHasSafeExceptionHandlers': 'false',
+            'AdditionalOptions': [
+              '/MACHINE:ARM64',
+            ],
+          },
+        },
+      },
       'Win_Static_Debug_CRT_Base': {
         'abstract': 1,
         'msvs_settings': {
@@ -275,6 +296,12 @@
       },
       'Release_x64': {
         'inherit_from': ['x64_Base', 'Release_Base', 'Win_Static_Release_CRT_Base'],
+      },
+      'Debug_arm64': {
+        'inherit_from': ['arm64_Base', 'Debug_Base', 'Win_Static_Debug_CRT_Base'],
+      },
+      'Release_arm64': {
+        'inherit_from': ['arm64_Base', 'Release_Base', 'Win_Static_Release_CRT_Base'],
       },
     },
     'default_configuration': 'Debug',


### PR DESCRIPTION
## Description
As a preparation to build Mozc for ARM64 in Windows (#1130), this commit demonstrates that it is technically possible for us to build `mozc_tip64.dll` as an ARM64 DLL with GYP even though GYP itself does not officially support it.

With this commit you need to install the following additional Visual Studio components even when you do not build Mozc for ARM64 Windows.

  * `Microsoft.VisualStudio.Component.VC.Redist.14.Latest`
  * `Microsoft.VisualStudio.Component.VC.ATL`
  * `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`
  * `Microsoft.VisualStudio.Component.VC.ATL.ARM64`
  * `Microsoft.VisualStudio.Component.VC.Tools.ARM64`

Note that `mozc_tip64.dll` for ARM64 will be built only when explicitly specified in `build_mozc.py build`. There must be no change in the final artifacts when just building the installer package.

Note also that we still need to build ARM64X DLL to actually support ARM64 Windows environment.

## Issue IDs

 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
  1. `python build_mozc.py gyp`
  2. `python build_mozc.py build out_win/Release_x64:mozc_tip64`
  3. `python build_mozc.py build out_win/Release_arm64:mozc_tip64`
  4. `dumpbin /headers out_win/Release_x64/mozc_tip64.dll | findstr machine`
  5. `dumpbin /headers out_win/Release_arm64/mozc_tip64.dll | findstr machine`
  6. Confirm `8664 machine (x64)` is shown at the step 4 and `AA64 machine (ARM64)` is shown at the step 5.

