### PR TITLE
Introduce platform `host-windows-clang-cl`

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -97,6 +97,16 @@ selects.config_setting_group(
     visibility = ["//:__subpackages__"],
 )
 
+# Generic Windows platform with clang-cl that automatically matches host CPU.
+platform(
+    name = "host-windows-clang-cl",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@bazel_tools//tools/cpp:clang-cl",
+    ],
+    parents = ["@local_config_platform//:host"],
+)
+
 # Special target so as to define special macros for each platforms.
 # Don't depend on this directly. Use mozc_cc_(library|binary|test) rule instead.
 cc_library(


### PR DESCRIPTION
## Description
This is a preparation to build Mozc for Windows with clang-cl (#1179).

Now that Windows Bazel builds rely on CC toolchain resolution (#1112), `clang-cl` needs to be picked up based on `platform` specified to Bazel. This gives us an inverse problem what needs to be passed to Bazel so that such a resolution can happen.

The simplest solution as far as I have figures out is doing the following two steps.

1. Specify `--host_platform=//:host-windows-clang-cl`, where it is defined as follows.

     ```
     platform(
         name = "host-windows-clang-cl",
         constraint_values = [
             "@platforms//os:windows",
             "@bazel_tools//tools/cpp:clang-cl",
         ],
         parents = ["@local_config_platform//:host"],
     )
     ```

   By doing this, `@bazel_tools//tools/cpp:clang-cl` can be propagated into each execution platform, which is mandatory for `clang-cl` to be picked up.

2. Specify `--extra_toolchains` command line options to put the following toolchains from `rules_cc` in higher priority than cl.exe.

     * `@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl`
     * `@local_config_cc//:cc-toolchain-x64_windows-clang-cl`

   This is important because CC toolchain resolution picks up the first toolchain that satisfies all the constraints. To give a higher priority to `clang-cl` toolchains, they need to be registered before 'cl' toolchains are registered.

   Note that
     ```
     register_toolchains("@local_config_cc//:all")
     ```
   in `MODULE.bazel` registers toolchains in the alphabetical order. To give a higher priority to `clang-cl` toolchains, `--extra_toolchains` command line looks to be the best way.

What this commit does is the step 1. Without the step 2, there must be no observable behavior change yet.

## Issue IDs

 * https://github.com/google/mozc/issues/1179

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Install [clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz](https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz)
   2. Run the following command
       ```
       bazelisk --bazelrc=windows.bazelrc build package --config oss_windows --config release_build --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl  --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl --host_platform=//:host-windows-clang-cl
      ```
