### PR TITLE
Disable logging in the Bazel release builds again

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -25,8 +25,7 @@ build:dev_channel --define CHANNEL=dev
 
 ## Release build
 build:release_build --compilation_mode=opt
-# Temporarily disable this definition to work around the build failure on Linux.
-# build:release_build --copt=-DABSL_MIN_LOG_LEVEL=100
+build:release_build --copt=-DABSL_MIN_LOG_LEVEL=100
 
 ## Clang-cl toolchain for Windows
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl


### PR DESCRIPTION
## Description
This commit effectively reverts our previous commit (7ae3290debea57132aafe3649c59a62f02fe6d8a), which commented out the following compile option from the release build as a workaround for the compile error in abseil and GCC (https://github.com/abseil/abseil-cpp/issues/1814).
```
  --copt=-DABSL_MIN_LOG_LEVEL=100
```
Now that the compiler error between abseil and GCC has already addressed in abseil 20250127.0, we should be ready for reverting the above temporary workaround. With this commit each executable file is expected to be reduced by more than 100 kB as compilers and linkers can trim down unused code and data around logging. This should also match the behavior of GYP builds.

Closes #1221.

## Issue IDs

 * https://github.com/google/mozc/issues/1221

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm that GitHub Actions still succeed
   2. Confirm that artifact file (e.g. `Mozc64.msi`) becomes smaller.
