### PR TITLE
PreeditHandler: update preedit string when it's empty

### DIFF
--- a/src/unix/ibus/preedit_handler.cc
+++ b/src/unix/ibus/preedit_handler.cc
@@ -109,6 +109,8 @@ int CursorPos(const commands::Output &output) {
 bool PreeditHandler::Update(IbusEngineWrapper *engine,
                             const commands::Output &output) {
   if (!output.has_preedit()) {
+    IbusTextWrapper empty_text("");
+    engine->UpdatePreeditTextWithMode(&empty_text, 0);
     engine->HidePreeditText();
     return true;
   }


### PR DESCRIPTION
See also https://bugreports.qt.io/browse/QTBUG-127995 , Deleted character appears again when switching languages (Mozc / IBus)

## Description
Deleted character appears again when switching languages (Mozc / IBus).

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: [Ubuntu 24.04 x11]
 - Steps:
   1. Japanese - Mozc, Heragana, a -> あ, for example, 3 times, then backspace 3 times
   2. Super+Space to switch to English, for example, the last あ was committed.
