### PR TITLE
Decode messages from `dotnet tool` as UTF-8

### DIFF
--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -408,6 +408,7 @@ def exec_command(
   process = subprocess.Popen(
       args,
       cwd=cwd,
+      encoding='utf-8',
       shell=False,
       stdout=subprocess.PIPE,
       text=True,


### PR DESCRIPTION
## Description
If `dotnet tool` outputs non-ASCII characters and the system locale is not `utf-8`, then `update_deps.py` can fail due to `UnicodeDecodeError`. This commit addresses the above issue by explicitly setting `utf-8` when calling `subprocess.Popen`.

Closes #1203

## Issue IDs

 * https://github.com/google/mozc/issues/1203

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Make sure `dotnet tool --help` shows messages in Japanese.
   2. Make sure `python -c "import locale; print(locale.getpreferredencoding())"` shows `cp932`
   3. Confirm `python build_tools/update_deps.py` finishes without any error.
