### PR TITLE
bzlmod: Remove redundant workaround for re2

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -37,15 +37,6 @@ bazel_dep(
     repo_name = "com_google_absl",
 )
 
-# This is a workaround for https://github.com/bazelbuild/bazel/issues/24426
-# Without this explicit rule, `bazelisk fetch` fails with the following error.
-#   @@bazel_tools//tools/cpp:cc_configure.bzl does not export
-#   a module extension called cc_configure_extension
-bazel_dep(
-    name = "re2",
-    version = "2024-07-02.bcr.1",
-)
-
 # protobuf: 31.1 2025-05-27
 # https://github.com/protocolbuffers/protobuf
 bazel_dep(


### PR DESCRIPTION
## Description
With out previous commit (022576ada305430c02c19edb8ff95058ca8595ed), which updated several bzlmod dependencies, the minimum `re2` version is already set to `2024-07-02.bcr.1` by both the `protobuf` and `googletest` where re2 is actually used.

 * https://github.com/protocolbuffers/protobuf/commit/20f0c29cfe54b7fd16dbaba8ca2012460e5bcdae
 * https://github.com/google/googletest/commit/155b337c938a2953e5675f9dc18c99f05f4c85d0

Let's remove ours from `src/MODULE.bazel` as which version of re2 should be used is a kind of implementation detail of `protobuf` and `googletest` unless its version really needs to be overridden.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm `bazelisk fetch package --config oss_windows --config release_build` succeeds
   2. Confirm `re2@2024-07-02.bcr.1` is shown in `bazelisk mod graph`

## Additional context
Add any other context about the pull request here.
