### PR TITLE
Register `cc-toolchain-arm64_windows-clang-cl`

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -28,6 +28,7 @@ build:release_build --compilation_mode=opt
 build:release_build --copt=-DABSL_MIN_LOG_LEVEL=100
 
 ## Clang-cl toolchain for Windows
+build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows-clang-cl
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
 build:windows_env --host_platform=//:host-windows-clang-cl

--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -84,3 +84,11 @@
  cc_toolchain(
      name = "cc-compiler-arm64_windows-clang-cl",
      toolchain_identifier = "clang_cl_arm64",
+@@ -668,6 +738,7 @@
+         "strip": "wrapper/bin/msvc_nop.bat",
+     },
+     archiver_flags = ["/MACHINE:ARM64"],
++    default_compile_flags = ["--target=aarch64-pc-windows-msvc"],
+     default_link_flags = ["/MACHINE:ARM64"],
+     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_arm64}",
+     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_arm64}",


### PR DESCRIPTION
## Description
As a preparation to support ARM64 Windows (#1130), this commit registers one more toolchain as follows
```
--extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows-clang-cl
```
with fixing a missing default compiler flag `--target=aarch64-pc-windows-msvc` as a local patch to `rules_cc`.

All the builds should continue succeeding without installing ARM64 dependencies in the Visual Studio installer.

## Issue IDs

 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm GitHub Actions succeed.
