### PR TITLE
Specify `target_compatible_with` to `qt_build_test`

### DIFF
--- a/src/renderer/qt/BUILD.bazel
+++ b/src/renderer/qt/BUILD.bazel
@@ -145,6 +145,7 @@ mozc_cc_qt_library(
 
 build_test(
     name = "qt_build_test",
+    target_compatible_with = ["@platforms//os:linux"],
     targets = [
         ":qt_ipc_server",
         ":qt_ipc_thread",


### PR DESCRIPTION
## Description
As a preparation to make unit tests run with Bazel on Windows (#1223), this commit sets `target_compatible_with` to `qt_build_test` so that the test can be excluded when the target is Android, macOS and Windows.

## Issue IDs

 * https://github.com/google/mozc/issues/1223

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build //renderer/qt/... --config oss_windows --build_tests_only`

