### PR TITLE
Get surrounding text from transitory context if possible

### DIFF
--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -211,7 +211,10 @@ mozc_cc_library(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        ":tip_compartment_util",
+        "//base:absl_nullability",
         "//base/win32:com",
+        "//base/win32:hresultor",
         "@com_microsoft_wil//:wil",
     ],
 )

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -285,11 +285,6 @@ void FillMozcContextForOnKey(TipTextService *text_service, ITfContext *context,
   if (!TipSurroundingText::Get(text_service, context, &info)) {
     return;
   }
-  if (info.is_transitory) {
-    // Ignore transitory context as it may not contain correct
-    // surrounding text info.
-    return;
-  }
   if (info.has_preceding_text) {
     mozc_context->set_preceding_text(WideToUtf8(info.preceding_text));
   }

--- a/src/win32/tip/tip_surrounding_text.h
+++ b/src/win32/tip/tip_surrounding_text.h
@@ -49,7 +49,6 @@ struct TipSurroundingTextInfo {
   bool has_preceding_text = false;
   bool has_selected_text = false;
   bool has_following_text = false;
-  bool is_transitory = false;   // context is a transitory context
   bool in_composition = false;  // context has a composition owned by Mozc.
 };
 

--- a/src/win32/tip/tip_transitory_extension.h
+++ b/src/win32/tip/tip_transitory_extension.h
@@ -38,30 +38,30 @@ namespace mozc {
 namespace win32 {
 namespace tsf {
 
-// This class provides utility methods to access parent object provided by
-// Transitory Extensions.
-// Starting with Windows Vista, CUAS provides Transitory Extensions with which
-// full text store support is available for edit control, rich edit control,
-// and Trident edit control. You can use these text stores mainly for one-shot
-// read/read-write access. For keyboard input, which may require text
-// composition, should use the original (transitory) text store.
-// See the following article for the details about Transitory Extensions.
-// http://blogs.msdn.com/b/tsfaware/archive/2007/05/21/transitory-extensions.aspx
+// This class provides a utility method to derive an ITfContext object that is
+// expected to support surrounding text TSF APIs, or get a nullptr if it is
+// supposed to be unavailable.
+//
+// This class can be used to get a supplimental ITfContext object that supports
+// full text store operations when the target ITfContext is actually an EditText
+// or RichEdit controls. This mechanism is called Transitory Extensions.
+// https://learn.microsoft.com/en-us/archive/blogs/tsfaware/transitory-extensions-or-how-to-get-full-text-store-support-in-tsf-unaware-controls
+// https://web.archive.org/web/20140518145404/http://blogs.msdn.com/b/tsfaware/archive/2007/05/21/transitory-extensions.aspx
+//
+// Another important use case of this class is to filter out mulfunctioning
+// ITfContext objects by returning a nullpter when there is no way to get
+// surrounding text through TSF APIs. This is because CUAS (Cicero Unaware
+// Application Support) does not try to fully support surrounding text APIs
+// through IMM32 APIs such as IMR_DOCUMENTFEED. Such an ITfContext object needs
+// to be filtered out before trying to get surrounding text through TSF APIs.
 class TipTransitoryExtension {
  public:
   TipTransitoryExtension() = delete;
   TipTransitoryExtension(const TipTransitoryExtension &) = delete;
   TipTransitoryExtension &operator=(const TipTransitoryExtension &) = delete;
 
-  // Returns the parent (full-text-store) document manager if exists.
-  // Returns |document_manager| otherwise.
-  static wil::com_ptr_nothrow<ITfDocumentMgr> ToParentDocumentIfExists(
-      ITfDocumentMgr *document_manager);
-
-  // Returns the parent (full-text-store) context if exists.
-  // Returns |context| otherwise.
-  static wil::com_ptr_nothrow<ITfContext> ToParentContextIfExists(
-      ITfContext *context);
+  // Returns full-text-store context if available, otherwise returns |nullptr|.
+  static wil::com_ptr_nothrow<ITfContext> AsFullContext(ITfContext *context);
 };
 
 }  // namespace tsf


### PR DESCRIPTION
## Description
This reworks how Mozc TIP (Text Input Processor) gets surrounding text through TSF (Text Services Framework) APIs when the target context is transitory.

Mozc used to check `TF_SS_TRANSITORY` bit to see if the surrounding text TSF APIs are supposed to return a valid value or not. However, as discussed #1289, Chromium-based applications are also filtered out as they intentionally specify `TF_SS_TRANSITORY` bit.

 * https://issues.chromium.org/issues/40724714#comment38

To distinguish the above two cases, this commit introduces a new way to check if the target context is backed by CUAS (Cicero Unaware Application Support) or not by using an undocumented TSF constant. While we in general would like to avoid using undocumented APIs, this seems to be the only practical way to distinguish the two cases.

Only Chromium-based applications start using surrounding text with this commit. Other cases should remain unchanged.

Closes #1289.

## Issue IDs

 * https://github.com/google/mozc/issues/1289
 * https://issues.chromium.org/issues/417529154

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build and Install Mozc
   2. Open `data:text/html,<textarea />` with Chrome 136.0.7103.114
   3. Focus into the `<textarea>` and enable Mozc.
   4. Confirm that "ひき" gives different suggestion before and after "1".
