### PR TITLE
Allow x64 processes to use Mozc on Windows ARM64

### DIFF
--- a/src/win32/installer/BUILD.bazel
+++ b/src/win32/installer/BUILD.bazel
@@ -83,7 +83,10 @@ genrule(
         "@qt_win//:bin/Qt6Core.dll",
         "@wix//:wix.exe",
     ] + select({
-        "@platforms//cpu:arm64": ["//win32/tip:mozc_tip64arm"],
+        "@platforms//cpu:arm64": [
+            "//win32/tip:mozc_tip64arm",
+            "//win32/tip:mozc_tip64x",
+        ],
         "//conditions:default": [],
     }),
     outs = [_MSI_FILE],
@@ -108,6 +111,7 @@ genrule(
     ]) + select({
         "@platforms//cpu:arm64": " " + " ".join([
             "--mozc_tip64arm=$(location //win32/tip:mozc_tip64arm)",
+            "--mozc_tip64x=$(location //win32/tip:mozc_tip64x)",
         ]),
         "//conditions:default": "",
     }) + select({

--- a/src/win32/installer/build_installer.py
+++ b/src/win32/installer/build_installer.py
@@ -147,9 +147,13 @@ def run_wix4(args) -> None:
       '-out', args.output,
       '-src', args.wxs_path,
   ]
-  if args.mozc_tip64arm:
+  if args.mozc_tip64arm and args.mozc_tip64x:
     mozc_tip64arm = pathlib.Path(args.mozc_tip64arm).resolve()
-    commands += ['-define', f'MozcTIP64ArmPath={mozc_tip64arm}']
+    mozc_tip64x = pathlib.Path(args.mozc_tip64x).resolve()
+    commands += [
+        '-define', f'MozcTIP64ArmPath={mozc_tip64arm}',
+        '-define', f'MozcTIP64XPath={mozc_tip64x}',
+    ]
   exec_command(commands, cwd=os.getcwd())
 
 
@@ -165,6 +169,7 @@ def main():
   parser.add_argument('--mozc_tip32', type=str)
   parser.add_argument('--mozc_tip64', type=str)
   parser.add_argument('--mozc_tip64arm', type=str)
+  parser.add_argument('--mozc_tip64x', type=str)
   parser.add_argument('--custom_action', type=str)
   parser.add_argument('--icon_path', type=str)
   parser.add_argument('--credit_file', type=str)

--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -40,6 +40,9 @@
 <?ifndef MozcTIP64ArmPath ?>
   <?define MozcTIP64ArmPath="" ?>
 <?endif?>
+<?ifndef MozcTIP64XPath ?>
+  <?define MozcTIP64XPath="" ?>
+<?endif?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
@@ -67,7 +70,7 @@
     <Launch Condition="Privileged" Message="Google 日本語入力をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="GoogleJapaneseInput.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <?if $(var.MozcTIP64ArmPath) == "" ?>
+    <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
       <Property Id="PROCESSOR_ARCHITECTURE">
         <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
       </Property>
@@ -115,8 +118,9 @@
     <Feature Id="GIMEJaInstall" Title="Google 日本語入力" Level="1">
       <ComponentRef Id="GIMEJaTIP32" />
       <ComponentRef Id="GIMEJaTIP64" />
-      <?if $(var.MozcTIP64ArmPath) != "" ?>
+      <?if $(var.MozcTIP64ArmPath) != "" and $(var.MozcTIP64XPath) != "" ?>
         <ComponentRef Id="GIMEJaTIP64Arm" />
+        <ComponentRef Id="GIMEJaTIP64X" />
       <?endif?>
       <ComponentRef Id="GIMEJaBroker" />
       <ComponentRef Id="GIMEJaConverter" />
@@ -258,14 +262,17 @@
           </Component>
           <Component Id="GIMEJaTIP64" Permanent="no" Bitness="always64">
             <File Id="GoogleIMEJaTIP64.dll" Name="GoogleIMEJaTIP64.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64Path)" Vital="yes">
-              <?if $(var.MozcTIP64ArmPath) == "" ?>
+              <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
                 <Class Context="InprocServer32" ThreadingModel="apartment" Description="Google Japanese Input" Id="D5A86FD5-5308-47EA-AD16-9C4EB160EC3C" />
               <?endif?>
             </File>
           </Component>
-          <?if $(var.MozcTIP64ArmPath) != "" ?>
+          <?if $(var.MozcTIP64ArmPath) != "" and $(var.MozcTIP64XPath) != "" ?>
             <Component Id="GIMEJaTIP64Arm" Permanent="no" Bitness="always64">
-              <File Id="GoogleIMEJaTIP64Arm.dll" Name="GoogleIMEJaTIP64Arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes">
+              <File Id="GoogleIMEJaTIP64Arm.dll" Name="GoogleIMEJaTIP64Arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes" />
+            </Component>
+            <Component Id="GIMEJaTIP64X" Permanent="no" Bitness="always64">
+              <File Id="GoogleIMEJaTIP64X.dll" Name="GoogleIMEJaTIP64X.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64XPath)" Vital="yes">
                 <Class Context="InprocServer32" ThreadingModel="apartment" Description="Google Japanese Input" Id="D5A86FD5-5308-47EA-AD16-9C4EB160EC3C" />
               </File>
             </Component>

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -41,6 +41,9 @@
 <?ifndef MozcTIP64ArmPath ?>
   <?define MozcTIP64ArmPath="" ?>
 <?endif?>
+<?ifndef MozcTIP64XPath ?>
+  <?define MozcTIP64XPath="" ?>
+<?endif?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
@@ -68,7 +71,7 @@
     <Launch Condition="Privileged" Message="Mozc をインストールするには管理者権限が必要です。" />
     <Media Id="1" Cabinet="Mozc.cab" EmbedCab="yes" CompressionLevel="high" />
 
-    <?if $(var.MozcTIP64ArmPath) == "" ?>
+    <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
       <Property Id="PROCESSOR_ARCHITECTURE">
         <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
       </Property>
@@ -99,8 +102,9 @@
     <Feature Id="MozcInstall" Title="Mozc" Level="1">
       <ComponentRef Id="MozcTIP32" />
       <ComponentRef Id="MozcTIP64" />
-      <?if $(var.MozcTIP64ArmPath) != "" ?>
+      <?if $(var.MozcTIP64ArmPath) != "" and $(var.MozcTIP64XPath) != "" ?>
         <ComponentRef Id="MozcTIP64Arm" />
+        <ComponentRef Id="MozcTIP64X" />
       <?endif?>
       <ComponentRef Id="MozcBroker" />
       <ComponentRef Id="MozcConverter" />
@@ -233,14 +237,17 @@
         </Component>
         <Component Id="MozcTIP64" Permanent="no" Bitness="always64">
           <File Id="mozc_tip64.dll" Name="mozc_tip64.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64Path)" Vital="yes">
-            <?if $(var.MozcTIP64ArmPath) == "" ?>
+            <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
               <Class Context="InprocServer32" ThreadingModel="apartment" Description="Mozc" Id="10A67BC8-22FA-4A59-90DC-2546652C56BF" />
             <?endif?>
           </File>
         </Component>
-        <?if $(var.MozcTIP64ArmPath) != "" ?>
+        <?if $(var.MozcTIP64ArmPath) != "" and $(var.MozcTIP64XPath) != "" ?>
           <Component Id="MozcTIP64Arm" Permanent="no" Bitness="always64">
-            <File Id="mozc_tip64arm.dll" Name="mozc_tip64arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes">
+            <File Id="mozc_tip64arm.dll" Name="mozc_tip64arm.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64ArmPath)" Vital="yes" />
+          </Component>
+          <Component Id="MozcTIP64X" Permanent="no" Bitness="always64">
+            <File Id="mozc_tip64x.dll" Name="mozc_tip64x.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64XPath)" Vital="yes">
               <Class Context="InprocServer32" ThreadingModel="apartment" Description="Mozc" Id="10A67BC8-22FA-4A59-90DC-2546652C56BF" />
             </File>
           </Component>

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -34,12 +34,25 @@ load(
     "MOZC_TAGS",
     "mozc_cc_library",
     "mozc_cc_test",
+    "mozc_py_binary",
     "mozc_win32_cc_prod_binary",
     "mozc_win32_resource_from_template",
 )
+load("//:config.bzl", "BRANDING")
 load(
     "//bazel/win32:build_defs.bzl",
     "features_gdi",
+)
+
+mozc_py_binary(
+    name = "build_tip_forwarder_dll",
+    srcs = ["build_tip_forwarder_dll.py"],
+    test_lib = False,
+    visibility = ["//visibility:private"],
+    deps = [
+        "//build_tools:mozc_version_lib",
+        "//build_tools:vs_util",
+    ],
 )
 
 mozc_cc_library(
@@ -118,6 +131,25 @@ mozc_win32_cc_prod_binary(
     deps = [
         ":mozc_tip_deps",
     ],
+)
+
+genrule(
+    name = "mozc_tip64x",
+    srcs = [
+        "//base:mozc_version_txt",
+    ],
+    outs = ["mozc_tip64x.dll" if BRANDING == "Mozc" else "GoogleIMEJaTIP64X.msi"],
+    cmd = " ".join([
+        "$(location :build_tip_forwarder_dll)",
+        "--output=$@",
+        "--version_file=$(location //base:mozc_version_txt)",
+        "--branding=" + BRANDING,
+    ]),
+    target_compatible_with = ["@platforms//os:windows"],
+    tools = [
+        ":build_tip_forwarder_dll",
+    ],
+    visibility = ["//win32/installer:__subpackages__"],  # Scheuklappen: keep
 )
 
 mozc_win32_resource_from_template(

--- a/src/win32/tip/build_tip_forwarder_dll.py
+++ b/src/win32/tip/build_tip_forwarder_dll.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+# Copyright 2010-2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""This script builds am Arm64X pure forwarder DLL for Mozc TIPs on Windows.
+
+See the following document for more details:
+https://learn.microsoft.com/en-us/windows/arm/arm64x-build#building-an-arm64x-pure-forwarder-dll
+"""
+
+
+import argparse
+import dataclasses
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+from typing import Union
+
+from build_tools import mozc_version
+from build_tools import vs_util
+
+
+def _get_def_file_content(filename: str) -> str:
+  """Generates an DEF file content for a pure forwarder of in-proc COM DLL.
+
+  Args:
+    filename: The name of the DLL to be forwarded.
+  Returns:
+    A string containing the content of the DEF file.
+  """
+  stem = str(pathlib.Path(filename).stem)
+  return '\n'.join(
+      [
+          'EXPORTS',
+          f'    DllGetClassObject = {stem}.DllGetClassObject',
+          f'    DllCanUnloadNow   = {stem}.DllCanUnloadNow',
+      ]
+  )
+
+
+@dataclasses.dataclass
+class ForwarderInfo:
+  """Information about the forwarder DLL to be generated."""
+
+  branding: str
+  version: mozc_version.MozcVersion
+
+  def get_version_string(self, separator='.') -> str:
+    components = ['@MAJOR@', '@MINOR@', '@BUILD@', '@REVISION@']
+    return self.version.GetVersionInFormat(separator.join(components))
+
+  @property
+  def forwarder_dll_name(self) -> str:
+    return {
+        'Mozc': 'mozc_tip64x.dll',
+        'GoogleJapaneseInput': 'GoogleIMEJaTIP64X.dll',
+    }[self.branding]
+
+  @property
+  def x64_impl_dll_name(self) -> str:
+    return {
+        'Mozc': 'mozc_tip64.dll',
+        'GoogleJapaneseInput': 'GoogleIMEJaTIP64.dll',
+    }[self.branding]
+
+  @property
+  def arm64_impl_dll_name(self) -> str:
+    return {
+        'Mozc': 'mozc_tip64arm.dll',
+        'GoogleJapaneseInput': 'GoogleIMEJaTIP64Arm.dll',
+    }[self.branding]
+
+  @property
+  def file_description(self) -> str:
+    return {
+        'Mozc': 'Mozc TIP Module Forwarder',
+        'GoogleJapaneseInput': 'Google 日本語入力 TIP モジュール フォワーダー',
+    }[self.branding]
+
+  @property
+  def product_name(self) -> str:
+    return {
+        'Mozc': 'Mozc',
+        'GoogleJapaneseInput': 'Google 日本語入力',
+    }[self.branding]
+
+  def get_def_file_content_for_x64(self) -> str:
+    return _get_def_file_content(self.x64_impl_dll_name)
+
+  def get_def_file_content_for_arm64(self) -> str:
+    return _get_def_file_content(self.arm64_impl_dll_name)
+
+  def get_rc_file_content(self) -> str:
+    comma_separated_versoin = self.get_version_string(',')
+    dot_separated_versoin = self.get_version_string('.')
+    file_description = self.file_description
+
+    original_file_name = self.forwarder_dll_name
+    internal_name = str(pathlib.Path(original_file_name).stem)
+    product_name = self.product_name
+    product_copyright = 'Google LLC'
+
+    return '\n'.join(
+        [
+            '#include "winres.h"',
+            'LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT',
+            '',
+            'VS_VERSION_INFO VERSIONINFO',
+            f'FILEVERSION {comma_separated_versoin}',
+            f'PRODUCTVERSION {comma_separated_versoin}',
+            (
+                'FILEFLAGSMASK'
+                ' VS_FF_DEBUG | VS_FF_PRERELEASE | VS_FF_PATCHED'
+                ' | VS_FF_INFOINFERRED'
+            ),
+            'FILEFLAGS 0x0L',
+            'FILEOS VOS__WINDOWS32',
+            'FILETYPE VFT_DLL',
+            'FILESUBTYPE VFT2_UNKNOWN',
+            'BEGIN',
+            '    BLOCK "StringFileInfo"',
+            '    BEGIN',
+            '        BLOCK "041104b0"',
+            '        BEGIN',
+            f'            VALUE "CompanyName", "{product_copyright}"',
+            f'            VALUE "FileDescription", "{file_description}"',
+            f'            VALUE "FileVersion", "{dot_separated_versoin}"',
+            f'            VALUE "InternalName", "{internal_name}"',
+            f'            VALUE "LegalCopyright", "{product_copyright}"',
+            f'            VALUE "OriginalFilename", "{original_file_name}"',
+            f'            VALUE "ProductName", "{product_name}"',
+            f'            VALUE "ProductVersion", "{dot_separated_versoin}"',
+            '        END',
+            '    END',
+            '    BLOCK "VarFileInfo"',
+            '    BEGIN',
+            '        VALUE "Translation", 0x411, 1200',
+            '    END',
+            'END',
+            '',
+        ]
+    )
+
+
+def exec_command(
+    command: list[str],
+    cwd: Union[str, pathlib.Path],
+    env: dict[str, str],
+    dryrun: bool = False,
+) -> None:
+  """Run the specified command.
+
+  Args:
+    command: Command to run.
+    cwd: Directory to execute the command.
+    env: Environment variables.
+    dryrun: True to execute the specified command as a dry run.
+
+  Raises:
+    CalledProcessError: When the process failed.
+  """
+  if dryrun:
+    print(
+        f"dryrun: subprocess.run('{command}', shell=False, check=True,"
+        f' cwd={cwd}, env={env})'
+    )
+  else:
+    subprocess.run(command, shell=False, check=True, cwd=cwd, env=env)
+
+
+def build_on_windows(args: argparse.Namespace) -> None:
+  """Build an ARM64X DLL.
+
+  Args:
+    args: build options to be used to customize behaviors.
+
+  Raises:
+    FileNotFoundError: when any required file is not found.
+  """
+  version = mozc_version.MozcVersion(args.version_file)
+  info = ForwarderInfo(branding=args.branding, version=version)
+
+  # Currently only x64 is supported as the host architecture.
+  # TODO: https://github.com/google/mozc/issues/1296 - Support ARM64 host.
+  env = vs_util.get_vs_env_vars('x64_arm64')
+
+  dest = pathlib.Path(args.output)
+  if dest.exists():
+    if args.dryrun:
+      print(f'dryrun: unlinking {str(dest)}')
+    else:
+      dest.unlink()
+
+  with tempfile.TemporaryDirectory() as work_dir:
+    empty_cc = pathlib.Path(work_dir).joinpath('empty.cc')
+    empty_cc.touch()
+
+    cl = shutil.which('cl.exe', path=env['PATH'])
+    link = shutil.which('link.exe', path=env['PATH'])
+    rc = shutil.which('rc.exe', path=env['PATH'])
+
+    exec_command(
+        [cl, '/nologo', '/c', '/Foempty_arm64.obj', 'empty.cc'],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+    exec_command(
+        [cl, '/nologo', '/c', '/arm64EC', '/Foempty_x64.obj', 'empty.cc'],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+
+    mozc_x64_def = pathlib.Path(work_dir).joinpath('mozc_x64.def')
+    mozc_x64_def.write_text(
+        info.get_def_file_content_for_x64(), encoding='utf-8', newline='\r\n'
+    )
+
+    exec_command(
+        [
+            link,
+            '/lib',
+            '/nologo',
+            '/machine:arm64EC',
+            '/ignore:4104',
+            '/def:mozc_x64.def',
+            '/out:mozc_x64.lib',
+        ],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+    mozc_arm64_def = pathlib.Path(work_dir).joinpath('mozc_arm64.def')
+    mozc_arm64_def.write_text(
+        info.get_def_file_content_for_arm64(), encoding='utf-8', newline='\r\n'
+    )
+    exec_command(
+        [
+            link,
+            '/lib',
+            '/nologo',
+            '/machine:arm64',
+            '/ignore:4104',
+            '/def:mozc_arm64.def',
+            '/out:mozc_arm64.lib',
+        ],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+
+    rc_file = pathlib.Path(work_dir).joinpath('mozc_tip_shim.rc')
+    rc_file.write_text(
+        info.get_rc_file_content(), encoding='utf-8', newline='\r\n'
+    )
+
+    exec_command(
+        [rc, '/nologo', '/r', '/8', str(rc_file)],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+
+    forwarder_filename = pathlib.Path(info.forwarder_dll_name).name
+    exec_command(
+        [
+            link,
+            '/dll',
+            '/nologo',
+            '/noentry',
+            '/machine:arm64x',
+            '/emitpogophaseinfo',
+            '/largeaddressaware',
+            '/dynamicbase',
+            '/highentropyva',
+            '/ignore:4104',
+            '/defArm64Native:mozc_arm64.def',
+            '/def:mozc_x64.def',
+            f'/out:{forwarder_filename}',
+            'empty_arm64.obj',
+            'empty_x64.obj',
+            'mozc_arm64.lib',
+            'mozc_x64.lib',
+            'mozc_tip_shim.res',
+        ],
+        cwd=work_dir,
+        env=env,
+        dryrun=args.dryrun,
+    )
+
+    src = pathlib.Path(work_dir).joinpath(forwarder_filename)
+    if args.dryrun:
+      print(f'dryrun: Copying {src} to {dest}')
+    else:
+      shutil.copy2(src=src, dst=dest)
+
+
+def parse_args() -> argparse.Namespace:
+  """Parse command line options."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--dryrun', action='store_true', default=False)
+
+  parser.add_argument(
+      '--version_file',
+      dest='version_file',
+      help='the path to version.txt',
+  )
+  parser.add_argument(
+      '--branding',
+      dest='branding',
+      default='Mozc',
+      choices=['Mozc', 'GoogleJapaneseInput'],
+      help='branding',
+  )
+  parser.add_argument(
+      '--output',
+      dest='output',
+      help='the path of the generated forwarder DLL file',
+  )
+
+  return parser.parse_args()
+
+
+def main():
+  args = parse_args()
+
+  if os.name == 'nt':
+    build_on_windows(args)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Description
In order to allow x64 processes to load Mozc TIP on Windows ARM64, this commit adds a new ARM64X pure forwarder DLL `mozc_tip64x.dll`, which forwards DLL export functions `DllGetClassObject` and `DllCanUnloadNow` to either `mozc_tip64.dll` or `mozc_tip64arm.dll` depending on the calling process architecture.

With this change there remains no functional difference between `Mozc64.msi` built for x64 and `Mozc64.msi` built for ARM64.

Note that in theory we should be able to remove `mozc_tip64arm.dll` by building `mozc_tip64x.dll` as a full ARM64X DLL. Hopefully the current approach remains to be a good mid term solution until we figure out how to build a full ARM64X DLL with clang-cl in Bazel.

Closes #1130.

## Issue IDs

 * https://github.com/google/mozc/issues/1130

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2 ARM64
 - Steps:
   1. `python build_tools/update_deps.py`
   2. `python build_tools/build_qt.py --release --confirm_license --target_arch=arm64`
   3. `bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64`
   4. `python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi`
   5. Confirm you can use Mozc on both ARM64 processes and x64 processes.
