### PR TITLE
Inline `//:intel_cpu` for simplicity

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -131,14 +131,6 @@ platform(
     ],
 )
 
-selects.config_setting_group(
-    name = "intel_cpu",
-    match_any = [
-        "@platforms//cpu:x86_32",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
 # Special target so as to define special macros for each platforms.
 # Don't depend on this directly. Use mozc_cc_(library|binary|test) rule instead.
 cc_library(

--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -392,7 +392,8 @@ def mozc_win32_cc_prod_binary(
         features = features,
         # '/CETCOMPAT' is available only on x86/x64 architectures.
         linkopts = modified_linkopts + select({
-            "//:intel_cpu": ["/CETCOMPAT"],
+            "@platforms//cpu:x86_32": ["/CETCOMPAT"],
+            "@platforms//cpu:x86_64": ["/CETCOMPAT"],
             "//conditions:default": [],
         }),
         linkshared = linkshared,


### PR DESCRIPTION
## Description
This follows up to my previous commit (d5bb10c474ff206f1dde1551ec5ae4cc91677e09), which introduced a synthesized config `//:intel_cpu` that is set when either `@platforms//cpu:x86_32` or `@platforms//cpu:x86_64` is set as part of the effort to speed up our Bazel-based build for Windows (#1295).

The problem is that in downstream targets we can still write select rules without `//:intel_cpu` as follows:

```starlark
select({
  "@platforms//cpu:x86_32": ["/CETCOMPAT"],
  "@platforms//cpu:x86_64": ["/CETCOMPAT"],
  "//conditions:default": [],
}),
```

Let's just write it be written as a redundant but more explicit select rules for now.

## Issue IDs

 * https://github.com/google/mozc/issues/1295

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm you can still build, install, and use Mozc.
