### PR TITLE
Update `rules_android_ndk` patch so that missing Android NDK can be handled gracefully

### DIFF
--- a/src/bazel/rules_android_ndk.patch
+++ b/src/bazel/rules_android_ndk.patch
@@ -1,15 +1,21 @@
 --- rules.bzl
 +++ rules.bzl
-@@ -25,8 +25,10 @@
+@@ -23,13 +23,14 @@ def _android_ndk_repository_impl(ctx):
+     Returns:
+         A final dict of configuration attributes and values.
      """
-     ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
-     if not ndk_path:
+-    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
+-    if not ndk_path:
 -        fail("Either the ANDROID_NDK_HOME environment variable or the " +
 -             "path attribute of android_ndk_repository must be set.")
-+        print("Either the ANDROID_NDK_HOME environment variable or the " +
-+              "path attribute of android_ndk_repository must be set.")
-+        ctx.file("BUILD.bazel", "")
-+        return
++    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", "")
      if ndk_path.startswith("$WORKSPACE_ROOT"):
          ndk_path = str(ctx.workspace_root) + ndk_path.removeprefix("$WORKSPACE_ROOT")
- 
+
++    if not ctx.path(ndk_path).exists:
++        ctx.file("BUILD.bazel", "")
++        return
++
+     is_windows = False
+     executable_extension = ""
+     if ctx.os.name == "linux":


### PR DESCRIPTION
## Description
This is a preparation before removing the dependency on Docker from our Android build instructions (#1181).

Suppose we want to set 'path' attribute to `android_ndk_repository_extension` so that we can specify the actual path to the Android NDK in our `MODULE.bazel`.

```starlark
  android_ndk_repository_extension = use_extension(
      "@rules_android_ndk//:extension.bzl",
      "android_ndk_repository_extension",
  )
  android_ndk_repository_extension.configure(
      path = "$WORKSPACE_ROOT/third_party/ndk/android-ndk-r28",
  )
  use_repo(android_ndk_repository_extension, "androidndk")
```

The problem is that there is currently no way to conditionally the the above path attribute depending on the host platform and/or the target platform. As a result, the above configuration takes effect not only on Linux but also on Windows environment, where we do not plan to support building libmozc.so right now.

To gracefully handle the above scenario, this commit updates our patch to `rules_android_ndk` to generate an empty `BUILD.bazel` file when an Android NDK does not exist at the location specified by `ANDROID_NDK_HOME` or the path attribute. Basically this is a superset of the behavior of the current patch, where an empty `BUILD.bazel` file is generated unless `ANDROID_NDK_HOME` is explicitly specified or the path attribute is set.

In general there should be no observable behavior change as long as the build is currently passing.

## Issue IDs

 * https://github.com/google/mozc/issues/1181

## Steps to test new behaviors (if any)
 - Steps:
   1. Confirm Linux and Android CI is still passing in GitHub Actions
