### PR TITLE
Add bazel 8 support to pkg_config_repository() (#1118)

### DIFF
--- a/src/bazel/pkg_config_repository.bzl
+++ b/src/bazel/pkg_config_repository.bzl
@@ -75,7 +75,7 @@ cc_library(
 """
 
 EXPORTS_FILES_TEMPLATE = """
-exports_files(glob(["libexec/*"]))
+exports_files(glob(["libexec/*"], allow_empty=True))
 """
 
 def _exec_pkg_config(repo_ctx, flags):


### PR DESCRIPTION
bazel 8 set --incompatible_disallow_empty_glob default to True. For
pkg-confg repository, libexec is likely to be empty, so empty should be
allowed there.
