### PR TITLE
Also download Android NDK in `update_deps.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ MODULE.bazel.lock
 .DS_Store
 
 # third_party dirs and cache dir checked out by update_deps.py
+/src/third_party/ndk/
 /src/third_party/ninja/
 /src/third_party/qt/
 /src/third_party/qt_host/


### PR DESCRIPTION
## Description
This is a preparation before removing the dependency on Docker from our Android build instructions (#1181).

With this commit running the `update_deps.py` also downloads Android NDK for macOS and Linux then extract it under `third_party/ndk/`.

This would enable us to fully control which version of Android NDK should be used to build Android Library (`libmozc.so`) in a subsequent commit.

At this moment only the observable difference is that the Android NDK will be extracted under `third_party/ndk/`. There must be no difference in the final artifact yet.

## Issue IDs

 * https://github.com/google/mozc/issues/1181

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm CI is still passing in GitHub Actions

