### PR TITLE
Rely on CC toolchain resolution on Windows Bazel builds

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -56,11 +56,17 @@ test:macos_env   --test_tag_filters=-nomac
 build:windows_env --build_tag_filters=-nowin
 test:windows_env   --test_tag_filters=-nowin
 
-# A temporary workaround to make "mozc_win_build_rule" work.
-# Note that "incompatible_enable_cc_toolchain_resolution" is now enabled by
-# default. See https://github.com/bazelbuild/bazel/issues/7260
-# TODO: Re-enable "incompatible_enable_cc_toolchain_resolution"
-build:windows_env --noincompatible_enable_cc_toolchain_resolution
+# Bazel does not register cc toolchains for Windows by default.
+# We need to explicitly specify them to be compatible with the new behavior
+# introduced by --incompatible_enable_cc_toolchain_resolution
+# https://github.com/google/mozc/issues/1112
+# https://bazel.build/extending/toolchains#registering-building-toolchains
+build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-arm64_windows
+build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_windows
+build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_x86_windows
+test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-arm64_windows
+test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_windows
+test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_x86_windows
 
 # Android specific options
 build:android_env --copt "-DOS_ANDROID"

--- a/src/gui/tool/BUILD.bazel
+++ b/src/gui/tool/BUILD.bazel
@@ -135,7 +135,7 @@ mozc_cc_qt_binary(
 
 mozc_win32_cc_prod_binary(
     name = "mozc_tool_win",
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_tool.exe",
         "GoogleJapaneseInput": "GoogleIMEJaTool.exe",

--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -48,7 +48,7 @@ package(
 mozc_win32_cc_prod_binary(
     name = "win32_renderer_main",
     srcs = ["win32_renderer_main.cc"],
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_renderer.exe",
         "GoogleJapaneseInput": "GoogleIMEJaRenderer.exe",

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -59,7 +59,7 @@ mozc_cc_binary(
 
 mozc_win32_cc_prod_binary(
     name = "mozc_server_win",
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_server.exe",
         "GoogleJapaneseInput": "GoogleIMEJaConverter.exe",

--- a/src/win32/broker/BUILD.bazel
+++ b/src/win32/broker/BUILD.bazel
@@ -44,7 +44,7 @@ package(
 mozc_win32_cc_prod_binary(
     name = "mozc_broker_main",
     srcs = ["mozc_broker_main.cc"],
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_broker.exe",
         "GoogleJapaneseInput": "GoogleIMEJaBroker.exe",

--- a/src/win32/cache_service/BUILD.bazel
+++ b/src/win32/cache_service/BUILD.bazel
@@ -45,7 +45,7 @@ package(default_visibility = ["//:__subpackages__"])
 mozc_win32_cc_prod_binary(
     name = "mozc_cache_service",
     srcs = ["mozc_cache_service.cc"],
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_cache_service.exe",
         "GoogleJapaneseInput": "GoogleIMEJaCacheService.exe",

--- a/src/win32/custom_action/BUILD.bazel
+++ b/src/win32/custom_action/BUILD.bazel
@@ -41,7 +41,7 @@ mozc_win32_cc_prod_binary(
         "custom_action.h",
         "resource.h",
     ],
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_installer_helper.dll",
         "GoogleJapaneseInput": "GoogleIMEJaInstallerHelper.dll",

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -68,7 +68,7 @@ mozc_cc_library(
 mozc_win32_cc_prod_binary(
     name = "mozc_tip32",
     srcs = ["mozc_tip_main.cc"],
-    cpu = "x64_x86_windows",
+    cpu = "@platforms//cpu:x86_32",
     executable_name_map = {
         "Mozc": "mozc_tip32.dll",
         "GoogleJapaneseInput": "GoogleIMEJaTIP32.dll",
@@ -87,7 +87,7 @@ mozc_win32_cc_prod_binary(
 mozc_win32_cc_prod_binary(
     name = "mozc_tip64",
     srcs = ["mozc_tip_main.cc"],
-    cpu = "x64_windows",
+    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_tip64.dll",
         "GoogleJapaneseInput": "GoogleIMEJaTIP64.dll",


### PR DESCRIPTION
## Description
This is a follow up commit to my previous commit (6dadef1c3d456649f8fbe48b6ee1f1515367b5e1), which updated the Bazel version from 7.4.1 to 8.0.0.

 * https://github.com/google/mozc/issues/1118

It turns out that `--noincompatible_enable_cc_toolchain_resolution` is now no-op in Bazel 8.0. Thus there remains no way other than fully migrating to the new CC toolchain resolution as planned.

 * https://github.com/google/mozc/issues/1112

Otherwise `mozc_tip32.dll` will be built as a 64-bit executable.

 * https://github.com/google/mozc/issues/1102

This commit consists of two parts:

 1. explicitly register CC toolchains in `.bazelrc`.
 2. Switch from `--cpu` commandline option to `--platforms` commandline option in `_win_executable_transition`.

With above 'mozc_tip32.dll' will be built as a 32-bit executable again.

Closes #1102.
Closes #1112.

## Issue IDs

 * https://github.com/google/mozc/issues/1102
 * https://github.com/google/mozc/issues/1112

## Steps to test new behaviors (if any)
 - OS: Windows 11
 - Steps:
   1. Build `Mozc64.msi` with Bazel
   2. Install `Mozc64.msi`
   3. `dumpbin /headers "C:\Program Files (x86)\Mozc\mozc_tip32.dll" | findstr machine`
   4. Confirm `14C machine (x86)` is shown.
