### PR TITLE
Fix `Valid/Utf8AsCharsTest.Substring/1` on Windows

### DIFF
--- a/src/base/strings/unicode.h
+++ b/src/base/strings/unicode.h
@@ -282,7 +282,7 @@ class Utf8CharIterator {
   template <typename RBaseIterator, typename RValueType>
   constexpr bool operator==(
       const Utf8CharIterator<RBaseIterator, RValueType> rhs) const {
-    return iter_ == rhs.iter_;
+    return std::to_address(iter_) == std::to_address(rhs.iter_);
   }
 
  private:


### PR DESCRIPTION
## Description
This follows up to our previous commits (0fa9ade2d2bc3143ec654a2c2e57fa70702d6157), which attempted to refactor Utf8CharIterator with C++20 contiguous iterators and <=> comparisons but also caused a build failure of `strings_unicode_test.cc` on Windows.

While the build failure of the test was already addressed by the subsequent commit (342eaf8eb76679d13864f12a1182484ebb7c23eb), the test is still failing due to an additional assertion implemented in microsoft/STL.

https://github.com/microsoft/STL/blob/b5df16a98934319e2e6864d6036cbe9cd9c74faf/stl/inc/__msvc_string_view.hpp#L1367-L1375
```cpp
    _NODISCARD constexpr bool operator==(const _String_view_iterator& _Right) const noexcept {
#if _ITERATOR_DEBUG_LEVEL >= 1
        _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
            "cannot compare incompatible string_view iterators for equality");
        return _Myoff == _Right._Myoff;
#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
        return _Myptr == _Right._Myptr;
#endif // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^
    }
```

This commit addresses the assertion failure by making sure that `Utf8CharIterator::operator==()` is comparering the two raw pointers.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build //base/strings:unicode_test --config oss_windows -c dbg --build_tests_only`
