### PR TITLE
Share platforms among rules in Windows bazel build

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -33,6 +33,10 @@ build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_win
 build:windows_env --host_platform=//:host-windows-clang-cl
 build:windows_env --copt "/D_WIN32_WINNT=0x0A00" --host_copt "/D_WIN32_WINNT=0x0A00"
 
+# A temporary setting until we fully support building Mozc on ARM64 environment.
+# TODO(https://github.com/google/mozc/issues/1296): Remove this.
+build:windows_env --platforms=//:windows-x86_64
+
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like
 common:android_env --config=compiler_gcc_like

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -107,6 +107,38 @@ platform(
     parents = ["@local_config_platform//:host"],
 )
 
+platform(
+    name = "windows-x86_32",
+    constraint_values = [
+        "@platforms//cpu:x86_32",
+        "@platforms//os:windows",
+    ],
+)
+
+platform(
+    name = "windows-x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+    ],
+)
+
+platform(
+    name = "windows-arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:windows",
+    ],
+)
+
+selects.config_setting_group(
+    name = "intel_cpu",
+    match_any = [
+        "@platforms//cpu:x86_32",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # Special target so as to define special macros for each platforms.
 # Don't depend on this directly. Use mozc_cc_(library|binary|test) rule instead.
 cc_library(

--- a/src/gui/tool/BUILD.bazel
+++ b/src/gui/tool/BUILD.bazel
@@ -133,7 +133,6 @@ mozc_cc_qt_binary(
 
 mozc_win32_cc_prod_binary(
     name = "mozc_tool_win",
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_tool.exe",
         "GoogleJapaneseInput": "GoogleIMEJaTool.exe",

--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -48,7 +48,6 @@ package(
 mozc_win32_cc_prod_binary(
     name = "win32_renderer_main",
     srcs = ["win32_renderer_main.cc"],
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_renderer.exe",
         "GoogleJapaneseInput": "GoogleIMEJaRenderer.exe",

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -62,7 +62,6 @@ mozc_cc_binary(
 
 mozc_win32_cc_prod_binary(
     name = "mozc_server_win",
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_server.exe",
         "GoogleJapaneseInput": "GoogleIMEJaConverter.exe",

--- a/src/win32/broker/BUILD.bazel
+++ b/src/win32/broker/BUILD.bazel
@@ -44,7 +44,6 @@ package(
 mozc_win32_cc_prod_binary(
     name = "mozc_broker_main",
     srcs = ["mozc_broker_main.cc"],
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_broker.exe",
         "GoogleJapaneseInput": "GoogleIMEJaBroker.exe",

--- a/src/win32/cache_service/BUILD.bazel
+++ b/src/win32/cache_service/BUILD.bazel
@@ -45,7 +45,6 @@ package(default_visibility = ["//visibility:private"])
 mozc_win32_cc_prod_binary(
     name = "mozc_cache_service",
     srcs = ["mozc_cache_service.cc"],
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_cache_service.exe",
         "GoogleJapaneseInput": "GoogleIMEJaCacheService.exe",

--- a/src/win32/custom_action/BUILD.bazel
+++ b/src/win32/custom_action/BUILD.bazel
@@ -41,7 +41,6 @@ mozc_win32_cc_prod_binary(
         "custom_action.h",
         "resource.h",
     ],
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_installer_helper.dll",
         "GoogleJapaneseInput": "GoogleIMEJaInstallerHelper.dll",

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -66,12 +66,12 @@ mozc_cc_library(
 mozc_win32_cc_prod_binary(
     name = "mozc_tip32",
     srcs = ["mozc_tip_main.cc"],
-    cpu = "@platforms//cpu:x86_32",
     executable_name_map = {
         "Mozc": "mozc_tip32.dll",
         "GoogleJapaneseInput": "GoogleIMEJaTIP32.dll",
     },
     linkshared = True,
+    platform = "//:windows-x86_32",
     static_crt = True,
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
@@ -85,12 +85,12 @@ mozc_win32_cc_prod_binary(
 mozc_win32_cc_prod_binary(
     name = "mozc_tip64",
     srcs = ["mozc_tip_main.cc"],
-    cpu = "@platforms//cpu:x86_64",
     executable_name_map = {
         "Mozc": "mozc_tip64.dll",
         "GoogleJapaneseInput": "GoogleIMEJaTIP64.dll",
     },
     linkshared = True,
+    platform = "//:windows-x86_64",
     static_crt = True,
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],


### PR DESCRIPTION
## Description
This reworks my precious commit (4aad25e97d9296a31c50d2c6de5309df8ad5efac), which introduced our initial support of CC toolchain resolution as planned in #1112.

While all the executables are still built as expected, defining a local private platform for every build target is turned out to be quite inefficient, as Bazel build their build dependencies separately as if they do not share the same CPU architecture.

```
    platform_name = "_" + name + "_platform"
    native.platform(
        name = platform_name,
        constraint_values = [
            cpu,
            "@platforms//os:windows",
        ],
        visibility = ["//visibility:private"],
    )
```

A simple and actually well-known solution is to define platforms globally then always refer to them.

```
platform(
    name = "windows-x86_32",
    constraint_values = [
        "@platforms//cpu:x86_32",
        "@platforms//os:windows",
    ],
)

platform(
    name = "windows-x86_64",
    constraint_values = [
        "@platforms//cpu:x86_64",
        "@platforms//os:windows",
    ],
)
```

The other motivation of this change is to start relying on `--platforms` command line option to specify the target CPU architecture when building Mozc64.msi for ARM64. Using `--platforms` option for this purpose is indeed a well known approach in Bazel, and following the same convention probably makes developers' lives easier.

In this commit we still specify `--platforms=//:windows-x86_64` in `.bazelrc` as `Mozc64.msi` is not yet compatible with ARM64, but eventually we can use the host CPU architecture as the default target CPU architecture with allowing developers to override it at the command line (#1296).

To summarize:

 * no behavior change in the final artifacts.
 * much faster build, which is almost the same as GYP build.
   * Number of build targets: 8,109 -> 4,457
   * Build time (bazel part): 50 min -> 31 min on GitHub Actions

Closes #1295.

## Issue IDs

 * https://github.com/google/mozc/issues/1295

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. On GitHub Actions, the build time of `build_bazel` is down from 1h10m to 50m.
