### PR TITLE
Register CC toolchain from `rules_cc`

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -56,18 +56,6 @@ test:macos_env   --test_tag_filters=-nomac
 build:windows_env --build_tag_filters=-nowin
 test:windows_env   --test_tag_filters=-nowin
 
-# Bazel does not register cc toolchains for Windows by default.
-# We need to explicitly specify them to be compatible with the new behavior
-# introduced by --incompatible_enable_cc_toolchain_resolution
-# https://github.com/google/mozc/issues/1112
-# https://bazel.build/extending/toolchains#registering-building-toolchains
-build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-arm64_windows
-build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_windows
-build:windows_env --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_x86_windows
-test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-arm64_windows
-test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_windows
-test:windows_env  --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc//:cc-toolchain-x64_x86_windows
-
 # Android specific options
 build:android_env --copt "-DOS_ANDROID"
 build:android_env --build_tag_filters=-noandroid

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -66,11 +66,28 @@ bazel_dep(
 )
 
 # Apple Support for Bazel (1.16.0 2024-07-10)
+## this must come above 'rules_cc'
+## https://github.com/bazelbuild/apple_support/blob/d87e8b07f3345e750834dbb6ce38c7c7d3b8b44b/README.md#bazel-7-setup
 bazel_dep(
     name = "apple_support",
     version = "1.16.0",
     repo_name = "build_bazel_apple_support",
 )
+
+# rules_cc: 0.0.17 2024-11-19
+# https://github.com/bazelbuild/rules_cc/
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.17",
+)
+
+cc_configure = use_extension(
+    "@rules_cc//cc:extensions.bzl",
+    "cc_configure_extension",
+)
+use_repo(cc_configure, "local_config_cc")
+
+register_toolchains("@local_config_cc//:all")
 
 # Android NDK rules (0.1.2 2024-07-23)
 # https://github.com/bazelbuild/rules_android_ndk


### PR DESCRIPTION
## Description
This reworks my previous PR #1156 that was to make Windows bazel build compatible with

  `--noincompatible_enable_cc_toolchain_resolution`

option, which is now unconditionally enabled (#1102) (#1112).

The difference from the previous approach is that this commit uses CC toolchains defined by `rules_cc` rather than the ones implicitly defined by the Bazel itself.

Given that `rules_cc` becomes the new home of CC-related rules and configurations, hopefully this change will reduce the likelihood of future troubles.

There must be no observable behavior change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/pull/1156
 * https://github.com/google/mozc/issues/1102
 * https://github.com/google/mozc/issues/1112

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build `Mozc64.msi` with Bazel
   2. Install `Mozc64.msi`
   3. `dumpbin /headers "C:\Program Files (x86)\Mozc\mozc_tip32.dll" | findstr machine`
   4. Confirm `14C machine (x86)` is shown.
