### PR TITLE
Fix `rules_cc_BUILD.windows.tpl.patch`

### DIFF
--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -69,13 +69,13 @@
 +toolchain(
 +    name = "cc-toolchain-x64_x86_windows-clang-cl",
 +    exec_compatible_with = [
-+        "//third_party/bazel_platforms/cpu:x86_64",
-+        "//third_party/bazel_platforms/os:windows",
++        "@platforms//cpu:x86_64",
++        "@platforms//os:windows",
 +        "@rules_cc//cc/private/toolchain:clang-cl",
 +    ],
 +    target_compatible_with = [
-+        "//third_party/bazel_platforms/cpu:x86_32",
-+        "//third_party/bazel_platforms/os:windows",
++        "@platforms//cpu:x86_32",
++        "@platforms//os:windows",
 +    ],
 +    toolchain = ":cc-compiler-x64_x86_windows-clang-cl",
 +    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",


### PR DESCRIPTION
## Description
This follows up to my previous commit (76343ffa704021a10ee6deec7d887d1c1e0f472b), which introduced several patches to `rules_cc` including `bazel/rules_cc_BUILD.windows.tpl.patch` to support `clang-cl` (#1179).

Seems that a subsequent commit (c523a3b998e9edaf0822a52e468d79f2233bb125) unexpectedly replacing `@platforms//` with `/third_party/bazel_platforms` probably because of some issue in [copybara](https://github.com/google/copybara) rewrite rules. This commit restores the above file to the original state to fix Windows Bazel build.

## Issue IDs

 * https://github.com/google/mozc/issues/1179

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm you can build Mozc for Windows with Bazel
