### PR TITLE
Switch to `windows-2025` for GitHub Actions

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -13,8 +13,8 @@ concurrency:
 
 jobs:
   build_gyp:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 120
 
     steps:
@@ -75,8 +75,8 @@ jobs:
           if-no-files-found: warn
 
   build_x64:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 120
 
     steps:
@@ -127,8 +127,8 @@ jobs:
           if-no-files-found: warn
 
   build_arm64:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 120
 
     steps:
@@ -179,8 +179,8 @@ jobs:
           if-no-files-found: warn
 
   test_gyp:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 90
 
     steps:
@@ -221,8 +221,8 @@ jobs:
           python build_mozc.py runtests -c Debug
 
   test:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 120
 
     steps:
@@ -256,8 +256,8 @@ jobs:
   # in other jobs. Another approach would be to use "needs:".
   # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
   cache_deps:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-    runs-on: windows-2022
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Description
[Windows Server 2025 image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md) has been generally available for GitHub Actions runners since April 2025.

Note that this commit only affects which version of Windows we build Mozc in GitHub Actions. The actual target Windows versions remain unchanged.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - Steps:
   1. Confirm GitHub Actions for Windows continue passing.
