### PR TITLE
Replace remaining "Google Inc." with "Google LLC"

### DIFF
--- a/src/build_tools/mozc_win32_resource_template.rc
+++ b/src/build_tools/mozc_win32_resource_template.rc
@@ -4,9 +4,9 @@
 //
 #ifndef MOZC_RES_COMPANY_NAME
   #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
-    #define MOZC_RES_COMPANY_NAME "Google Inc."
+    #define MOZC_RES_COMPANY_NAME "Google LLC"
   #elif defined(MOZC_BUILD)
-    #define MOZC_RES_COMPANY_NAME "Google Inc."
+    #define MOZC_RES_COMPANY_NAME "Google LLC"
   #endif
 #endif
 #ifndef MOZC_RES_FILE_DESCRIPTION

--- a/src/unix/ibus/gen_mozc_xml.py
+++ b/src/unix/ibus/gen_mozc_xml.py
@@ -213,7 +213,7 @@ def main():
       'exec': ibus_mozc_path + ' --ibus',
       # TODO(mazda): Generate the version number.
       'version': '0.0.0.0',
-      'author': 'Google Inc.',
+      'author': 'Google LLC',
       'license': 'New BSD',
       'homepage': 'https://github.com/google/mozc',
       'textdomain': 'ibus-mozc',

--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -46,8 +46,8 @@
     http://msdn.microsoft.com/en-us/library/aa367850.aspx.
     So we change the product ID for every new version.
   -->
-  <Package Name="Google 日本語入力" Language="1041" Codepage="932" Version="$(var.MozcVersion)" Manufacturer="Google Inc." UpgradeCode="$(var.UpgradeCode)" InstallerVersion="500">
-    <SummaryInformation Keywords="Installer" Description="Google 日本語入力 インストーラー" Manufacturer="Google Inc." Codepage="932" />
+  <Package Name="Google 日本語入力" Language="1041" Codepage="932" Version="$(var.MozcVersion)" Manufacturer="Google LLC" UpgradeCode="$(var.UpgradeCode)" InstallerVersion="500">
+    <SummaryInformation Keywords="Installer" Description="Google 日本語入力 インストーラー" Manufacturer="Google LLC" Codepage="932" />
 
     <!--
                      VersionNT

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -47,8 +47,8 @@
     http://msdn.microsoft.com/en-us/library/aa367850.aspx.
     So we change the product ID for every new version.
   -->
-  <Package Name="Mozc" Language="1041" Codepage="932" Version="$(var.MozcVersion)" Manufacturer="Google Inc." UpgradeCode="$(var.UpgradeCode)" InstallerVersion="500">
-    <SummaryInformation Keywords="Installer" Description="Mozc インストーラー" Manufacturer="Google Inc." Codepage="932" />
+  <Package Name="Mozc" Language="1041" Codepage="932" Version="$(var.MozcVersion)" Manufacturer="Google LLC" UpgradeCode="$(var.UpgradeCode)" InstallerVersion="500">
+    <SummaryInformation Keywords="Installer" Description="Mozc インストーラー" Manufacturer="Google LLC" Codepage="932" />
 
     <!--
                      VersionNT


### PR DESCRIPTION
## Description
This follows up to our previous commit (060367d120dcd64060df1fcc5ac0bbbf52c6ba11), which not only updated the copyright year but also replaced "Google Inc." with "Google LLC" for consistency.

This commit takes care of the remaining instances of "Google Inc." that are user visible.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - OS: Windows 24H2
 - Steps:
   1. Build `Mozc64.msi`
   2. Install `Mozc64.msi`
   3. Run `start ms-settings:appsfeatures-app`
   4. Search `mozc`
   5. Confirm that `Google LLC` is shown about Mozc
<img width="428" src="https://github.com/user-attachments/assets/947fc27a-4d34-402d-b41c-9a0668958722" />

