### PR TITLE
Start using `clang-cl` for Windows Bazel build

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -43,9 +43,6 @@ build:compiler_msvc_like --copt "/J" --host_copt "/J"
 build:compiler_msvc_like --copt "/utf-8" --host_copt "/utf-8"
 build:compiler_msvc_like --cxxopt "/J" --host_cxxopt "/J"
 build:compiler_msvc_like --cxxopt "/utf-8" --host_cxxopt "/utf-8"
-## See https://github.com/protocolbuffers/protobuf/issues/20085
-## This can be removed if we can switch to clang-cl for Windows
-build:compiler_msvc_like --define=protobuf_allow_msvc=true
 
 ## Linux specific options
 build:linux_env --build_tag_filters=-nolinux --copt "-fPIC"

--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -1,4 +1,16 @@
 @echo off
+
+rem set BAZEL_LLVM only if clang-cl exists under third_party/llvm.
+set TMP_THIRD_PARTY_LLVN_DIR=third_party\llvm\clang+llvm-19.1.7-x86_64-pc-windows-msvc
+set TMP_MOZC_BAZEL_WRAPPER_DIR=%~dp0
+set TMP_MOZC_SRC_DIR=%TMP_MOZC_BAZEL_WRAPPER_DIR:~0,-21%
+set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\%TMP_THIRD_PARTY_LLVN_DIR%
+if exist %TMP_MOZC_LLVM_DIR% set BAZEL_LLVM=%TMP_MOZC_LLVM_DIR%
+set TMP_MOZC_BAZEL_WRAPPER_DIR=
+set TMP_MOZC_SRC_DIR=
+set TMP_MOZC_LLVM_DIR=
+set TMP_THIRD_PARTY_LLVN_DIR=
+
 %BAZEL_REAL% %* & call:myexit
 
 :myexit

--- a/src/windows.bazelrc
+++ b/src/windows.bazelrc
@@ -7,9 +7,8 @@
 #   bazel --bazelrc=windows.bazelrc build //protocol:commands_proto \
 #         --config oss_windows
 
-# There has been a long standing path-length issue on building protobuf on
-# Windows with bazel. See the following for details.
-# https://github.com/protocolbuffers/protobuf/issues/12947
-# https://github.com/bazelbuild/bazel/issues/18683
-# Here is an ugly workaround, which we really hope to get rid of.
-startup  --output_base=C:/x --windows_enable_symlinks
+startup  --windows_enable_symlinks
+
+build    --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
+build    --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
+build    --host_platform=//:host-windows-clang-cl


### PR DESCRIPTION
## Description
With this commit we start using `clang-cl` to build Mozc for Windows with Bazel.

While the original motivation of switching to `clang-cl` is that protobuf is planning to stop supporting `cl.exe` with bazel build in protobuf v34, there is also an on-going build breakage that happens when combining protobuf and abseil-cpp 20250127.0, which is not yet fixed.
 
 * https://github.com/protocolbuffers/protobuf/issues/20085
 * https://github.com/protocolbuffers/protobuf/issues/20331

The latter one is more critical for us because more and more bzlmod dependencies start requiring abseil-cpp 20250127.0 or higher.

There must be no impact on Windows GYP build.

Closes #1179.

## Issue IDs

 * https://github.com/google/mozc/issues/1179

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk --bazelrc=windows.bazelrc build package --config oss_windows --config release_build`
   2. Confirm you can build Mozc for Windows with Bazel. Also confirm `clang-cl.exe` is running during the build.
