### PR TITLE
Fix `_WIN32_WINNT` redefinition warnings

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -31,6 +31,7 @@ build:release_build --copt=-DABSL_MIN_LOG_LEVEL=100
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
 build:windows_env --host_platform=//:host-windows-clang-cl
+build:windows_env --copt "/D_WIN32_WINNT=0x0A00" --host_copt "/D_WIN32_WINNT=0x0A00"
 
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like

--- a/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
@@ -9,7 +9,15 @@
  
  def _impl(ctx):
      if _use_msvc_toolchain(ctx):
-@@ -763,7 +763,7 @@ def _impl(ctx):
+@@ -753,7 +753,6 @@ def _impl(ctx):
+                             flags = [
+                                 "/DCOMPILER_MSVC",
+                                 "/DNOMINMAX",
+-                                "/D_WIN32_WINNT=0x0601",
+                                 "/D_CRT_SECURE_NO_DEPRECATE",
+                                 "/D_CRT_SECURE_NO_WARNINGS",
+                                 "/bigobj",
+@@ -763,7 +762,7 @@ def _impl(ctx):
                                  "/wd4291",
                                  "/wd4250",
                                  "/wd4996",


### PR DESCRIPTION
## Description
This commit aims to address `_WIN32_WINNT` redefinition warnings from `clang-cl`.

The issue is `rules_cc_windows_cc_toolchain_config.bzl` in `rules_cc` hard-codes `_WIN32_WINNT` to be 0x0601. As a temporary workaround, this commit reuses `bazel/rules_cc_windows_cc_toolchain_config.bzl.patch`, which was introduced to support clang-cl to build x86 binaries (76343ffa704021a10ee6deec7d887d1c1e0f472b).

The final artifacts remain unchanged.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build package --config oss_windows --config release_build`
   2. Confirm there is no warning due to `_WIN32_WINNT` redefinition.

