### PR TITLE
Fix `dbg` Bazel build on Windows

### DIFF
--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -498,9 +498,10 @@ def mozc_cc_win32_library(
         name = cc_binary_target_name,
         srcs = srcs,
         deps = deps,
-        features = ["-generate_pdb_file"],
         win_def_file = win_def_file,
         linkshared = 1,
+        # Workaround for https://github.com/google/mozc/issues/1224
+        linkopts = ["/DEBUG"],
         tags = tags,
         target_compatible_with = target_compatible_with,
         visibility = ["//visibility:private"],


### PR DESCRIPTION
## Description
It turned out that my previous commit (51b4cd065d78aac6bec9a6152b9d96de00ec9c76), which aimed to generate a PDB file from`mozc_win32_cc_prod_binary` (#1108), introduced a build failure for `dbg` build.

This commit reworks `mozc_cc_win32_library` so that it can work for both `dbg` and `opt` builds.

No user-observable behavior change is intended.

Closes #1224.

## Issue IDs
 * https://github.com/google/mozc/issues/1108
 * https://github.com/google/mozc/issues/1224

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm `bazelisk build package --config oss_windows -c dbg` succeeds
   2. Confirm `bazelisk build package --config oss_windows --config release_build` succeeds
