### PR TITLE
Use `IMR_DOCUMENTFEED` for legacy IMM32-based apps

### DIFF
--- a/src/win32/base/imm_reconvert_string.cc
+++ b/src/win32/base/imm_reconvert_string.cc
@@ -101,9 +101,21 @@ std::wstring_view WStringView(const wchar_t *begin, const wchar_t *end) {
 
 }  // namespace
 
-UniqueReconvertString ReconvertString::Request(const HWND hwnd) {
+UniqueReconvertString
+ReconvertString::Request(HWND hwnd, RequestType request_type) {
   UniqueReconvertString result(nullptr, &Deleter);
-  LPARAM l_result = SendMessageW(hwnd, WM_IME_REQUEST, IMR_RECONVERTSTRING, 0);
+  WPARAM wparam;
+  switch (request_type) {
+    case RequestType::kReconvertString:
+      wparam = IMR_RECONVERTSTRING;
+      break;
+    case RequestType::kDocumentFeed:
+      wparam = IMR_DOCUMENTFEED;
+      break;
+    default:
+      return result;
+  }
+  LPARAM l_result = SendMessageW(hwnd, WM_IME_REQUEST, wparam, 0);
   if (l_result == 0) {
     // IMR_RECONVERTSTRING is not supported.
     return result;
@@ -115,7 +127,7 @@ UniqueReconvertString ReconvertString::Request(const HWND hwnd) {
   result = Allocate(buffer_size);
   result->dwSize = buffer_size;
   result->dwVersion = 0;
-  l_result = SendMessageW(hwnd, WM_IME_REQUEST, IMR_RECONVERTSTRING,
+  l_result = SendMessageW(hwnd, WM_IME_REQUEST, wparam,
                           reinterpret_cast<LPARAM>(result.get()));
   if (l_result == 0) {
     result.release();

--- a/src/win32/base/imm_reconvert_string.h
+++ b/src/win32/base/imm_reconvert_string.h
@@ -85,9 +85,14 @@ class ReconvertString : public RECONVERTSTRING {
     std::wstring_view following_text;
   };
 
-  // Sends WM_IME_REQUEST for IMR_RECONVERTSTRING to the windows specified by
-  // hwnd and returns the result. The result is nullptr if it fails.
-  static UniqueReconvertString Request(HWND hwnd);
+  enum class RequestType {
+    kReconvertString,  // IMR_RECONVERTSTRING
+    kDocumentFeed,     // IMR_DOCUMENTFEED
+  };
+
+  // Sends WM_IME_REQUEST to the windows specified by hwnd and returns the
+  // result. The result is nullptr if it fails.
+  static UniqueReconvertString Request(HWND hwnd, RequestType request_type);
   // Constructs and returns a UniqueReconvertString with the substrings copied
   // into the buffer.
   static UniqueReconvertString Compose(Strings ss);


### PR DESCRIPTION
## Description
This commit re-introduces the logic to retrieve the surrounding text through `IMR_DOCUMENTFEED` for legacy IMM32-based applications such as Hidemaru and Sakura Editor. The same code used to be used in IMM32-based Mozc but has not been ported to TSF-based Mozc.

There must be no observable behavior change for TSF-based applications including Chromium-based applications (#1289). Legacy apps that use `EditText` and `RichEdit` are also unaffected as Transitory Extension provides the full TSF TextStore support including surrounding text retrieval.

Closes #1293.

## Issue IDs

 * https://github.com/google/mozc/issues/1293

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build and launch [Sakura Editor](https://github.com/sakura-editor/sakura).
   2. Type <kbd>1</kbd> without enabling Mozc. Then place the cursor after `1`.
   3. Enable Mozc then type <kbd>h</kbd><kbd>i</kbd><kbd>k</kbd><kbd>i</kbd>
   4. Confirm "匹" is suggested.
