### PR TITLE
Remove no-op `windows.bazelrc`

### DIFF
--- a/src/windows.bazelrc
+++ b/src/windows.bazelrc
@@ -1,1 +1,0 @@
-# This file is deprecated and to be removed.


### PR DESCRIPTION
## Description
Now that `windows.bazelrc` is effectively no-op (94151b318aaa6f496e012be975f3212485958fd3), we should be able to safely remove it. If your continuous builds still have `--bazelrc=windows.bazelrc` then just remove it.

There must be no difference in the final artifacts.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
```
python build_tools/update_deps.py
python build_tools/build_qt.py --release --confirm_license
bazelisk build package --config oss_windows --config release_build
```
