### PR TITLE
Fix the Windows build of `//unix/ibus:gen_main_h`

### DIFF
--- a/src/unix/ibus/gen_mozc_xml.py
+++ b/src/unix/ibus/gen_mozc_xml.py
@@ -174,10 +174,10 @@ def OutputCpp(component, engine_common, engines):
     OutputCppVariable('Engine', key, value)
   print('const size_t kEngineArrayLen = %s;' % len(engines))
   print('const char kEnginesXml[] = R"#(', end='')
-  print(GetEnginesXml(engine_common, engines))
+  print(GetEnginesXml(engine_common, engines).encode('utf-8'))
   print(')#";')
   print('const char kIbusConfigTextProto[] = R"#(', end='')
-  print(GetIbusConfigTextProto(engines))
+  print(GetIbusConfigTextProto(engines).encode('utf-8'))
   print(')#";')
   print(CPP_FOOTER % guard_name)
 


### PR DESCRIPTION
## Description
As part of running unit tests with Bazel on Windows (#1223), this commit fixes an existing build failure of `//unix/ibus:gen_main_h`, which is required by `//unix/ibus:ibus_config_test`.

Perhaps test targets under `//unix/ibus/...` should have been annotated with `target_compatible_with` so that they can be excluded on non-Linux desktop builds, but at this point just fixing `//unix/ibus:gen_main_h` on Windows is easier.

No user-visible behavior change is intended in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1223

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. .Confirm `bazelisk build //unix/ibus:gen_main_h --config oss_windows` succeeds
