### PR TITLE
Make `update_deps.py` compatible with Python 3.9

### DIFF
--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -221,7 +221,11 @@ def remove_directory(path: os.PathLike[str]):
   Args:
     path: the directory path to be deleted.
   """
-  shutil.rmtree(path, onexc=_remove_readonly)
+  # 'onexc' is added in Python 3.12.
+  if 'onexc' in shutil.rmtree.__code__.co_varnames:
+    shutil.rmtree(path, onexc=_remove_readonly)
+  else:
+    shutil.rmtree(path, onerror=_remove_readonly)
 
 
 def llvm_extract_filter(


### PR DESCRIPTION
## Description
This follows up to my previous commit (837d4da6b3b26283f406f761e3606adca1bd11fb), where `update_deps.py` is updated to also deploy MSYS2 for Windows to automate build environment setup for Windows.

The issue is that the above commit introduced the dependency on `onexc` parameter in `shutil.rmtree`, which is only available in Python 3.12 and later, while we still would like to support Python 3.9.6 that is installed as part of Xcode Command Line Tools.

To make `update_deps.py` compatible with Python 3.9.6 again, let's use `onexc` when and only when it is actually available.

## Issue IDs

 * https://github.com/google/mozc/pull/1079

## Steps to test new behaviors (if any)
 - OS: macOS Sequoia 15.4
 - Steps:
   1. Confirm `python3 build_tools/update_deps.py` succeeds.
