### PR TITLE
Fix `counter_suffix.data` corruption on Windows Bazel build

### DIFF
--- a/src/dictionary/gen_filtered_dictionary.py
+++ b/src/dictionary/gen_filtered_dictionary.py
@@ -82,7 +82,7 @@ class Dictionary():
     return False
 
   def WriteFile(self, output):
-    with open(output, 'w', encoding='utf-8') as file:
+    with open(output, 'w', encoding='utf-8', newline='\n') as file:
       for line in self.lines:
         file.write(line)
 


### PR DESCRIPTION
## Description
Many dictionary-related scripts assume dictionary files including generated ones have LF as the line ending. Without this change, `counter_suffix.data` will not be created as expected only on Windows Bazel build, which is why `NumberRewriter::RewriteOneSegment` does not work here.

Closes #1251.

## Issue IDs

 * https://github.com/google/mozc/issues/1251

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build `Mozc64.msi` with Bazel and install it.
   2. Confirm '1本' is included in the candidate list of 'いっぽん'
