### PR TITLE
Follow PEP 394 in `build_mozc_for_android.md`

### DIFF
--- a/docs/build_mozc_for_android.md
+++ b/docs/build_mozc_for_android.md
@@ -69,7 +69,7 @@ Using `mozc/src/python-venv` as the virtual environment location is not mandator
 ### Check out additional build dependencies
 
 ```
-python build_tools/update_deps.py
+python3 build_tools/update_deps.py
 ```
 
 In this step, additional build dependencies will be downloaded.


### PR DESCRIPTION
## Description
This follows up to my previous commit (f215eaf71ab75940c1516347164f05aac1589203), which introduced `docs/build_mozc_for_android.md` as a dedicated build instruction page for building `libmozc.so` for Android as part of removing the dependency on Docker from our build instructions (#1181).

While the above document already uses `python3` elsewhere, there was one place where 'python' was used instead. It would be better to avoid 'python' in favor of [PEP 394](https://peps.python.org/pep-0394/).

## Issue IDs

 * https://github.com/google/mozc/issues/1181
