### PR TITLE
Set `/DEPENDENTLOADFLAG` in Bazel Windows build

### DIFF
--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -345,6 +345,16 @@ def mozc_win32_cc_prod_binary(
     if cpu in ["@platforms//cpu:x86_32", "@platforms//cpu:x86_64"]:
         modified_linkopts.append("/CETCOMPAT")
 
+    LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x200
+    LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x800
+    load_flags = LOAD_LIBRARY_SEARCH_SYSTEM32
+    if not linkshared:
+        # We build *.exe with dynamic CRT and deploy CRT DLLs into the
+        # application dir. Thus LOAD_LIBRARY_SEARCH_APPLICATION_DIR is also
+        # necessary.
+        load_flags += LOAD_LIBRARY_SEARCH_APPLICATION_DIR
+    modified_linkopts.append("/DEPENDENTLOADFLAG:0x%X" % load_flags)
+
     mozc_cc_binary(
         name = intermediate_name,
         srcs = srcs,


### PR DESCRIPTION
## Description
This mirrors my previous commit (18d1bcaab499695004c3520133c4d9d4ee2d6bfd) for Windows GYP build so that Bazel build can also specify appropriate `/DEPENDENTLOADFLAG` options (#836).

Closes #1114.

## Issue IDs

 * https://github.com/google/mozc/issues/836
 * https://github.com/google/mozc/issues/1114

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build Mozc for Windows with Bazel.
   2. `dumpbin /LOADCONFIG mozc_server.exe | findstr /c:"Dependent Load Flag"` -> Confirm `0A00 Dependent Load Flag` is shown
   3. `dumpbin /LOADCONFIG mozc_tip64.dll | findstr /c:"Dependent Load Flag"` -> Confirm `0800 Dependent Load Flag` is shown

