### PR TITLE
bzlmod: `abseil-cpp`, `googletest` and `protobuf`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -2,46 +2,27 @@
 # To use Bzlmod, you need to specify --enable_bzlmod to the Bazel command or modify .bazelrc.
 module(name = "mozc")
 
-# absl-cpp: 2024-08-02
+# absl-cpp: 2025-02-04
 # https://github.com/abseil/abseil-cpp
-#
-# abseil-cpp with patches for Bazel 8.0.0 is used instead of the local Abseil in third_party/.
-# Otherwise, `bazel fetch` will fail with the error: "cc_configure_extension no longer available".
-# References
-#   * https://github.com/bazelbuild/bazel/issues/24426
-#   * https://github.com/bazelbuild/bazel-central-registry/pull/3320
-# Also we cannot switch to 20250127.0 until the protobuf team fixes the following issue.
-#   * https://github.com/protocolbuffers/protobuf/issues/20331
 bazel_dep(
     name = "abseil-cpp",
-    version = "20240722.0.bcr.2",
+    version = "20250127.0",
     repo_name = "com_google_absl",
 )
 
-# This is also workaround for the above issue bazel/issues/24426.
-# This bazel_dep should be removed after the issue is fixed.
-bazel_dep(
-    name = "re2",
-    version = "2024-07-02.bcr.1",
-)
-
-# protobuf: 29.3 2025-01-09
+# protobuf: 30.0 2025-03-05
 # https://github.com/protocolbuffers/protobuf
-# We cannot switch to 30.x until the protobuf team fixes the following issue.
-#   * https://github.com/protocolbuffers/protobuf/issues/20331
 bazel_dep(
     name = "protobuf",
-    version = "29.3",
+    version = "30.0",
     repo_name = "com_google_protobuf",
 )
 
-# googletest: 1.15.2 2024-07-31
+# googletest: 1.16.0 2024-07-31
 # https://github.com/google/googletest
-# We cannot switch to 1.16.0 until the protobuf team fixes the following issue.
-#   * https://github.com/protocolbuffers/protobuf/issues/20331
 bazel_dep(
     name = "googletest",
-    version = "1.15.2",
+    version = "1.16.0",
     repo_name = "com_google_googletest",
 )
 


### PR DESCRIPTION
## Description
This commit updates `MODULE.bazel` as follows.

 * `abseil-cpp`: `20240722.0.bcr.2` -> `20250127.0`
 * `googletest`: `1.15.2` -> `1.16.0`
 * `protobuf` : `29.3` -> `30.0`

Note that GYP build remain unchanged until the corresponding git submodules are updated to the above versions.

No observable behavior change is intended.

## Issue IDs

 * https://github.com/google/mozc/issues/1172
 * https://github.com/google/mozc/issues/1177

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: All
 - Steps:
   1. Confirm GitHub Actions still succeed.
