### PR TITLE
Build `Mozc64.msi` with Bazel in Windows CI

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build_gyp:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
     runs-on: windows-2022
     timeout-minutes: 120
@@ -67,14 +67,14 @@ jobs:
         run: |
           python build_mozc.py build -c Release package
 
-      - name: upload Mozc64.msi
+      - name: upload Mozc64_gyp.msi
         uses: actions/upload-artifact@v4
         with:
-          name: Mozc64.msi
+          name: Mozc64_gyp.msi
           path: src/out_win/Release/Mozc64.msi
           if-no-files-found: warn
 
-  build_bazel:
+  build:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
     runs-on: windows-2022
     timeout-minutes: 120
@@ -119,14 +119,14 @@ jobs:
         run: |
           bazelisk build --config oss_windows --config release_build package
 
-      - name: upload Mozc64_bazel.msi
+      - name: upload Mozc64.msi
         uses: actions/upload-artifact@v4
         with:
-          name: Mozc64_bazel.msi
+          name: Mozc64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
 
-  test:
+  test_gyp:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
     runs-on: windows-2022
     timeout-minutes: 90
@@ -168,7 +168,7 @@ jobs:
         run: |
           python build_mozc.py runtests -c Debug
 
-  test_bazel:
+  test:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
     runs-on: windows-2022
     timeout-minutes: 120


### PR DESCRIPTION
## Description
This commit removes the `_bazel` suffix from the Windows CI jobs and artifacts, and adds `_gyp` suffix instead to GYP-based ones.

We have put '_bazel' suffix in GitHub Actions for Windows to make it clear that jobs and artifacts with Bazel are still experimental (421ecca1f7bfdf1446726a2f93771768ea1ebb3e). Now that Bazel-based build is becoming production-ready (#1272) and the GYP build is being deprecated, let's put `_gyp` suffix instead for GYP-based jobs and artifacts.

This commit is only about how our CI jobs and artifacts are labeled. There must be no user-visible change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1272

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm GitHub Actions still succeed.
   2. Confirm `Mozc64.msi` built with GYP is now uploaded as `Mozc64_gyp.msi.zip`
