### PR TITLE
Make `windows.bazelrc` no-op before deprecating it

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -123,7 +123,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk --bazelrc=windows.bazelrc build --config oss_windows --config release_build package
+          bazelisk build --config oss_windows --config release_build package
 
       - name: upload Mozc64_bazel.msi
         uses: actions/upload-artifact@v4

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -175,7 +175,7 @@ Additional requirements:
 After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run the following command instead of `build_mozc.py`:
 
 ```
-bazelisk --bazelrc=windows.bazelrc build --config oss_windows --config release_build package
+bazelisk build --config oss_windows --config release_build package
 ```
 
 You have release build binaries in `bazel-bin\win32\installer\Mozc64.msi`.

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -1,3 +1,6 @@
+## Startup options
+startup  --windows_enable_symlinks  # ignored on non-Windows platforms
+
 ## Target platforms
 common:linux      --config=linux_env --define TARGET=oss_linux
 common:oss_linux  --config=linux_env --define TARGET=oss_linux
@@ -24,6 +27,11 @@ build:dev_channel --define CHANNEL=dev
 build:release_build --compilation_mode=opt
 # Temporarily disable this definition to work around the build failure on Linux.
 # build:release_build --copt=-DABSL_MIN_LOG_LEVEL=100
+
+## Clang-cl toolchain for Windows
+build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
+build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
+build:windows_env --host_platform=//:host-windows-clang-cl
 
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like

--- a/src/windows.bazelrc
+++ b/src/windows.bazelrc
@@ -1,14 +1,1 @@
-# Currently there seems to be no way to customize startup option based on the
-# host platform.
-# https://github.com/bazelbuild/bazel/issues/22763
-# Thus having our own file here.
-# To specify this file, use the "-bazelrc" option as follows.
-#
-#   bazel --bazelrc=windows.bazelrc build //protocol:commands_proto \
-#         --config oss_windows
-
-startup  --windows_enable_symlinks
-
-build    --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
-build    --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
-build    --host_platform=//:host-windows-clang-cl
+# This file is deprecated and to be removed.


### PR DESCRIPTION
## Description
This follows up to my previous commit (9adf5cedd493084d2663a9b07f7808a9afa3bea9), which introduced `src/windows.bazelrc` to work around the path length limitation in cl.exe.

Now that Windows Bazel build has switched to clang-cl (#1198), the above workaround can also be removed. As the first step, this commit moves the remaining lines into `.bazelrc`. The actual file removal will happen in a subsequent commit.

No user-observable behavior change is intended in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/948
 * https://github.com/google/mozc/issues/1179

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
```
bazelisk build --config oss_windows --config release_build package
```
