### PR TITLE
Follow up build instructions on bazelisk

### DIFF
--- a/docs/build_mozc_in_osx.md
+++ b/docs/build_mozc_in_osx.md
@@ -22,7 +22,7 @@ python3 build_tools/update_deps.py
 # CMake is also required to build Qt.
 python3 build_tools/build_qt.py --release --confirm_license
 
-MOZC_QT_PATH=${PWD}/third_party/qt bazel build package --config oss_macos --config release_build
+MOZC_QT_PATH=${PWD}/third_party/qt bazelisk build package --config oss_macos --config release_build
 open bazel-bin/mac/Mozc.pkg
 ```
 
@@ -49,8 +49,9 @@ Building on Mac requires the following software.
 * [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
   * Xcode 13 (macOS 13 SDK) or later
   * ⚠️Xcode Command Line Tools aren't sufficient.
-* [Bazel](https://docs.bazel.build/versions/master/install-os-x.html) for Bazel build
-  * check [src/.bazelversion](../src/.bazelversion) for the supported Bazel version.
+* [Bazelisk](https://github.com/bazelbuild/bazelisk)
+  * Bazelisk is a wrapper of [Bazel](https://bazel.build/) to use the specific version of Bazel.
+  * [src/.bazeliskrc](../src/.bazeliskrc) controls which version of Bazel is used.
 * Python 3.9 or later with the following pip module.
   * `requests`
 * CMake 3.18.4 or later (to build Qt6)

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -167,7 +167,8 @@ Note that you can specify `--qtdir=` option instead of `--noqt` in GYP phase sin
 Additional requirements:
 
 * [Bazelisk](https://github.com/bazelbuild/bazelisk)
-  * Bazelisk is a wrapper of [Bazel](https://bazel.build/) to use the specific version of Bazel.
+  * Bazelisk is a wrapper of [Bazel](https://bazel.build) to use the specific version of Bazel.
+  * [src/.bazeliskrc](../src/.bazeliskrc) controls which version of Bazel is used.
 * [MSYS2](https://github.com/msys2/msys2)
 
 After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run the following command instead of `build_mozc.py`:


### PR DESCRIPTION
## Description
This follows up to our previous commit (8d704f0f82288b355d0e2cacb18f077a27ed032d), which introduced `.bazelversion` so that we can centralize where to specify the expected version of Bazel in our CI and build instructions.

This commit replaces the remaining usage of `bazel` command with `bazelisk` command then explain where the expected bazel version is specified.

This is just a documentation change. There must be no behavior change in the final artifacts.

## Issue IDs

N/A
