### PR TITLE
Patch `rules_android_ndk` to make it compatible with '--incompatible_disallow_empty_glob'

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -72,7 +72,17 @@ bazel_dep(
 )
 single_version_override(
     module_name = "rules_android_ndk",
-    patches = ["bazel/rules_android_ndk.patch"],
+    # Bazel's built-in patch engine cannot deal with a patch file that affects
+    # multiple files. This is why we have two separate patch files here.
+    # https://github.com/bazelbuild/bazel/issues/10267
+    patches = [
+        # Look like this should have been included in the following PR.
+        # https://github.com/bazelbuild/rules_android_ndk/pull/37
+        "bazel/rules_android_ndk.allow_empty_glob.patch",
+        # Might be removed after the folloing PR.
+        # https://github.com/bazelbuild/rules_android_ndk/pull/63
+        "bazel/rules_android_ndk.patch",
+    ],
     version = "0.1.2",
 )
 

--- a/src/bazel/rules_android_ndk.allow_empty_glob.patch
+++ b/src/bazel/rules_android_ndk.allow_empty_glob.patch
@@ -1,0 +1,11 @@
+--- BUILD.ndk_clang.tpl
++++ BUILD.ndk_clang.tpl
+@@ -49,7 +49,7 @@
+       "bin/*",
+       "lib64/**/*",
+       "lib/**/*",
+-    ]),
++    ], allow_empty = True),
+ )
+
+ filegroup(


### PR DESCRIPTION
## Description
There was an attempt to make `rules_android_ndk` compatible with `--incompatible_disallow_empty_glob`, but it seems that it was not complete.

 * https://github.com/bazelbuild/rules_android_ndk/pull/37

Let's work around this in the Mozc side for now.

There must be no behavior change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1150

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Ubuntu 24.04.1
 - Steps:
   1. `bazel build --config oss_linux package --config release_build --incompatible_disallow_empty_glob package`
   2. Confirm the build succeeds.
