### PR TITLE
bzlmod: Update `rules_python` to 1.0.0

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -42,11 +42,11 @@ bazel_dep(
     version = "1.7.1",
 )
 
-# rules_python: 0.34.0 2024-07-01
+# rules_python: 1.0.0 2024-12-06
 # https://github.com/bazelbuild/rules_python/
 bazel_dep(
     name = "rules_python",
-    version = "0.34.0",
+    version = "1.0.0",
 )
 
 # Bazel macOS build (3.16.1 2024-12-13)


### PR DESCRIPTION
## Description
This is just a mechanical update of `rules_python` from 0.34.0 to 1.0.0. No change is expected in the final artifacts.

Closes #1148.

## Issue IDs

 * https://github.com/google/mozc/issues/1148

## Steps to test new behaviors (if any)
 - OS: GitHub Actions
 - Steps:
   1. Confirm you can still build Mozc with Bazel.
