### PR TITLE
Enable to build protobuf v30 with Bazel+MSVC

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -43,6 +43,9 @@ build:compiler_msvc_like --copt "/J" --host_copt "/J"
 build:compiler_msvc_like --copt "/utf-8" --host_copt "/utf-8"
 build:compiler_msvc_like --cxxopt "/J" --host_cxxopt "/J"
 build:compiler_msvc_like --cxxopt "/utf-8" --host_cxxopt "/utf-8"
+## See https://github.com/protocolbuffers/protobuf/issues/20085
+## This can be removed if we can switch to clang-cl for Windows
+build:compiler_msvc_like --define=protobuf_allow_msvc=true
 
 ## Linux specific options
 build:linux_env --build_tag_filters=-nolinux --copt "-fPIC"


### PR DESCRIPTION
## Description
As seen in the following thread, the protobuf team is planning to stop supporting the combination of Bazel and cl.exe due to well-known its path length limitation.

 * https://github.com/protocolbuffers/protobuf/issues/20085

As a preparation before switching to protobuf v30 (#1177), let's explicitly add a command line option as explained to continue using this combination as a short term solution.

This commit should have no impact on probobuf v29.x.

## Issue IDs

 * https://github.com/google/mozc/issues/1177
 * https://github.com/protocolbuffers/protobuf/issues/20085

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 24H2
 - Steps:
   1. Modify `MODULE.bazel` to use protobuf v30.rc1
   2. Apply this patch.
   3. Confirm you can still build Mozc for Windows with bazel.

## Additional context
Add any other context about the pull request here.
