### PR TITLE
Add `open.py` to open file after resolving symlink

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -177,7 +177,11 @@ After running `build_tools/update_deps.py` and `build_tools/build_qt.py`, run th
 bazelisk build --config oss_windows --config release_build package
 ```
 
-You have release build binaries in `bazel-bin\win32\installer\Mozc64.msi`.
+To install `bazel-bin/win32/installer/Mozc64.msi` built with the above command,
+run the following command.
+```
+python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
+```
 
 ### Tips for Bazel setup
 

--- a/src/build_tools/open.py
+++ b/src/build_tools/open.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright 2010-2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""A cross-platform script to open file with resolving symlink.
+
+Usage:
+  % python3 build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
+"""
+
+import argparse
+import os
+import pathlib
+import subprocess
+
+
+def is_windows() -> bool:
+  """Returns true if the platform is Windows."""
+  return os.name == 'nt'
+
+
+def is_mac() -> bool:
+  """Returns true if the platform is Mac."""
+  return os.name == 'posix' and os.uname()[0] == 'Darwin'
+
+
+def is_linux() -> bool:
+  """Returns true if the platform is Linux."""
+  return os.name == 'posix' and os.uname()[0] == 'Linux'
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('filename', type=str)
+
+  args = parser.parse_args()
+
+  if args.filename is None:
+    print('Please specify the filename.')
+    return
+
+  filename = pathlib.Path(args.filename)
+  abspath = filename.resolve()
+
+  if not abspath.exists():
+    if abspath == filename:
+      print(f'The specified file {filename} does not exist.')
+    else:
+      print(f'The specified file {filename} ({abspath}) does not exist.')
+    return
+
+  command = []
+  if is_windows():
+    command = ['cmd', '/c', 'start', str(abspath)]
+  elif is_mac():
+    command = ['open', str(abspath)]
+  elif is_linux():
+    command = ['xdg-open', str(abspath)]
+  else:
+    print('Unsupported platform.')
+    return
+  subprocess.run(command, shell=False, check=False)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Description
When `Mozc64.msi` is built with Bazel, it is placed under a symlinked directory, which `msiexec.exe` does not recognize. To avoid this pitfall this commit introduces a helper script `open.py` to open the file after resolving symlink so that the real path can be passed to 'msiexec.exe'.

```
  python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
```

With above the build instructions can be simplified as the readers can just copy and paste the commands to build the installer then install it.

Closes #1283.

## Issue IDs

 * https://github.com/google/mozc/issues/1283

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. `bazelisk build --config oss_windows --config release_build package`
   2. `python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi`

