### PR TITLE
bzlmod: Update `abseil-cpp` to 20250127.0

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -2,25 +2,12 @@
 # To use Bzlmod, you need to specify --enable_bzlmod to the Bazel command or modify .bazelrc.
 module(name = "mozc")
 
-# absl-cpp: 2024-08-02
+# absl-cpp: 2025-02-04
 # https://github.com/abseil/abseil-cpp
-#
-# abseil-cpp with patches for Bazel 8.0.0 is used instead of the local Abseil in third_party/.
-# Otherwise, `bazel fetch` will fail with the error: "cc_configure_extension no longer available".
-# References
-#   * https://github.com/bazelbuild/bazel/issues/24426
-#   * https://github.com/bazelbuild/bazel-central-registry/pull/3320
 bazel_dep(
     name = "abseil-cpp",
-    version = "20240722.0.bcr.2",
+    version = "20250127.0",
     repo_name = "com_google_absl",
-)
-
-# This is also workaround for the above issue bazel/issues/24426.
-# This bazel_dep should be removed after the issue is fixed.
-bazel_dep(
-    name = "re2",
-    version = "2024-07-02.bcr.1",
 )
 
 # protobuf: 29.3 2025-01-09


### PR DESCRIPTION
## Description
As planned in #1172, this commit updates `MODULE.bazel` as follows.

 * abseil-cpp: 20240722.0.bcr.2 -> 20250127.0

Note that GYP build remain unchanged until the corresponding git submodule is updated to the above version.

No user-visible behavior change is intended in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1172

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm bazel builds on GitHub Actions are still passing.
