### PR TITLE
Specify `/CETCOMPAT` in Bazel Windows build

### DIFF
--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -340,6 +340,11 @@ def mozc_win32_cc_prod_binary(
         "/DEBUG:FULL",
         "/PDBALTPATH:%_PDB%",
     ])
+
+    # '/CETCOMPAT' is available only on x86/x64 architectures.
+    if cpu in ["@platforms//cpu:x86_32", "@platforms//cpu:x86_64"]:
+        modified_linkopts.append("/CETCOMPAT")
+
     mozc_cc_binary(
         name = intermediate_name,
         srcs = srcs,


### PR DESCRIPTION
## Description
Win32 x64/x86 executables built with GYP are already declared to be Intel CET compatible (#835).

With this commit those executables built with Bazel also become Intel CET compatible.

Closes #1113.

## Issue IDs

 * https://github.com/google/mozc/issues/835
 * https://github.com/google/mozc/issues/1113

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build `Mozc64.msi` with Bazel.
   2. Install `Mozc64.msi`
   3. `dumpbin /HEADERS mozc_tip64.dll | findstr compatible` -> Confirm `CET compatible`
   4. `dumpbin /HEADERS mozc_server.exe | findstr compatible` -> Confirm `CET compatible`

