### PR TITLE
Download MSYS2 for Windows Bazel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ MODULE.bazel.lock
 
 # third_party dirs and cache dir checked out by update_deps.py
 /src/third_party/llvm/
+/src/third_party/msys64/
 /src/third_party/ndk/
 /src/third_party/ninja/
 /src/third_party/qt/

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -69,6 +69,7 @@ python build_tools/update_deps.py
 In this step, additional build dependencies will be downloaded.
 
   * [LLVM 19.1.7](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7)
+  * [MSYS2 2025-02-21](https://github.com/msys2/msys2-installer/releases/tag/2025-02-21)
   * [Ninja 1.11.0](https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip)
   * [Qt 6.8.0](https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz)
   * [.NET tools](../dotnet-tools.json)
@@ -170,7 +171,6 @@ Additional requirements:
 * [Bazelisk](https://github.com/bazelbuild/bazelisk)
   * Bazelisk is a wrapper of [Bazel](https://bazel.build) to use the specific version of Bazel.
   * [src/.bazeliskrc](../src/.bazeliskrc) controls which version of Bazel is used.
-* [MSYS2](https://github.com/msys2/msys2)
 
 After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run the following command instead of `build_mozc.py`:
 
@@ -183,9 +183,6 @@ You have release build binaries in `bazel-bin\win32\installer\Mozc64.msi`.
 ### Tips for Bazel setup
 
 * You do not need to install a new JDK just for Mozc.
-* If you installed Bazel via [Scoop](https://scoop.sh), it is recommended to install MSYS2 via Scoop, too.
-
-https://bazel.build/install/windows?hl=ja#install-compilers
 
 ---
 

--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -1,15 +1,20 @@
 @echo off
 
-rem set BAZEL_LLVM only if clang-cl exists under third_party/llvm.
-set TMP_THIRD_PARTY_LLVN_DIR=third_party\llvm\clang+llvm-19.1.7-x86_64-pc-windows-msvc
 set TMP_MOZC_BAZEL_WRAPPER_DIR=%~dp0
 set TMP_MOZC_SRC_DIR=%TMP_MOZC_BAZEL_WRAPPER_DIR:~0,-21%
-set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\%TMP_THIRD_PARTY_LLVN_DIR%
+
+rem set BAZEL_LLVM only if clang-cl exists under third_party/llvm.
+set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\third_party\llvm\clang+llvm-19.1.7-x86_64-pc-windows-msvc
 if exist %TMP_MOZC_LLVM_DIR% set BAZEL_LLVM=%TMP_MOZC_LLVM_DIR%
+set TMP_MOZC_LLVM_DIR=
+
+rem set BAZEL_SH only if MSYS2 exists under third_party/msys64/bin/bash.exe.
+set TMP_MOZC_BASH_PATH=%TMP_MOZC_SRC_DIR%\third_party\msys64\usr\bin\bash.exe
+if exist %TMP_MOZC_BASH_PATH% set BAZEL_SH=%TMP_MOZC_BASH_PATH%
+set TMP_MOZC_BASH_PATH=
+
 set TMP_MOZC_BAZEL_WRAPPER_DIR=
 set TMP_MOZC_SRC_DIR=
-set TMP_MOZC_LLVM_DIR=
-set TMP_THIRD_PARTY_LLVN_DIR=
 
 %BAZEL_REAL% %* & call:myexit
 


### PR DESCRIPTION
## Description
This follows up to #1079, where how to install MSYS2 for Windows Bazel build was discussed.

Instead of asking each user to make sure that Bazel can find MSYS2 on Windows, let's use `build_tools/update_deps.py` to download MSYS2 then use `bazel/bazel_wrapper/bazel.bat` to deterministically set `BAZEL_SH` environment variable like we have already done for `clang-cl` (5780bf9aaa50555bd80a16b07a5bdf0af1a9fa83).

No observable behavior change is intended in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/pull/1079
 * https://github.com/google/mozc/issues/932

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
```
python build_tools/update_deps.py
python build_tools/build_qt.py --release --confirm_license
bazelisk --bazelrc=windows.bazelrc build package --config oss_windows --config release_build
```