### PR TITLE
Remove `rules_java` from `MODULE.bazel`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -65,13 +65,6 @@ bazel_dep(
     repo_name = "build_bazel_apple_support",
 )
 
-# Java rules (7.9.0 2024-08-13)
-# https://github.com/bazelbuild/rules_java
-bazel_dep(
-    name = "rules_java",
-    version = "7.9.0",
-)
-
 # Android NDK rules (0.1.2 2024-07-23)
 # https://github.com/bazelbuild/rules_android_ndk
 bazel_dep(


### PR DESCRIPTION
## Description
This follows up to our previous commit (699c2ce5b7d92476199e9a6ba1d83414c3558016), which introduced the dependency on `rules_java` as an attempt to support Android build with bzlmod (#1002).

Luckily a subsequent commit (6c61c4f29a966264784d608584000a56596f3ed9) had effectively removed the the dependency on `rules_java`, but `MODULE.bazel` has not been reflected yet. Let's also update `MODULE.bazel` for simplicity and maintainability.

There must be no difference in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1002
