### PR TITLE
Make `usage_item_array.data` stable

### DIFF
--- a/src/rewriter/gen_usage_rewriter_dictionary_main.cc
+++ b/src/rewriter/gen_usage_rewriter_dictionary_main.cc
@@ -275,7 +275,8 @@ void Convert() {
   LoadUsage(absl::GetFlag(FLAGS_usage_data_file), &usage_entries,
             &conjugation_list);
   RemoveBaseformConjugationSuffix(baseform_map, &usage_entries);
-  std::sort(usage_entries.begin(), usage_entries.end(), UsageItemKeynameCmp);
+  std::stable_sort(
+      usage_entries.begin(), usage_entries.end(), UsageItemKeynameCmp);
 
   // Assign unique index to every string data.  The same string share the same
   // index, so the data is slightly compressed.


### PR DESCRIPTION
## Description
Previously the content of `usage_item_array.data` was processed with `std::sort` rather than `std::stable_sort`. As a result, the content can easily vary depending on platforms (to be precise STL implementations).

By switching to `std::stable_sort`, we can assume the same content will be generated across platforms, which would be a huge win when diagnosing conversion related issues.

Note that `gen_usage_rewriter_dictionary_main.cc` runs as a build step. Thus there should be no major performance implications at runtime.

Closes #1254.

## Issue IDs

 * https://github.com/google/mozc/issues/1254

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: All
 - Steps:
   1. `bazelisk //data_manager/oss:mozc_dataset_for_oss --config oss_windows` (on Windows)
   2. `bazelisk //data_manager/oss:mozc_dataset_for_oss --config oss_macos` (on macOS)
   3. `bazelisk //data_manager/oss:mozc_dataset_for_oss --config oss_linux` (on Linux)
   4. Confirm `bazel-bin/data_manager/oss/usage_item_array.data` is the same.

