### PR TITLE
Switch to Qt 6.9.0 for macOS and Windows

### DIFF
--- a/docs/build_mozc_in_osx.md
+++ b/docs/build_mozc_in_osx.md
@@ -70,7 +70,7 @@ python build_tools/update_deps.py
 In this step, additional build dependencies will be downloaded.
 
   * [Ninja 1.11.0](https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-mac.zip)
-  * [Qt 6.8.0](https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz)
+  * [Qt 6.9.0](https://download.qt.io/archive/qt/6.9/6.9.0/submodules/qtbase-everywhere-src-6.9.0.tar.xz)
   * [git submodules](../.gitmodules)
 
 You can specify `--noqt` option if you would like to use your own Qt binaries.

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -70,7 +70,7 @@ In this step, additional build dependencies will be downloaded.
   * [LLVM 20.1.0](https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0)
   * [MSYS2 2025-02-21](https://github.com/msys2/msys2-installer/releases/tag/2025-02-21)
   * [Ninja 1.11.0](https://github.com/ninja-build/ninja/releases/download/v1.11.0/ninja-win.zip)
-  * [Qt 6.8.0](https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz)
+  * [Qt 6.9.0](https://download.qt.io/archive/qt/6.9/6.9.0/submodules/qtbase-everywhere-src-6.9.0.tar.xz)
   * [.NET tools](../dotnet-tools.json)
   * [git submodules](../.gitmodules)
 

--- a/src/build_tools/build_qt.py
+++ b/src/build_tools/build_qt.py
@@ -37,7 +37,7 @@ with dropping unnecessary features to minimize the installer size.
 
 By default, this script assumes that Qt archives are stored as
 
-  src/third_party_cache/qtbase-everywhere-src-6.8.0.tar.xz
+  src/third_party_cache/qtbase-everywhere-src-6.9.0.tar.xz
 
 and Qt src files that are necessary to build Mozc will be checked out into
 
@@ -72,7 +72,7 @@ ABS_QT_DEST_DIR = ABS_MOZC_SRC_DIR.joinpath('third_party', 'qt')
 ABS_QT_HOST_DIR = ABS_MOZC_SRC_DIR.joinpath('third_party', 'qt_host')
 # The archive filename should be consistent with update_deps.py.
 ABS_QT6_ARCHIVE_PATH = ABS_MOZC_SRC_DIR.joinpath(
-    'third_party_cache', 'qtbase-everywhere-src-6.8.0.tar.xz'
+    'third_party_cache', 'qtbase-everywhere-src-6.9.0.tar.xz'
 )
 ABS_DEFAULT_NINJA_DIR = ABS_MOZC_SRC_DIR.joinpath('third_party', 'ninja')
 QT_CONFIGURE_COMMON = [

--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -86,9 +86,9 @@ class ArchiveInfo:
 
 
 QT6 = ArchiveInfo(
-    url='https://download.qt.io/archive/qt/6.8/6.8.0/submodules/qtbase-everywhere-src-6.8.0.tar.xz',
-    size=49819628,
-    sha256='1bad481710aa27f872de6c9f72651f89a6107f0077003d0ebfcc9fd15cba3c75',
+    url='https://download.qt.io/archive/qt/6.9/6.9.0/submodules/qtbase-everywhere-src-6.9.0.tar.xz',
+    size=49658320,
+    sha256='c1800c2ea835801af04a05d4a32321d79a93954ee3ae2172bbeacf13d1f0598c',
 )
 
 NDK_LINUX = ArchiveInfo(


### PR DESCRIPTION
## Description
With this commit macOS and Windows builds switch to Qt 6.9.0.

Here is the release note:
https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md

Closes #1247.

## Issue IDs

 * https://github.com/google/mozc/issues/1247

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 24H2, macOS 14.7.4
 - Steps:
   1. Confirm GitHub Actions are still passing.
