### PR TITLE
Remove an obsolete comment from `MODULE.bazel`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -1,5 +1,3 @@
-# MODULE.bazel is the new dependency configuration system (Bzlmod), but not used yet by default.
-# To use Bzlmod, you need to specify --enable_bzlmod to the Bazel command or modify .bazelrc.
 module(name = "mozc")
 
 # absl-cpp: 2025-02-04


### PR DESCRIPTION
## Description
This follows up to our previous commit (834755d822574d98170f267166dec9e685651c45), which introduced the initial support for bzlmod (#1002).

Now that we have fully migrated to bzlmod and `WORKSPACE` support is already removed (#1115), the comment that implies that bzlmod is still an option is obsolete and just confusing.

Let's remove it to avoid possible confusions.

There must be no behavior change in the actual build steps.

## Issue IDs

 * https://github.com/google/mozc/issues/1002
 * https://github.com/google/mozc/issues/1115

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm GitHub Actions still pass
