### PR TITLE
Download LLVM to use `clang-cl` for Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ MODULE.bazel.lock
 .DS_Store
 
 # third_party dirs and cache dir checked out by update_deps.py
+/src/third_party/llvm/
 /src/third_party/ndk/
 /src/third_party/ninja/
 /src/third_party/qt/

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -68,6 +68,7 @@ python build_tools/update_deps.py
 
 In this step, additional build dependencies will be downloaded.
 
+  * [LLVM 19.1.7](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7)
   * [Ninja 1.11.0](https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip)
   * [Qt 6.8.0](https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz)
   * [.NET tools](../dotnet-tools.json)


### PR DESCRIPTION
## Description
As a preparation to start using clang-cl for Windows (#1179), with this commit
```
python build_tools/update_deps.py
```
will start deploying LLVM for windows into `src/third_party/llvm/` by downloading the archive from LLVM's GitHub releases page.

The downloaded `clang-cl` is not yet used.

## Issue IDs

 * https://github.com/google/mozc/issues/1179

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 24H2
 - Steps:
   1. `python build_tools/update_deps.py`
   2. Confirm `third_party/llvm/clang+llvm-19.1.7-x86_64-pc-windows-msvc/bin/clang-cl.exe` exists.
