### PR TITLE
Remove unused PDB stuff from `src/win32/installer`

### DIFF
--- a/src/win32/installer/BUILD.bazel
+++ b/src/win32/installer/BUILD.bazel
@@ -75,8 +75,6 @@ genrule(
         "//win32/cache_service:mozc_cache_service",
         "//win32/tip:mozc_tip32",
         "//win32/tip:mozc_tip64",
-        # Temporary disabled until mozc_win32_cc_prod_binary supports pdb file.
-        # "//win32/tip:mozc_tip64.pdb",
         "//win32/custom_action",
         _WXS_FILE,
         "//base:mozc_version_txt",
@@ -97,8 +95,6 @@ genrule(
         "--mozc_cache_service=$(location //win32/cache_service:mozc_cache_service)",
         "--mozc_tip32=$(location //win32/tip:mozc_tip32)",
         "--mozc_tip64=$(location //win32/tip:mozc_tip64)",
-        # Temporary disabled until mozc_win32_cc_prod_binary supports pdb file.
-        # "--mozc_tip64_pdb=$(location //win32/tip:mozc_tip64.pdb)",
         "--custom_action=$(location //win32/custom_action)",
         "--icon_path=$(location //data/images/win:product_icon.ico)",
         "--credit_file=$(location //data/installer:credits_en.html)",

--- a/src/win32/installer/build_installer.py
+++ b/src/win32/installer/build_installer.py
@@ -157,7 +157,6 @@ def main():
   parser.add_argument('--mozc_cache_service', type=str)
   parser.add_argument('--mozc_tip32', type=str)
   parser.add_argument('--mozc_tip64', type=str)
-  parser.add_argument('--mozc_tip64_pdb', type=str)
   parser.add_argument('--custom_action', type=str)
   parser.add_argument('--icon_path', type=str)
   parser.add_argument('--credit_file', type=str)


### PR DESCRIPTION
## Description
This follows up to my previous commit (e6af83493b691c516d65a08a7981d13faa68a24e), with which `Mozc64.msi` stopped deploying a PDB file for `mozc_tip64.dll`.

There must be no behavior change in the final artifacts as the lines of code this commit is deleting are no longer used.

## Issue IDs

 * https://github.com/google/mozc/issues/1261

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm GitHub Actions still pass.
