### PR TITLE
Set `--enable_runfiles` for Windows Bazel builds

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -60,6 +60,7 @@ build:macos_env --build_tag_filters=-nomac --objccopt "-fsigned-char"
 test:macos_env   --test_tag_filters=-nomac
 
 ## Windows specific options
+common:windows_env --enable_runfiles
 build:windows_env --build_tag_filters=-nowin
 test:windows_env   --test_tag_filters=-nowin
 


### PR DESCRIPTION
## Description
As a preparation to make unit tests run with Bazel on Windows (#1223), this commit adds `--enable_runfiles` to build/test commands on Windows. Otherwise, some tests fail due to missing generated files.

## Issue IDs

 * https://github.com/google/mozc/issues/1223

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. ` bazelisk test //win32/base:text_icon_test --config oss_windows -c dbg --build_tests_only`
