### PR TITLE
Start building `Mozc64.msi` for ARM64 environment

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -74,7 +74,7 @@ jobs:
           path: src/out_win/Release/Mozc64.msi
           if-no-files-found: warn
 
-  build:
+  build_x64:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
     runs-on: windows-2022
     timeout-minutes: 120
@@ -119,10 +119,62 @@ jobs:
         run: |
           bazelisk build --config oss_windows --config release_build package
 
-      - name: upload Mozc64.msi
+      - name: upload Mozc64_x64.msi
         uses: actions/upload-artifact@v4
         with:
-          name: Mozc64.msi
+          name: Mozc64_x64.msi
+          path: src/bazel-bin/win32/installer/Mozc64.msi
+          if-no-files-found: warn
+
+  build_arm64:
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+    runs-on: windows-2022
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v4
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py
+
+      - name: Build Qt (arm64)
+        shell: cmd
+        working-directory: .\src
+        run: |
+          python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
+
+      # This is needed only for GitHub Actions where free disk space is quite limited.
+      - name: Delete Qt src to save disk space
+        shell: cmd
+        working-directory: .\src
+        run: |
+          rmdir third_party\qt_src /s /q
+
+      - name: build artifacts
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64
+
+      - name: upload Mozc64_arm64.msi
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mozc64_arm64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
 

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -29,6 +29,9 @@ python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 
 64-bit Windows 10 or later.
 
