### PR TITLE
Patch `rules_cc` 0.0.17 to use clang-cl for x86

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -71,6 +71,17 @@ bazel_dep(
     name = "rules_cc",
     version = "0.0.17",
 )
+single_version_override(
+    module_name = "rules_cc",
+    patches = [
+        # Enable to build x86 (32-bit) executables with clang-cl.
+        # https://github.com/bazelbuild/rules_cc/pull/360
+        "bazel/rules_cc_BUILD.windows.tpl.patch",
+        "bazel/rules_cc_windows_cc_configure.bzl.patch",
+        "bazel/rules_cc_windows_cc_toolchain_config.bzl.patch",
+    ],
+    version = "0.0.17",
+)
 
 cc_configure = use_extension(
     "@rules_cc//cc:extensions.bzl",

--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -1,0 +1,86 @@
+--- cc/private/toolchain/BUILD.windows.tpl
++++ cc/private/toolchain/BUILD.windows.tpl
+@@ -85,6 +85,7 @@ cc_toolchain_suite(
+         "x64_windows|mingw-gcc": ":cc-compiler-x64_windows_mingw",
+         "x64_x86_windows|mingw-gcc": ":cc-compiler-x64_x86_windows_mingw",
+         "x64_windows|clang-cl": ":cc-compiler-x64_windows-clang-cl",
++        "x64_x86_windows|clang-cl": ":cc-compiler-x64_x86_windows-clang-cl",
+         "x64_windows_msys": ":cc-compiler-x64_windows_msys",
+         "x64_windows": ":cc-compiler-x64_windows",
+         "x64_x86_windows": ":cc-compiler-x64_x86_windows",
+@@ -621,6 +622,75 @@ toolchain(
+     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+ )
+ 
++cc_toolchain(
++    name = "cc-compiler-x64_x86_windows-clang-cl",
++    toolchain_identifier = "clang_cl_x64_x86",
++    toolchain_config = ":clang_cl_x64_x86",
++    all_files = ":empty",
++    ar_files = ":empty",
++    as_files = ":clangcl_compiler_files",
++    compiler_files = ":clangcl_compiler_files",
++    dwp_files = ":empty",
++    linker_files = ":empty",
++    objcopy_files = ":empty",
++    strip_files = ":empty",
++    supports_param_files = 1,
++)
++
++cc_toolchain_config(
++    name = "clang_cl_x64_x86",
++    cpu = "x64_x86_windows",
++    compiler = "clang-cl",
++    host_system_name = "local",
++    target_system_name = "local",
++    target_libc = "msvcrt",
++    abi_version = "local",
++    abi_libc_version = "local",
++    toolchain_identifier = "clang_cl_x64_x86",
++    msvc_env_tmp = "%{clang_cl_env_tmp_x86}",
++    msvc_env_path = "%{clang_cl_env_path_x86}",
++    msvc_env_include = "%{clang_cl_env_include_x86}",
++    msvc_env_lib = "%{clang_cl_env_lib_x86}",
++    msvc_cl_path = "%{clang_cl_cl_path_x86}",
++    msvc_ml_path = "%{clang_cl_ml_path_x86}",
++    msvc_link_path = "%{clang_cl_link_path_x86}",
++    msvc_lib_path = "%{clang_cl_lib_path_x86}",
++    cxx_builtin_include_directories = [%{clang_cl_cxx_builtin_include_directories_x86}],
++    tool_paths = {
++        "ar": "%{clang_cl_lib_path_x86}",
++        "ml": "%{clang_cl_ml_path_x86}",
++        "cpp": "%{clang_cl_cl_path_x86}",
++        "gcc": "%{clang_cl_cl_path_x86}",
++        "gcov": "wrapper/bin/msvc_nop.bat",
++        "ld": "%{clang_cl_link_path_x86}",
++        "nm": "wrapper/bin/msvc_nop.bat",
++        "objcopy": "wrapper/bin/msvc_nop.bat",
++        "objdump": "wrapper/bin/msvc_nop.bat",
++        "strip": "wrapper/bin/msvc_nop.bat",
++    },
++    archiver_flags = ["/MACHINE:X86"],
++    default_compile_flags = ["-m32"],
++    default_link_flags = ["/MACHINE:X86"],
++    dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x86}",
++    fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x86}",
++    supports_parse_showincludes = %{clang_cl_parse_showincludes_x86},
++)
++
++toolchain(
++    name = "cc-toolchain-x64_x86_windows-clang-cl",
++    exec_compatible_with = [
++        "@platforms//cpu:x86_64",
++        "@platforms//os:windows",
++        "@rules_cc//cc/private/toolchain:clang-cl",
++    ],
++    target_compatible_with = [
++        "@platforms//cpu:x86_32",
++        "@platforms//os:windows",
++    ],
++    toolchain = ":cc-compiler-x64_x86_windows-clang-cl",
++    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
++)
++
+ cc_toolchain(
+     name = "cc-compiler-arm64_windows-clang-cl",
+     toolchain_identifier = "clang_cl_arm64",

--- a/src/bazel/rules_cc_windows_cc_configure.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_configure.bzl.patch
@@ -1,0 +1,16 @@
+--- cc/private/toolchain/windows_cc_configure.bzl
++++ cc/private/toolchain/windows_cc_configure.bzl
+@@ -879,10 +879,12 @@ def configure_windows_toolchain(repository_ctx):
+ 
+     template_vars = dict()
+     msvc_vars_x64 = _get_msvc_vars(repository_ctx, paths, "x64")
++    msvc_vars_x86 = _get_msvc_vars(repository_ctx, paths, "x86", msvc_vars_x64)
+     template_vars.update(msvc_vars_x64)
++    template_vars.update(msvc_vars_x86)
+     template_vars.update(_get_clang_cl_vars(repository_ctx, paths, msvc_vars_x64, "x64"))
++    template_vars.update(_get_clang_cl_vars(repository_ctx, paths, msvc_vars_x86, "x86"))
+     template_vars.update(_get_msys_mingw_vars(repository_ctx))
+-    template_vars.update(_get_msvc_vars(repository_ctx, paths, "x86", msvc_vars_x64))
+     template_vars.update(_get_msvc_vars(repository_ctx, paths, "arm", msvc_vars_x64))
+     msvc_vars_arm64 = _get_msvc_vars(repository_ctx, paths, "arm64", msvc_vars_x64)
+     template_vars.update(msvc_vars_arm64)

--- a/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
@@ -1,0 +1,20 @@
+--- cc/private/toolchain/windows_cc_toolchain_config.bzl
++++ cc/private/toolchain/windows_cc_toolchain_config.bzl
+@@ -89,7 +89,7 @@ all_link_actions = [
+ ]
+ 
+ def _use_msvc_toolchain(ctx):
+-    return ctx.attr.cpu in ["x64_windows", "arm64_windows"] and (ctx.attr.compiler == "msvc-cl" or ctx.attr.compiler == "clang-cl")
++    return ctx.attr.cpu in ["x64_windows", "x64_x86_windows", "arm64_windows"] and (ctx.attr.compiler == "msvc-cl" or ctx.attr.compiler == "clang-cl")
+ 
+ def _impl(ctx):
+     if _use_msvc_toolchain(ctx):
+@@ -763,7 +763,7 @@ def _impl(ctx):
+                                 "/wd4291",
+                                 "/wd4250",
+                                 "/wd4996",
+-                            ],
++                            ] + ctx.attr.default_compile_flags,
+                         ),
+                     ],
+                 ),


### PR DESCRIPTION
## Description
This is a preparation to build Mozc for Windows with clang-cl.

This commit pulls [my pull request](https://github.com/bazelbuild/rules_cc/pull/360) to let `rules_cc` register clang-cl as a valid toolchain to build x86 (32-bit) Windows executables. While when and how my pull request will get merged into upstream, having these local patches allows us to go ahead to see if we can fully migrate to clang-cl or not.

There must be no impact on Bazel with msvc build in this commit.

## Issue IDs

 * https://github.com/google/mozc/issues/1179
 * https://github.com/bazelbuild/rules_cc/pull/360

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm you can still build Mozc with Bazel for Windows with msvc
