### PR TITLE
Specify `target_compatible_with` for IBus tests

### DIFF
--- a/src/unix/ibus/BUILD.bazel
+++ b/src/unix/ibus/BUILD.bazel
@@ -163,6 +163,7 @@ mozc_cc_test(
         "message_translator_test.cc",
         "path_util_test.cc",
     ],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":ibus_utils",
         "//testing:gunit_main",
@@ -266,6 +267,7 @@ mozc_cc_test(
     name = "ibus_config_test",
     size = "small",
     srcs = ["ibus_config_test.cc"],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":ibus_config",
         ":ibus_config_cc_proto",
@@ -311,6 +313,7 @@ mozc_cc_test(
             "surrounding_text_util_test.cc",
         ],
     ),
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":ibus_config",
         ":ibus_mozc_lib",
@@ -366,6 +369,7 @@ mozc_cc_library(
 mozc_cc_test(
     name = "candidate_window_handler_test",
     srcs = mozc_select(linux = ["candidate_window_handler_test.cc"]),
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":candidate_window_handler",
         "//base:coordinates",


### PR DESCRIPTION
## Description
As a preparation to make unit tests run with Bazel on Windows (#1223), this commit sets `target_compatible_with` to tests under `src/unix/ibus/...` so that such tests can be excluded when the target is Android, macOS and Windows. Otherwise, `//unix/ibus:gen_main_h` cannot be built on Windows.

## Issue IDs

 * https://github.com/google/mozc/issues/1223

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build //unix/ibus/... --config oss_windows --build_tests_only`

