### PR TITLE
Simplify Ubuntu package installation in Linux CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup
         run: |
           sudo apt-get update
-          sudo apt-get install -y libibus-1.0-dev qt6-base-dev libgl-dev
+          sudo apt-get install -y libibus-1.0-dev qt6-base-dev
           #
           # Unset the Android NDK setting to skip the unnecessary configuration.
           echo "ANDROID_NDK_HOME=" >> $GITHUB_ENV
@@ -57,7 +57,7 @@ jobs:
       - name: Setup
         run: |
           sudo apt-get update
-          sudo apt-get install -y libibus-1.0-dev qt6-base-dev libgl-dev
+          sudo apt-get install -y libibus-1.0-dev qt6-base-dev
           #
           # Unset the Android NDK setting to skip the unnecessary configuration.
           echo "ANDROID_NDK_HOME=" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
This commit simplifies our GitHub Actions for Linux desktop running on Ubuntu 24.04.

In Ubuntu 24.04, just installing `qt6-base-dev` guarantees that `libgl-dev` is also installed as a dependency. Let's specify only `qt6-base-dev` for simplicity.

## Issue IDs

 * https://github.com/google/mozc/discussions/1211

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Ubuntu 24.04 GitHub Actions runner
 - Steps:
   1. Confirm the build still succeeds.
