### PR TITLE
Fix `evaluation_diff_test` on Windows

### DIFF
--- a/src/converter/quality_regression.py
+++ b/src/converter/quality_regression.py
@@ -72,7 +72,7 @@ def LoadInput(input_file, input_version, base_data):
 def SaveOutput(output_file, output_lines):
   """Save the output file."""
   fields = ['status', 'input', 'output', 'command', 'argument', 'version']
-  with open(output_file, 'w', encoding='utf-8') as file:
+  with open(output_file, 'w', encoding='utf-8', newline='\n') as file:
     file.write('# ' + '\t'.join(fields) + '\n')
     file.write('\n'.join(output_lines) + '\n')
 


### PR DESCRIPTION
## Description
Currently `evaluation_diff_test`, which is using `diff_test`, is failing on Windows because `evaluation_updated.tsv` is using **CRLF** line endings whereas `evaluation.tsv` is using **LF** line endings. This commit fixes this by ensuring that `evaluation_updated.tsv` is created with **LF** line endings even on Windows.

Closes #1250.

## Issue IDs

 * https://github.com/google/mozc/issues/1250

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm `bazelisk test //data/dictionary_oss:evaluation_diff_test --config oss_windows -c dbg` passes
