### PR TITLE
Normalize `submodules` param in `actions/checkout`

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: setup
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'false'
+          submodules: false
 
       - name: Run
         working-directory: ./src

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Setup
         run: |
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Setup
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -62,7 +62,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -103,7 +103,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -144,7 +144,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -180,6 +180,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          submodules: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Set up pip
         shell: cmd
@@ -83,7 +83,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -135,7 +135,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: recursive
 
       - name: Set up pip
         shell: cmd
@@ -179,6 +179,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Description
Removed unnecessary quotes around the `submodules` parameter in the [`actions/checkout`](https://github.com/actions/checkout) step for better readability and consistency.

Note that there are no functional changes, as the quotes were not needed in the first place. This change is purely cosmetic and aims to improve the readability of the workflow files.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm all the GitHub Actions are still passing
