### PR TITLE
Extract out Android build instructions

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -1,5 +1,5 @@
 name: CI for Android
-# https://github.com/google/mozc/blob/master/docs/build_mozc_in_docker.md
+# https://github.com/google/mozc/blob/master/docs/build_mozc_for_android.md
 
 # Run on push.
 on: push
@@ -11,8 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  PYTHON_VENV_ROOT: ${{ github.workspace }}/src/python-venv
+
 jobs:
-  build:
+  build_on_linux:
     # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -27,6 +30,25 @@ jobs:
         run: |
           sudo apt-get update
 
+      - name: Setup Python
+        run: |
+          python3 -m venv ${PYTHON_VENV_ROOT}
+          source ${PYTHON_VENV_ROOT}/bin/activate
+          python3 -m pip install requests
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v4
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install dependencies
+        working-directory: ./src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          source ${PYTHON_VENV_ROOT}/bin/activate
+          python3 build_tools/update_deps.py
+
       - name: build
         working-directory: ./src
         run: |
@@ -38,3 +60,38 @@ jobs:
           name: native_libs.zip
           path: src/bazel-bin/android/jni/native_libs.zip
           if-no-files-found: warn
+
+  build_on_mac:
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+    runs-on: macos-14
+    timeout-minutes: 60
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Setup Python
+        run: |
+          python3 -m venv ${PYTHON_VENV_ROOT}
+          source ${PYTHON_VENV_ROOT}/bin/activate
+          python3 -m pip install requests
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v4
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install dependencies
+        working-directory: ./src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          source ${PYTHON_VENV_ROOT}/bin/activate
+          python3 build_tools/update_deps.py
+
+      - name: build
+        working-directory: ./src
+        run: |
+          bazelisk build --config oss_android package --config release_build

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Detailed differences between Google Japanese Input and Mozc are described in [Ab
 Build Instructions
 ------------------
 
-* [How to build Mozc in Docker](docs/build_mozc_in_docker.md): Android library and Linux desktop builds.
-* [How to build Mozc in macOS](docs/build_mozc_in_osx.md): macOS build.
-* [How to build Mozc in Windows](docs/build_mozc_in_windows.md): Windows build.
+* [How to build Mozc for Android](docs/build_mozc_for_docker.md): for Android library (`libmozc.so`)
+* [How to build Mozc for Linux](docs/build_mozc_in_docker.md): for Linux desktop
+* [How to build Mozc for macOS](docs/build_mozc_in_osx.md): for macOS build
+* [How to build Mozc for Windows](docs/build_mozc_in_windows.md): for Windows
 
 Release Plan
 ------------

--- a/docker/ubuntu22.04/Dockerfile
+++ b/docker/ubuntu22.04/Dockerfile
@@ -61,11 +61,6 @@ RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/ba
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazelisk \
   && chmod u+x /home/mozc_builder/bin/bazelisk
 
-## Set up Android NDK
-## https://github.com/android/ndk/wiki/Home/24fe2d7ee3591346e0e8ae615977a15c0a4fba40#ndk-r28
-RUN curl -LO https://dl.google.com/android/repository/android-ndk-r28-linux.zip && unzip android-ndk-r28-linux.zip && rm android-ndk-r28-linux.zip
-ENV ANDROID_NDK_HOME /home/mozc_builder/work/android-ndk-r28
-
 # check out Mozc source with submodules
 RUN mkdir /home/mozc_builder/work/mozc
 # COPY --chown=mozc_builder:mozc_builder src/ /home/mozc_builder/work/mozc/src/

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -57,11 +57,6 @@ RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/ba
   && mv bazelisk-linux-amd64 /home/mozc_builder/bin/bazelisk \
   && chmod u+x /home/mozc_builder/bin/bazelisk
 
-## Set up Android NDK
-## https://github.com/android/ndk/wiki/Home/24fe2d7ee3591346e0e8ae615977a15c0a4fba40#ndk-r28
-RUN curl -LO https://dl.google.com/android/repository/android-ndk-r28-linux.zip && unzip android-ndk-r28-linux.zip && rm android-ndk-r28-linux.zip
-ENV ANDROID_NDK_HOME /home/mozc_builder/work/android-ndk-r28
-
 # check out Mozc source with submodules
 RUN mkdir /home/mozc_builder/work/mozc
 # COPY --chown=mozc_builder:mozc_builder src/ /home/mozc_builder/work/mozc/src/

--- a/docs/build_mozc_for_android.md
+++ b/docs/build_mozc_for_android.md
@@ -1,0 +1,86 @@
+# How to build `libmozc.so` for Android
+
+[![Android lib](https://github.com/google/mozc/actions/workflows/android.yaml/badge.svg)](https://github.com/google/mozc/actions/workflows/android.yaml)
+
+## Summary
+
+If you are not sure what the following commands do, please check the descriptions below
+and make sure the operations before running them.
+
+```
+git clone https://github.com/google/mozc.git
+cd mozc/src
+
+export PYTHON_VENV_ROOT=${PWD}/python-venv
+python3 -m venv ${PYTHON_VENV_ROOT}
+source ${PYTHON_VENV_ROOT}/bin/activate
+python3 -m pip install requests
+
+python3 build_tools/update_deps.py
+
+bazelisk build package --config oss_android --config release_build
+```
+
+Client code for Android apk is deprecated.
+(the last revision with Android client code is
+[afb03dd](https://github.com/google/mozc/commit/afb03ddfe72dde4cf2409863a3bfea160f7a66d8)).
+
+## Setup
+
+### System Requirements
+
+Currently macOS and Linux are tested to build `libmozc.so` for Android.
+
+### Software Requirements
+
+Building `libmozc.so` for Android requires the following software.
+
+ * [bazelisk](https://github.com/bazelbuild/bazelisk)
+ * C++ compiler (GCC or clang)
+ * Python 3.9 or later with the following pip module.
+   * `requests`
+
+## Build instructions
+
+### Get the Code
+
+You can download Mozc source code as follows:
+
+```
+git clone https://github.com/google/mozc.git
+cd mozc/src
+```
+
+Hereafter you can do all the operations without changing directory.
+
+### Set up and enable Python virtual environment
+
+The following commands set up Python virtual environment under `mozc/src/python-venv`.
+
+```
+export PYTHON_VENV_ROOT=${PWD}/python-venv
+python3 -m venv ${PYTHON_VENV_ROOT}
+source ${PYTHON_VENV_ROOT}/bin/activate
+python3 -m pip install requests
+```
+
+Using `mozc/src/python-venv` as the virtual environment location is not mandatory. Any other location should also work.
+
+### Check out additional build dependencies
+
+```
+python build_tools/update_deps.py
+```
+
+In this step, additional build dependencies will be downloaded.
+
+  * [Android NDK r28](https://github.com/android/ndk/wiki/Home/24fe2d7ee3591346e0e8ae615977a15c0a4fba40#ndk-r28)
+  * [git submodules](../.gitmodules)
+
+### Build `libmozc.so` for Android
+
+```
+bazelisk build package --config oss_android --config release_build
+```
+
+`package` is an alias to build `android/jni:native_libs`.

--- a/docs/build_mozc_in_docker.md
+++ b/docs/build_mozc_in_docker.md
@@ -19,7 +19,7 @@ docker cp mozc_build:/home/mozc_builder/work/mozc/src/bazel-bin/unix/mozc.zip .
 ```
 
 ## Introduction
-Docker containers are available to build Mozc binaries for Android JNI library and Linux desktop.
+Docker containers are available to build Mozc binaries for Linux desktop.
 
 ## System Requirements
 Currently, only Ubuntu 24.04 is tested to host the Docker container to build Mozc.
@@ -185,22 +185,6 @@ If the issue persists, also try the following command to [clean Bazel's build ca
 ```
 bazelisk clean --expunge
 ```
-
-## Build Mozc library for Android:
-
-Client code for Android apk is deprecated.
-(the last revision with Android client code is
-[afb03dd](https://github.com/google/mozc/commit/afb03ddfe72dde4cf2409863a3bfea160f7a66d8)).
-
-The conversion engine for Android is built with Bazel.
-
-```
-bazelisk build package --config oss_android
-```
-
-`package` is an alias to build `android/jni:native_libs`.
-
-We have tested Android NDK r27. The former versions may not work.
 
 -----
 

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -111,6 +111,9 @@ android_ndk_repository_extension = use_extension(
     "@rules_android_ndk//:extension.bzl",
     "android_ndk_repository_extension",
 )
+android_ndk_repository_extension.configure(
+    path = "$WORKSPACE_ROOT/third_party/ndk/android-ndk-r28",
+)
 use_repo(android_ndk_repository_extension, "androidndk")
 
 register_toolchains("@androidndk//:all")


### PR DESCRIPTION
## Description
This is the first part towards removing the dependency on Docker from our build instructions for Linux desktop and Android.

This commit makes it clear that you can build 'libmozc.so' on both Linux and macOS by the same Bazel command with actually demonstrating it in `.github/workflows/android.yaml` that `libmozc.so` can be built on both Linux and macOS GitHub Actions runners.

With above our `Dockerfile` can stop setting up Android NDK since `build_mozc_in_docker.md` does not mention Android any more.

This commit is only about the build instructions of `libmozc.so` for Android. There must be no difference in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1181

## Steps to test new behaviors (if any)
 - OS: Linux and macOS
 - Steps:
   1. .Confirm you can build `libmozc.so` for Android

