### PR TITLE
Skip building Qt when running tests on macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -158,12 +158,6 @@ jobs:
         run: |
           python3 build_tools/update_deps.py
 
-      - name: Build Qt
-        working-directory: ./src
-        run: |
-          python3 build_tools/build_qt.py --release --confirm_license
-          echo "MOZC_QT_PATH=${PWD}/third_party/qt" >> $GITHUB_ENV
-
       - name: bazel test
         working-directory: ./src
         run: |


### PR DESCRIPTION
## Description
With my previous commit (a45df5915dcf8edb6ed0fe3e8e30e9e53e8cd523), it should no longer be necessary to build Qt before running unit tests on macOS.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: macOS 14
 - Steps:
   1. Confirm the GitHub Actions are still passing
