### PR TITLE
Propagate `%ERRORLEVEL%` in the Bazel wrapper

### DIFF
--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -19,4 +19,4 @@ set TMP_MOZC_SRC_DIR=
 %BAZEL_REAL% %* & call:myexit
 
 :myexit
-exit /b
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Description
This follows up to my previous commit (e453da9454530e714e9e0ce542f3fc7684dcebe9), which introduced a Bazel wrapper batch file.

There was a bug that always reset `%ERRORLEVEL%` to `0` in the wrapper script, which has prevented any build and/or test failure from being shown up on the continuous build/test pages. Let's fix it by simply propagating `%ERRORLEVEL%` in the `exit` command.

Closes #1219.

## Issue IDs

 * https://github.com/google/mozc/issues/1219

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build //base/win32:com_implements_test --config oss_windows`
   2. Confirm `echo $?` returns `False`.
