### PR TITLE
Fix missing error propagation in `RegisterTIP`

### DIFF
--- a/src/win32/custom_action/custom_action.cc
+++ b/src/win32/custom_action/custom_action.cc
@@ -454,7 +454,7 @@ UINT __stdcall RegisterTIP(MSIHANDLE msi_handle) {
   // which does not need to match the native CPU architecture. Here we use
   // 32-bit TIP DLL as it is always installed even on an ARM64 target.
   const std::wstring resource_dll_path = GetMozcComponentPath(mozc::kMozcTIP32);
-  mozc::win32::TsfRegistrar::RegisterProfiles(resource_dll_path);
+  result = mozc::win32::TsfRegistrar::RegisterProfiles(resource_dll_path);
   if (FAILED(result)) {
     LOG_ERROR_FOR_OMAHA();
     UnregisterTIP(msi_handle);


### PR DESCRIPTION
## Description
This follows up to my previous commit (a2a490e78b0d4d34543261f2aaf13a180acf071e), which made 'custom_action.cc' buildable for ARM64 target as a preparation for ARM64 support.

My intention was to not change any existing behavior, but I accidentally removed the error propagation from `mozc::win32::TsfRegistrar::RegisterProfiles` in `RegisterTIP` custom action.

This commit restores the previous behavior.

## Issue IDs

 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build `Mozc64.msi` and install it.
   2. Confirm Mozc works as expected.
