### PR TITLE
Add some middle dot symbols

### DIFF
--- a/src/data/symbol/symbol.tsv
+++ b/src/data/symbol/symbol.tsv
@@ -359,10 +359,10 @@ POS	CHAR	Reading (space separated)	description	additional description	category	m
 アルファベット	э	きりる ろしあ えー	キリル文字	小文字
 アルファベット	ю	きりる ろしあ ゆー	キリル文字	小文字
 アルファベット	я	きりる ろしあ やー	キリル文字	小文字
-句読点	·	てん なかてん なかぐろ 、 ・ /	中点	欧文		OTHER	U+00B7 MIDDLE DOT
-句読点	•	てん びゅれっと ぶれっと ばれっと ぶりっと 、 ・ /	ビュレット		OTHER	リストの点は本来これ・圏点に使われることあり https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis#dot	U+2022 BULLET
-句読点	◦	てん びゅれっと ぶれっと ばれっと ぶりっと 、 ・ /	白ビュレット		OTHER		U+25E6 WHITE BULLET
-記号	⋅	てん ないせき かける ・	内積 乗算	ドット演算子	SYMBOL	TeXの\cdot https://medemanabu.net/latex/dots/	U+22C5 DOT OPERATOR
+句読点	·	てん なかてん なかぐろ ・	中点	欧文		OTHER	U+00B7 MIDDLE DOT
+句読点	•	てん びゅれっと ぶれっと ばれっと ぶりっと ・ * 	ビュレット		OTHER		U+2022 BULLET
+句読点	◦	てん びゅれっと ぶれっと ばれっと ぶりっと ・ *	白ビュレット		OTHER		U+25E6 WHITE BULLET
+記号	⋅	てん ないせき かける ・ *	内積 乗算	ドット演算子	SYMBOL		U+22C5 DOT OPERATOR
 記号	─	けいせん ほそわく よこ	罫線		OTHER
 記号	│	けいせん ほそわく たて	罫線		OTHER
 記号	┌	けいせん ほそわく ひだりうえ	罫線		OTHER


### PR DESCRIPTION
## Description

Makes it possible to input some single dot symbols similar to the katakana middle dot (・):

| Symbol | Unicode | JIS X 0213 | Description |
| -------- | --------- |  ----------- | -------- |
| · | U+00B7 MIDDLE DOT | 1-9-14 | middle dot for Euroamerican languages  |
| • | U+2022 BULLET | 1-3-32 | List mark or emphasis mark (<span lang="ja">圏点</span>) when `text-emphasis: dot` in CSS |
| ◦ | U+25E6 WHITE BULLET | 1-3-31 | 〃 |
| ⋅ | U+22C5 DOT OPERATOR | - | multiplication instead of ×; inner product of vectors; `\cdot` in LaTeX |

## Issue IDs
Issue and/or discussion IDs related to this pull request.

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: [e.g. Windows 11, macOS 13.1, etc]
 - Steps:
   1. Input ・
   2. Compose
   3. Confirm all of them appear around the division mark ÷

## Additional context
Add any other context about the pull request here.

![image](https://github.com/user-attachments/assets/121e8abb-11cd-4044-a347-d0c13b216d6e)

![image](https://github.com/user-attachments/assets/dd420b54-2eca-4758-9930-a63bd9f4c776)