### PR TITLE
Stop using `CrashReportHandler` under `win32/tip`

### DIFF
--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -55,11 +55,9 @@ mozc_cc_library(
         ":tip_text_service_impl",
         ":tip_ui_handler",
         ":tip_ui_handler_impl",
-        "//base:crash_report_handler",
         "//base/protobuf",
         "//base/protobuf:message",
         "//base/win32:com_implements",
-        "//config:stats_config_util",
         "//win32/base:tsf_profile",
         "@com_google_absl//absl/base",
     ],
@@ -127,9 +125,7 @@ mozc_cc_library(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
-        "//base:crash_report_handler",
         "//base/win32:com_implements",
-        "@com_google_absl//absl/base",
     ],
 )
 
@@ -726,7 +722,6 @@ mozc_cc_test(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":tip_display_attributes",
-        ":tip_dll_module",
         "//testing:gunit_main",
         "@com_microsoft_wil//:wil",
     ],
@@ -739,7 +734,6 @@ mozc_cc_test(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
-        ":tip_dll_module",
         ":tip_enum_display_attributes",
         "//testing:gunit_main",
         "@com_microsoft_wil//:wil",

--- a/src/win32/tip/tip.gyp
+++ b/src/win32/tip/tip.gyp
@@ -95,12 +95,10 @@
           'dependencies': [
             '<(mozc_oss_src_dir)/base/absl.gyp:absl_base',
             '<(mozc_oss_src_dir)/base/base.gyp:base',
-            '<(mozc_oss_src_dir)/base/base.gyp:crash_report_handler',
             '<(mozc_oss_src_dir)/base/base.gyp:update_util',
             '<(mozc_oss_src_dir)/base/win32/base_win32.gyp:com_implements',
             '<(mozc_oss_src_dir)/client/client.gyp:client',
             '<(mozc_oss_src_dir)/config/config.gyp:config_handler',
-            '<(mozc_oss_src_dir)/config/config.gyp:stats_config_util',
             '<(mozc_oss_src_dir)/protobuf/protobuf.gyp:protobuf',
             '<(mozc_oss_src_dir)/protocol/protocol.gyp:commands_proto',
             '<(mozc_oss_src_dir)/protocol/protocol.gyp:renderer_proto',

--- a/src/win32/tip/tip_candidate_list_test.cc
+++ b/src/win32/tip/tip_candidate_list_test.cc
@@ -42,7 +42,6 @@
 
 #include "absl/strings/string_view.h"
 #include "testing/gunit.h"
-#include "win32/tip/tip_dll_module.h"
 
 namespace mozc {
 namespace win32 {
@@ -52,11 +51,6 @@ namespace {
 using ::testing::AssertionFailure;
 using ::testing::AssertionResult;
 using ::testing::AssertionSuccess;
-
-class TipCandidateListTest : public testing::Test {
- protected:
-  static void SetUpTestCase() { TipDllModule::InitForUnitTest(); }
-};
 
 class MockCallbackResult {
  public:

--- a/src/win32/tip/tip_display_attributes_test.cc
+++ b/src/win32/tip/tip_display_attributes_test.cc
@@ -36,7 +36,6 @@
 #include <string>
 
 #include "testing/gunit.h"
-#include "win32/tip/tip_dll_module.h"
 
 namespace mozc {
 namespace win32 {
@@ -84,11 +83,6 @@ bool IsSameColor(const TF_DA_COLOR &color1, const TF_DA_COLOR &color2) {
 }
 
 }  // namespace
-
-class TipDisplayAttributesTest : public testing::Test {
- protected:
-  static void SetUpTestCase() { TipDllModule::InitForUnitTest(); }
-};
 
 TEST(TipDisplayAttributesTest, BasicTest) {
   TestableTipDisplayAttribute attribute(kTestGuid, kTestAttribute,

--- a/src/win32/tip/tip_dll_module.cc
+++ b/src/win32/tip/tip_dll_module.cc
@@ -31,24 +31,10 @@
 
 #include <windows.h>
 
-#include "absl/base/call_once.h"
-#include "base/crash_report_handler.h"
-
 namespace mozc::win32::tsf {
-namespace {
-
-void TipShutdownCrashReportHandler() {
-  if (CrashReportHandler::IsInitialized()) {
-    // Uninitialize the breakpad.
-    CrashReportHandler::Uninitialize();
-  }
-}
-
-}  // namespace
 
 HMODULE TipDllModule::module_handle_ = nullptr;
 bool TipDllModule::unloaded_ = false;
-absl::once_flag TipDllModule::uninitialize_once_;
 
 void TipComTraits::OnObjectRelease(ULONG ref) {
   if (ref == 0) {
@@ -68,11 +54,6 @@ void TipDllModule::PrepareForShutdown() {
   // here.
   // - mozc::FinalizeSingletons()                - b/10233768
   // - mozc::protobuf::ShutdownProtobufLibrary() - b/2126375
-  absl::call_once(uninitialize_once_, &TipShutdownCrashReportHandler);
-}
-
-void TipDllModule::InitForUnitTest() {
-  absl::call_once(uninitialize_once_, []() {});
 }
 
 }  // namespace mozc::win32::tsf

--- a/src/win32/tip/tip_dll_module.h
+++ b/src/win32/tip/tip_dll_module.h
@@ -32,7 +32,6 @@
 
 #include <windows.h>
 
-#include "absl/base/call_once.h"
 #include "base/win32/com_implements.h"
 
 namespace mozc {
@@ -57,12 +56,9 @@ class TipDllModule {
   static void set_module_handle(HMODULE handle) { module_handle_ = handle; }
   static HMODULE module_handle() { return module_handle_; }
 
-  static void InitForUnitTest();
-
  private:
   static HMODULE module_handle_;
   static bool unloaded_;
-  static absl::once_flag uninitialize_once_;
 };
 
 template <typename... Interfaces>

--- a/src/win32/tip/tip_enum_display_attributes_test.cc
+++ b/src/win32/tip/tip_enum_display_attributes_test.cc
@@ -35,19 +35,13 @@
 #include <iterator>
 
 #include "testing/gunit.h"
-#include "win32/tip/tip_dll_module.h"
 
 namespace mozc {
 namespace win32 {
 namespace tsf {
 namespace {
 
-class TipEnumDisplayAttributesTest : public testing::Test {
- protected:
-  TipEnumDisplayAttributesTest() { TipDllModule::InitForUnitTest(); }
-};
-
-TEST_F(TipEnumDisplayAttributesTest, BasicTest) {
+TEST(TipEnumDisplayAttributesTest, BasicTest) {
   TipEnumDisplayAttributes enum_display_attribute;
   ASSERT_TRUE(SUCCEEDED(enum_display_attribute.Reset()));
 
@@ -68,7 +62,7 @@ TEST_F(TipEnumDisplayAttributesTest, BasicTest) {
   }
 }
 
-TEST_F(TipEnumDisplayAttributesTest, NextTest) {
+TEST(TipEnumDisplayAttributesTest, NextTest) {
   TipEnumDisplayAttributes enum_display_attribute;
 
   ITfDisplayAttributeInfo *infolist[4] = {};


### PR DESCRIPTION
## Description
As the first step towards removing `CrashReportHandler` from the codebase (#1263), this commit removes its usage from the `src/win32/tip` directory.

Other directories will be handled in subsequent commits.

Note that there must be no observable behavior change as `CrashReportHandler` has been no-op in the OSS build. It is used when and only when 1) `branding` is `GoogleJapaneseInput` and 2) it is built with GYP.

## Issue IDs

 * https://github.com/google/mozc/issues/1263

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk test ... --config oss_windows -c dbg --build_tests_only`
