### PR TITLE
Update `clang-cl` to 20.1.0 for Windows Bazel build

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -68,7 +68,7 @@ python build_tools/update_deps.py
 
 In this step, additional build dependencies will be downloaded.
 
-  * [LLVM 19.1.7](https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7)
+  * [LLVM 20.1.0](https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0)
   * [MSYS2 2025-02-21](https://github.com/msys2/msys2-installer/releases/tag/2025-02-21)
   * [Ninja 1.11.0](https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip)
   * [Qt 6.8.0](https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz)

--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -4,7 +4,7 @@ set TMP_MOZC_BAZEL_WRAPPER_DIR=%~dp0
 set TMP_MOZC_SRC_DIR=%TMP_MOZC_BAZEL_WRAPPER_DIR:~0,-21%
 
 rem set BAZEL_LLVM only if clang-cl exists under third_party/llvm.
-set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\third_party\llvm\clang+llvm-19.1.7-x86_64-pc-windows-msvc
+set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\third_party\llvm\clang+llvm-20.1.0-x86_64-pc-windows-msvc
 if exist %TMP_MOZC_LLVM_DIR% set BAZEL_LLVM=%TMP_MOZC_LLVM_DIR%
 set TMP_MOZC_LLVM_DIR=
 

--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -115,9 +115,9 @@ NINJA_WIN = ArchiveInfo(
 )
 
 LLVM_WIN = ArchiveInfo(
-    url='https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz',
-    size=845236708,
-    sha256='b4557b4f012161f56a2f5d9e877ab9635cafd7a08f7affe14829bd60c9d357f0',
+    url='https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.0/clang+llvm-20.1.0-x86_64-pc-windows-msvc.tar.xz',
+    size=939145596,
+    sha256='91e29416f4a0c188368f0540a5538efc0d8a9f7134afba7a2160296472ce84eb',
 )
 
 MSYS2 = ArchiveInfo(


### PR DESCRIPTION
## Description
LLVM 20.1.0 was released on March 5, 2025.

 * https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0

Let's update our Windows Bazel build to use `clang-cl` 20.1.0 there.

No user-visible behavior change is intended in the final artifacts.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm that the bazel build still succeeds.
