### PR TITLE
Remove unused `crash_report_handler` dependency

### DIFF
--- a/src/mac/BUILD.bazel
+++ b/src/mac/BUILD.bazel
@@ -125,7 +125,6 @@ mozc_objc_library(
         ":mozc_imk_input_controller",
         ":renderer_receiver",
         "//base:const",
-        "//base:crash_report_handler",
         "//base:init_mozc",
         "//base:run_level",
         "//client",

--- a/src/server/BUILD.bazel
+++ b/src/server/BUILD.bazel
@@ -97,7 +97,6 @@ mozc_cc_library(
     ],
     copts = ["$(STACK_FRAME_UNLIMITED)"],  # mozc_server.cc
     deps = [
-        "//base:crash_report_handler",
         "//base:init_mozc",
         "//base:process_mutex",
         "//base:run_level",


### PR DESCRIPTION
## Description
This follows up to my previous commit (18c59459ad4f5a3aa53b825e122d38eceffd744c), which remove all the remaining invocations of `CrashReportHandler::Initialize` from the codebase towards removing the dependency on `breakpad` (#1263).

One thing I missed in that commit was the `//base:crash_report_handler` dependency in `src/mac/BUILD.bazel` and `src/server/BUILD.bazel` files were not cleaned up. As a result, the `//base:crash_report_handler` target is still being built, even though it is not used anywhere in the codebase. Let's also remove those unused dependencies before we fully remove `src/base/crash_report_handler.*` files.

## Issue IDs

 * https://github.com/google/mozc/issues/1263

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All the GitHub Actions pass

