### PR TITLE
Fix configuration example for enabling JIS layout

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -155,7 +155,7 @@ Sample configuration:
 engines {
   name : "mozc-jp"
   longname : "Mozc"
-  layout : "ja"  # or "us"
+  layout : "jp"  # or "us"
   layout_variant : ""
   layout_option : ""
   rank : 80
@@ -190,7 +190,7 @@ active_on_launch: True  # default is False.
 engines {
   name : "mozc-jp"
   longname : "Mozc"
-  layout : "ja"
+  layout : "jp"
   layout_variant : ""
   layout_option : ""
   rank : 80


### PR DESCRIPTION
## Description

As I understand it, "ja" is used in locale, but the keyboard layout is "jp".

## Issue IDs

none

## Steps to test new behaviors (if any)

Using "ja" does not change actual layout from ANSI. And switcing to "jp" fixed the behavior.

## Additional context

```console
> grep 'PRETTY_NAME' /etc/os-release
PRETTY_NAME="NixOS 24.11 (Vicuna)"

> grep --perl-regexp '\b(ja|jp)\b' /etc/X11/xkb/rules/base.lst
  jp              Japanese
  kana            jp: Japanese (Kana)
  kana86          jp: Japanese (Kana 86)
  OADG109A        jp: Japanese (OADG 109A)
  mac             jp: Japanese (Macintosh)
  dvorak          jp: Japanese (Dvorak)
```