### PR TITLE
Make `absl.gyp` compatible with Abseil 20250512.0

### DIFF
--- a/src/base/absl.gyp
+++ b/src/base/absl.gyp
@@ -96,14 +96,24 @@
       ],
     },
     {
+      'target_name': 'absl_container_internal',
+      'toolsets': ['host', 'target'],
+      'type': 'static_library',
+      'sources': [
+        '<!@(<(glob_absl) container/internal "*.cc")',
+      ],
+    },
+    {
       'target_name': 'absl_hash_internal',
       'toolsets': ['host', 'target'],
       'type': 'static_library',
       'sources': [
-        '<(absl_srcdir)/container/internal/raw_hash_set.cc',
         '<(absl_srcdir)/hash/internal/city.cc',
         '<(absl_srcdir)/hash/internal/hash.cc',
         '<(absl_srcdir)/hash/internal/low_level_hash.cc',
+      ],
+      'dependencies': [
+          'absl_container_internal',
       ],
     },
     {


### PR DESCRIPTION
## Description
This follows up to our previous commit (022576ada305430c02c19edb8ff95058ca8595ed), which updated `abseil-cpp` version from `20250127.0` to `20250512.0` only for Bazel build.

Before applying the same change to GYP build, this commit ensures that the `base/absl.gyp` is compatible with both `20250127.0` and `20250512.0`.

Until we actually update `abseil-cpp` version in GYP build, there must be no change in the final artifacts.

## Issue IDs

 * N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. .GitHub Actions still pass
