### PR TITLE
Also start using `macos-15` runner for Android Lib

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -52,8 +52,8 @@ jobs:
           if-no-files-found: warn
 
   build_on_mac:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-    runs-on: macos-14
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
+    runs-on: macos-15
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
## Description
To follow up my previous commit (3ca75cf8d66582548854221b5f184d319a25565f), with this commit `android.yaml` also starts using the new `macos-15` runner.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - Steps:
   1. Confirm GitHub Actions for Android Lib still pass.
