### PR TITLE
bzlmod: Use `http_archive` to download `wil`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -166,14 +166,6 @@ archive_override(
     url = "https://github.com/hiroyuki-komatsu/japanese-usage-dictionary/archive/refs/tags/%s.zip" % JA_USAGE_DICT_TAG,
 )
 
-# Windows Implementation Library (WIL)
-# https://github.com/microsoft/wil/
-new_local_repository(
-    name = "com_microsoft_wil",
-    build_file = "@//bazel:BUILD.wil.bazel",
-    path = "third_party/wil",
-)
-
 pkg_config_repository = use_repo_rule(
     "@//bazel:pkg_config_repository.bzl",
     "pkg_config_repository",
@@ -295,6 +287,16 @@ http_file(
 )
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Windows Implementation Library (WIL)
+# https://github.com/microsoft/wil/
+http_archive(
+    name = "com_microsoft_wil",
+    build_file = "@//bazel:BUILD.wil.bazel",
+    sha256 = "f116af6cd96b8404d5e3cd6ef18853f7baa9c7d96930e741591fea8b5a3ef919",
+    strip_prefix = "wil-1.0.230629.1",
+    url = "https://github.com/microsoft/wil/archive/refs/tags/v1.0.230629.1.zip",
+)
 
 # Google Toolbox for Mac
 # https://github.com/google/google-toolbox-for-mac


### PR DESCRIPTION
## Description
As a preparation for stopping using git-submodules (#1320), this commit switches the `wil` dependency from a git submodule to a `http_archive` rule in the `MODULE.bazel` file.

Note that the Wil v1.0.230629.1 is chosen to be the nearest tagged version from the commit [fc5dbf55989fe20351c71d038a8d12de4b397a6d](https://github.com/microsoft/wil/commit/fc5dbf55989fe20351c71d038a8d12de4b397a6d) that is currently used. We prefer to use the source archive associated with a tag as a lesson learned from [the past incident](https://github.blog/open-source/git/update-on-the-future-stability-of-source-code-archives-and-hashes/).

In general there must be no observable changes in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1320

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build and Install Mozc
   2. Confirm there is no behavior change.
