### PR TITLE
bzlmod: Update `protobuf` to 30.2

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -17,13 +17,11 @@ bazel_dep(
     version = "2024-07-02.bcr.1",
 )
 
-# protobuf: 29.3 2025-01-09
+# protobuf: 30.2 2025-03-27
 # https://github.com/protocolbuffers/protobuf
-# We cannot switch to 30.x until the protobuf team fixes the following issue.
-#   * https://github.com/protocolbuffers/protobuf/issues/20645
 bazel_dep(
     name = "protobuf",
-    version = "29.3",
+    version = "30.2",
     repo_name = "com_google_protobuf",
 )
 


### PR DESCRIPTION
## Description
As planned in #1240, this commit updates `MODULE.bazel` as follows.

 * `protobuf`: 29.3 -> 30.2

Note that GYP build remain unchanged until the corresponding git submodule is updated to the above version.

No user-visible behavior change is intended in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1240

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm GitHub Actions are still passing
