### PR TITLE
Run `bazelisk test` for Windows in GitHub Actions

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -168,6 +168,38 @@ jobs:
         run: |
           python build_mozc.py runtests -c Debug
 
+  test_bazel:
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+    runs-on: windows-2022
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v4
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py
+
+      - name: runtests
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk test ... --config oss_windows -c dbg --build_tests_only
+
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".
   # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow


### PR DESCRIPTION
## Description
Now that all the known test failures in Bazel builds on Windows are fixed, we should be ready to run these tests continuously like other platforms.

Closes #1223.

## Issue IDs

 * https://github.com/google/mozc/issues/1223

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. .Confirm `test_bazel` for Windows is passing in GitHub Actions.