+> [!IMPORTANT]
+> Building Mozc on a Windows ARM64 environment is not yet supported ([#1296](https://github.com/google/mozc/issues/1296)).
+
 ### Software Requirements
 
 Building Mozc on Windows requires the following software.
@@ -107,6 +110,20 @@ start ms-settings:appsfeatures-app
 ```
 
 Then, uninstall `Mozc` from the list of installed applications.
+
+### Build `Mozc64.msi` for ARM64
+
+To compile executables for ARM64, the following Visual Studio components also
+need to be installed:
+
+  * MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
+  * C++ ATL for latest v143 build tools (ARM64/ARM64EC)
+
+To build `Mozc64.msi` for ARM64, run the following commands:
+```
+python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
+bazelisk build --config oss_windows --config release_build package --platforms=//:windows-arm64
+```
 
 ## Bazel command examples
 

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -34,10 +34,6 @@ build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_win
 build:windows_env --host_platform=//:host-windows-clang-cl
 build:windows_env --copt "/D_WIN32_WINNT=0x0A00" --host_copt "/D_WIN32_WINNT=0x0A00"
 
-# A temporary setting until we fully support building Mozc on ARM64 environment.
-# TODO(https://github.com/google/mozc/issues/1296): Remove this.
-build:windows_env --platforms=//:windows-x86_64
-
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like
 common:android_env --config=compiler_gcc_like

--- a/src/win32/installer/BUILD.bazel
+++ b/src/win32/installer/BUILD.bazel
@@ -82,7 +82,10 @@ genrule(
         "//data/installer:credits_en.html",
         "@qt_win//:bin/Qt6Core.dll",
         "@wix//:wix.exe",
-    ],
+    ] + select({
+        "@platforms//cpu:arm64": ["//win32/tip:mozc_tip64arm"],
+        "//conditions:default": [],
+    }),
     outs = [_MSI_FILE],
     cmd = " ".join([
         "$(location :build_installer)",
@@ -103,7 +106,16 @@ genrule(
         "--wix_path=$(location @wix//:wix.exe)",
         "--branding=" + BRANDING,
     ]) + select({
+        "@platforms//cpu:arm64": " " + " ".join([
+            "--mozc_tip64arm=$(location //win32/tip:mozc_tip64arm)",
+        ]),
+        "//conditions:default": "",
+    }) + select({
         ":debug_build": " --debug_build",
+        "//conditions:default": "",
+    }) + select({
+        "@platforms//cpu:x86_64": " --arch=x64",
+        "@platforms//cpu:arm64": " --arch=arm64",
         "//conditions:default": "",
     }),
     target_compatible_with = _TARGET_COMPATIBLE_WITH,

--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -37,6 +37,10 @@
 <?define QtWidgetsFilename="Qt$(var.QtVer)Widgets.dll" ?>
 <?define QtWidgetsdFilename="Qt$(var.QtVer)Widgetsd.dll" ?>
 
+<?ifndef MozcTIP64ArmPath ?>
+  <?define MozcTIP64ArmPath="" ?>
+<?endif?>
+
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <!--
@@ -63,10 +67,12 @@
     <Launch Condition="Privileged" Message="Google 日本語入力をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="GoogleJapaneseInput.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <Property Id="PROCESSOR_ARCHITECTURE">
-      <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
-    </Property>
-    <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です。" />
+    <?if $(var.MozcTIP64ArmPath) == "" ?>
+      <Property Id="PROCESSOR_ARCHITECTURE">
+        <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
+      </Property>
+      <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />
+    <?endif?>
 
     <!-- Set Add/Remove Program Icon -->
     <Icon Id="add_remove_program_icon.ico" SourceFile="$(var.AddRemoveProgramIconPath)" />
@@ -109,6 +115,9 @@
     <Feature Id="GIMEJaInstall" Title="Google 日本語入力" Level="1">
       <ComponentRef Id="GIMEJaTIP32" />
       <ComponentRef Id="GIMEJaTIP64" />
+      <?if $(var.MozcTIP64ArmPath) != "" ?>
+        <ComponentRef Id="GIMEJaTIP64Arm" />
+      <?endif?>
       <ComponentRef Id="GIMEJaBroker" />
       <ComponentRef Id="GIMEJaConverter" />
       <ComponentRef Id="GIMEJaCacheService" />
@@ -249,9 +258,18 @@
           </Component>
           <Component Id="GIMEJaTIP64" Permanent="no" Bitness="always64">
             <File Id="GoogleIMEJaTIP64.dll" Name="GoogleIMEJaTIP64.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64Path)" Vital="yes">
-              <Class Context="InprocServer32" ThreadingModel="apartment" Description="Google Japanese Input" Id="D5A86FD5-5308-47EA-AD16-9C4EB160EC3C" />
+              <?if $(var.MozcTIP64ArmPath) == "" ?>
+                <Class Context="InprocServer32" ThreadingModel="apartment" Description="Google Japanese Input" Id="D5A86FD5-5308-47EA-AD16-9C4EB160EC3C" />
+              <?endif?>
             </File>
           </Component>
+          <?if $(var.MozcTIP64ArmPath) != "" ?>
+            <Component Id="GIMEJaTIP64Arm" Permanent="no" Bitness="always64">
+              <File Id="GoogleIMEJaTIP64Arm.dll" Name="GoogleIMEJaTIP64Arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes">
+                <Class Context="InprocServer32" ThreadingModel="apartment" Description="Google Japanese Input" Id="D5A86FD5-5308-47EA-AD16-9C4EB160EC3C" />
+              </File>
+            </Component>
+          <?endif?>
           <Component Id="GIMEJaBroker" Permanent="no">
             <File Id="GoogleIMEJaBroker.exe" Name="GoogleIMEJaBroker.exe" DiskId="1" Checksum="yes" Source="$(var.MozcBroker64Path)" Vital="yes" />
           </Component>

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -38,6 +38,10 @@
 <?define QtWidgetsFilename="Qt$(var.QtVer)Widgets.dll" ?>
 <?define QtWidgetsdFilename="Qt$(var.QtVer)Widgetsd.dll" ?>
 
+<?ifndef MozcTIP64ArmPath ?>
+  <?define MozcTIP64ArmPath="" ?>
+<?endif?>
+
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
   <!--
@@ -64,10 +68,12 @@
     <Launch Condition="Privileged" Message="Mozc をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="Mozc.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <Property Id="PROCESSOR_ARCHITECTURE">
-      <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
-    </Property>
-    <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />
+    <?if $(var.MozcTIP64ArmPath) == "" ?>
+      <Property Id="PROCESSOR_ARCHITECTURE">
+        <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
+      </Property>
+      <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />
+    <?endif?>
 
     <!-- Set Add/Remove Program Icon -->
     <Icon Id="add_remove_program_icon.ico" SourceFile="$(var.AddRemoveProgramIconPath)" />
@@ -93,6 +99,9 @@
     <Feature Id="MozcInstall" Title="Mozc" Level="1">
       <ComponentRef Id="MozcTIP32" />
       <ComponentRef Id="MozcTIP64" />
+      <?if $(var.MozcTIP64ArmPath) != "" ?>
+        <ComponentRef Id="MozcTIP64Arm" />
+      <?endif?>
       <ComponentRef Id="MozcBroker" />
       <ComponentRef Id="MozcConverter" />
       <ComponentRef Id="MozcCacheService" />
@@ -224,9 +233,18 @@
         </Component>
         <Component Id="MozcTIP64" Permanent="no" Bitness="always64">
           <File Id="mozc_tip64.dll" Name="mozc_tip64.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64Path)" Vital="yes">
-            <Class Context="InprocServer32" ThreadingModel="apartment" Description="Mozc" Id="10A67BC8-22FA-4A59-90DC-2546652C56BF" />
+            <?if $(var.MozcTIP64ArmPath) == "" ?>
+              <Class Context="InprocServer32" ThreadingModel="apartment" Description="Mozc" Id="10A67BC8-22FA-4A59-90DC-2546652C56BF" />
+            <?endif?>
           </File>
         </Component>
+        <?if $(var.MozcTIP64ArmPath) != "" ?>
+          <Component Id="MozcTIP64Arm" Permanent="no" Bitness="always64">
+            <File Id="mozc_tip64arm.dll" Name="mozc_tip64arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes">
+              <Class Context="InprocServer32" ThreadingModel="apartment" Description="Mozc" Id="10A67BC8-22FA-4A59-90DC-2546652C56BF" />
+            </File>
+          </Component>
+        <?endif?>
         <Component Id="MozcBroker" Permanent="no">
           <File Id="mozc_broker.exe" Name="mozc_broker.exe" DiskId="1" Checksum="yes" Source="$(var.MozcBroker64Path)" Vital="yes" />
         </Component>

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -101,6 +101,25 @@ mozc_win32_cc_prod_binary(
     ],
 )
 
+mozc_win32_cc_prod_binary(
+    name = "mozc_tip64arm",
+    srcs = ["mozc_tip_main.cc"],
+    executable_name_map = {
+        "Mozc": "mozc_tip64arm.dll",
+        "GoogleJapaneseInput": "GoogleIMEJaTIP64Arm.dll",
+    },
+    linkshared = True,
+    platform = "//:windows-arm64",
+    static_crt = True,
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    visibility = ["//win32/installer:__subpackages__"],  # Scheuklappen: keep
+    win_def_file = "mozc_tip.def",
+    deps = [
+        ":mozc_tip_deps",
+    ],
+)
+
 mozc_win32_resource_from_template(
     name = "mozc_tip_resource",
     src = "tip_resource.rc",

--- a/src/win32/tip/tip_resource.rc
+++ b/src/win32/tip/tip_resource.rc
@@ -73,7 +73,22 @@ END
 // Version
 //
 
-#ifdef _WIN64
+#if defined(_ARM64_)
+  #ifndef MOZC_RES_INTERNAL_NAME
+    #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
+      #define MOZC_RES_INTERNAL_NAME "GoogleIMEJaTIP64Arm"
+    #elif defined(MOZC_BUILD)
+      #define MOZC_RES_INTERNAL_NAME "mozc_tip64Arm"
+    #endif
+  #endif
+  #ifndef MOZC_RES_ORIGINAL_FILENAME
+    #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
+      #define MOZC_RES_ORIGINAL_FILENAME "GoogleIMEJaTIP64Arm.dll"
+    #elif defined(MOZC_BUILD)
+      #define MOZC_RES_ORIGINAL_FILENAME "mozc_tip64arm.dll"
+    #endif
+  #endif
+#elif defined(_WIN64)
   #ifndef MOZC_RES_INTERNAL_NAME
     #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
       #define MOZC_RES_INTERNAL_NAME "GoogleIMEJaTIP64"


### PR DESCRIPTION
## Description
This is an important milestone towards supporting ARM64 Windows.

With this commit, we can start building `Mozc64.msi` that is compatible with ARM64 processes and x86 processes on Windows. To build `Mozc64.msi` to be ARM64 compatible, run the following commands:

```
python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64
```

Note that no additional Visual Studio components are required unless you explicitly specify the above options. Existing continuous builds for x64 should continue to work without any changes.

Note also that using Mozc in x64 processes on ARM64 machines is not yet supported, as it requires us to build an ARM64X DLL that can be loaded into both x64 and arm64 processes. It will be handled in a subsequent commit.

## Issue IDs

 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2 ARM64
 - Steps:
   1. `python build_tools/build_qt.py --release --confirm_license --target_arch=arm64`
   2. `bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64`
   3. `python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi`
   4. Confirm that you can use Mozc on Notepad.
