### PR TITLE
Fixed problems related to date conversion function, etc.

### DIFF
--- a/src/engine/engine_converter_interface.h
+++ b/src/engine/engine_converter_interface.h
@@ -241,4 +241,4 @@ class EngineConverterInterface {
 }  // namespace engine
 }  // namespace mozc
 
-#endif  // MOZC_SESSION_SESSION_CONVERTER_INTERFACE_H_
+#endif  // MOZC_ENGINE_SESSION_CONVERTER_INTERFACE_H_

--- a/src/rewriter/rewriter.cc
+++ b/src/rewriter/rewriter.cc
@@ -103,9 +103,9 @@
 #include "rewriter/command_rewriter.h"
 #endif  // MOZC_COMMAND_REWRITER
 
-#ifdef MOZC_DATA_REWRITER
+#ifdef MOZC_DATE_REWRITER
 #include "rewriter/date_rewriter.h"
-#endif  // MOZC_DATA_REWRITER
+#endif  // MOZC_DATE_REWRITER
 
 #ifdef MOZC_FORTUNE_REWRITER
 #include "rewriter/fortune_rewriter.h"
@@ -161,13 +161,13 @@ Rewriter::Rewriter(const engine::Modules &modules) {
         std::make_unique<UserSegmentHistoryRewriter>(&pos_matcher, pos_group));
   }
 
-#ifdef MOZC_DATE_REWRITERS
+#ifdef MOZC_DATE_REWRITER
   AddRewriter(std::make_unique<DateRewriter>(dictionary));
-#endif  // MOZC_DATE_REWRITERS
+#endif  // MOZC_DATE_REWRITER
 
-#ifdef MOZC_FORTUNE_REWRITERS
+#ifdef MOZC_FORTUNE_REWRITER
   AddRewriter(std::make_unique<FortuneRewriter>());
-#endif  // MOZC_FORTUNE_REWRITERS
+#endif  // MOZC_FORTUNE_REWRITER
 
 #ifdef MOZC_COMMAND_REWRITER
   AddRewriter(std::make_unique<CommandRewriter>());


### PR DESCRIPTION
Fixed problems related to date conversion function, etc.
Resolved a minor issue where a recent typographical error temporarily disabled the date conversion function and other functions.

Fix typos
DATA => DATE
REWRITERS => REWRITER

MOZC_DATA_REWRITER => MOZC_DATE_REWRITER
MOZC_DATE_REWRITERS => MOZC_DATE_REWRITER
MOZC_FORTUNE_REWRITERS => MOZC_FORTUNE_REWRITER

related commit:
bd8f5e51dc7bdfc3c0d4a39e33c11d2bf4cda4e0

## Description
[A clear and concise description of this pull request.](https://github.com/google/mozc/issues/1171)

## Issue IDs
#1171

## Additional
Fixed an unmodified comment when moving SessionConverter from session/ to engine/.
related commit:
b39050e6b36f8d8b64729b5725feadcf561c070e
```
MOZC_SESSION_SESSION_CONVERTER_INTERFACE_H_ =>  MOZC_ENGINE_SESSION_CONVERTER_INTERFACE_H_
```
```sh
$(go env GOPATH)/bin/buildifier --mode=diff --diff_command="diff -u" -r .
```
There is no output.