### PR TITLE
Switch to Bazel 8.0.0

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: build
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel build --config oss_android package --config release_build
 

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: bazel build
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel build --config oss_linux package --config release_build
 
@@ -67,6 +67,6 @@ jobs:
       - name: bazel test
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel test ... --config oss_linux --build_tests_only -c dbg

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: bazel build
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel build --config oss_macos package --macos_cpus=arm64 --config release_build
 
@@ -106,7 +106,7 @@ jobs:
       - name: bazel build
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel build --config oss_macos package --macos_cpus=x86_64 --config release_build
 
@@ -157,7 +157,7 @@ jobs:
       - name: bazel build
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel build --config oss_macos package --macos_cpus=x86_64,arm64 --config release_build
 
@@ -208,7 +208,7 @@ jobs:
       - name: bazel test
         working-directory: ./src
         env:
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel test ... --config oss_macos --build_tests_only -c dbg
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -122,7 +122,7 @@ jobs:
         working-directory: .\src
         env:
           ANDROID_NDK_HOME: ""
-          USE_BAZEL_VERSION: "7.4.1"
+          USE_BAZEL_VERSION: "8.0.0"
         run: |
           bazel --bazelrc=windows.bazelrc build --config oss_windows --config release_build package
 

--- a/docker/ubuntu22.04/Dockerfile
+++ b/docker/ubuntu22.04/Dockerfile
@@ -61,11 +61,10 @@ WORKDIR /home/mozc_builder/work
 ENV PKG_CONFIG_PATH="/home/mozc_builder/work/mozc/docker/ubuntu22.04/qt6-core-pkgconfig:${PKG_CONFIG_PATH}"
 
 ## Set up bazelisk as bazel
-RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.22.0/bazelisk-linux-amd64 \
+RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 \
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazel \
   && chmod u+x /home/mozc_builder/bin/bazel
-### TODO(https://github.com/google/mozc/issues/1118): Support Bazel 8.0
-ENV USE_BAZEL_VERSION 7.4.1
+ENV USE_BAZEL_VERSION 8.0.0
 
 ## Set up Android SDK and NDK
 ENV ANDROID_HOME /home/mozc_builder/Android/Sdk

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -55,11 +55,10 @@ RUN mkdir -p /home/mozc_builder/work
 WORKDIR /home/mozc_builder/work
 
 ## Set up bazelisk as bazel
-RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.22.0/bazelisk-linux-amd64 \
+RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 \
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazel \
   && chmod u+x /home/mozc_builder/bin/bazel
-### TODO(https://github.com/google/mozc/issues/1118): Support Bazel 8.0
-ENV USE_BAZEL_VERSION 7.4.1
+ENV USE_BAZEL_VERSION 8.0.0
 
 ## Set up Android SDK and NDK
 ENV ANDROID_HOME /home/mozc_builder/Android/Sdk

--- a/docs/build_mozc_in_osx.md
+++ b/docs/build_mozc_in_osx.md
@@ -50,7 +50,7 @@ Building on Mac requires the following software.
   * Xcode 13 (macOS 13 SDK) or later
   * ⚠️Xcode Command Line Tools aren't sufficient.
 * [Bazel](https://docs.bazel.build/versions/master/install-os-x.html) for Bazel build
-  * ⚠️ Bazel 8.x is not yet supported ([#1118](https://github.com/google/mozc/issues/1118))
+  * check [src/.bazelversion](../src/.bazelversion) for the supported Bazel version.
 * Python 3.9 or later with the following pip module.
   * `requests`
 * CMake 3.18.4 or later (to build Qt6)

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -167,7 +167,7 @@ Note that you can specify `--qtdir=` option instead of `--noqt` in GYP phase sin
 Additional requirements:
 
 * [Bazel](https://bazel.build/)
-  * ⚠️ Bazel 8.x is not yet supported ([#1118](https://github.com/google/mozc/issues/1118))
+  * check [src/.bazelversion](../src/.bazelversion) for the supported Bazel version.
 * [MSYS2](https://github.com/msys2/msys2)
 
 After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run the following command instead of `build_mozc.py`:

--- a/src/.bazelversion
+++ b/src/.bazelversion
@@ -1,5 +1,5 @@
 
-7.4.1
+8.0.0
 # The first liine is intentionally empty to allow any Bazel versions.
-# We have checked the build and tests with Bazel 7.4.1.
+# We have checked the build and tests with Bazel 8.0.0.
 # Remove the first line and use Bazelisk to use the confirmed version.


### PR DESCRIPTION
## Description
With this commit we fully switch to Bazel 8.0.0 as the officially supported build environment for Mozc.

Closes #1118.

## Issue IDs

 * https://github.com/google/mozc/issues/1118

## Steps to test new behaviors (if any)
 - OS: All GitHub Action
 - Steps:
   1. Confirm that all the Bazel builds succeed.

