### PR TITLE
Override `QT_QPA_PLATFORM` only on Linux desktop

### DIFF
--- a/src/renderer/qt/qt_server.cc
+++ b/src/renderer/qt/qt_server.cc
@@ -29,7 +29,9 @@
 
 #include "renderer/qt/qt_server.h"
 
+#if defined(__linux__) && !defined(__ANDROID__)
 #include <stdlib.h>
+#endif  // __linux__ && !__ANDROID__
 
 #include <QApplication>
 #include <QMetaType>
@@ -104,9 +106,12 @@ void QtServer::Update(std::string command) {
 }
 
 int QtServer::StartServer(int argc, char **argv) {
+
+#if defined(__linux__) && !defined(__ANDROID__)
   // |QWidget::move()| never works with wayland platform backend. Always use
   // 'xcb' platform backend.  https://github.com/google/mozc/issues/794
   ::setenv("QT_QPA_PLATFORM", "xcb", 1);
+#endif  // __linux__ && !__ANDROID__
 
   qRegisterMetaType<std::string>("std::string");
   QApplication app(argc, argv);


### PR DESCRIPTION
## Description
This follows up to my previous commit (f8b2358b171b0baf095b53ad2c828fc647901d2e), which attempted to let Qt `mozc_renderer` always use X11 protocol to work around #794.

What is remaining is that we want to keep Qt `mozc_renderer` buildable not only on Linux but also on macOS and Windows. So let's apply the above workaround only for Linux desktop.

## Issue IDs

 * https://github.com/google/mozc/issues/794

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build --config oss_windows --config release_build //renderer/qt:mozc_renderer`
