### PR TITLE
bzlmod: Update `rules_apple` to 3.16.1

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -49,12 +49,11 @@ bazel_dep(
     version = "0.34.0",
 )
 
-# Bazel macOS build (3.5.1 2024-04-09)
-# Note, versions after 3.5.1 result a build failure of universal binary.
+# Bazel macOS build (3.16.1 2024-12-13)
 # https://github.com/bazelbuild/rules_apple
 bazel_dep(
     name = "rules_apple",
-    version = "3.5.1",
+    version = "3.16.1",
     repo_name = "build_bazel_rules_apple",
 )
 


### PR DESCRIPTION
## Description
This follows up to our previous commit (c1e9f8b19aa5ecf51d643e3c338bc997988d7909), which downgraded `rules_apple` from 3.8.0 to 3.5.1 to work around bazelbuild/rules_apple#2516, which was fixed in [3.9.0](https://github.com/bazelbuild/rules_apple/releases/tag/3.9.0) and later.

Now that Bazel 8.0 RC3+ requires `rules_apple` [3.16.0](https://github.com/bazelbuild/rules_apple/releases/tag/3.16.0) and later , let's update it to the latest one, which is [3.16.1](https://github.com/bazelbuild/rules_apple/releases/tag/3.16.1).

No difference is expected in the final artifacts.

Closes #1145.

## Issue IDs

* https://github.com/google/mozc/issues/1145

## Steps to test new behaviors (if any)
 - OS: macOS
 - Steps:
   1. Confirm you can still build Mozc with Bazel
