### PR TITLE
bzlmod: Use `http_archive` over `archive_override`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -169,23 +169,6 @@ new_local_repository = use_repo_rule(
     "new_local_repository",
 )
 
-# Japanese Usage Dictionary (2025-01-25)
-bazel_dep(
-    name = "ja_usage_dict",
-    repo_name = "ja_usage_dict",
-)
-
-JA_USAGE_DICT_TAG = "2025-01-25"
-
-# archive_override is used instead of git_override because bazelisk fetch does not work with
-# git_repository used by git_override. See: https://github.com/bazelbuild/bazel/issues/5116
-archive_override(
-    module_name = "ja_usage_dict",
-    sha256 = "140f24f71f7d78d5eb5b93a9c079f44f23728dca5ab16bf857fe8a3fa1bf20ed",
-    strip_prefix = "japanese-usage-dictionary-%s" % JA_USAGE_DICT_TAG,
-    url = "https://github.com/hiroyuki-komatsu/japanese-usage-dictionary/archive/refs/tags/%s.zip" % JA_USAGE_DICT_TAG,
-)
-
 pkg_config_repository = use_repo_rule(
     "@//bazel:pkg_config_repository.bzl",
     "pkg_config_repository",
@@ -306,6 +289,10 @@ http_file(
     ],
 )
 
+# Note that there is also 'archive_override', which wraps 'http_archive'.
+# https://bazel.build/rules/lib/globals/module#archive_override
+# Note also that 'git_override' isn't an option here because 'bazelisk fetch'
+# would fail. https://github.com/bazelbuild/bazel/issues/5116
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Windows Implementation Library (WIL)
@@ -333,6 +320,15 @@ http_archive(
     urls = [
         "https://github.com/google/google-toolbox-for-mac/archive/%s.zip" % GTM_GIT_SHA,
     ],
+)
+
+# Japanese Usage Dictionary (2025-01-25)
+JA_USAGE_DICT_TAG = "2025-01-25"
+http_archive(
+    name = "ja_usage_dict",
+    sha256 = "140f24f71f7d78d5eb5b93a9c079f44f23728dca5ab16bf857fe8a3fa1bf20ed",
+    strip_prefix = "japanese-usage-dictionary-%s" % JA_USAGE_DICT_TAG,
+    url = "https://github.com/hiroyuki-komatsu/japanese-usage-dictionary/archive/refs/tags/%s.zip" % JA_USAGE_DICT_TAG,
 )
 
 # Zip code (2025-03-08, 6ece210081fb73d0ea4a5ea8e13ac9584d03fd76)


### PR DESCRIPTION
## Description
This aims to simplify 'MODULE.bazel' without changing anything.

As explained in the reference, [`archive_override`](https://bazel.build/docs/bzlmod#archive_override) is implemented on top of `http_archive`, and they are actually interchangeable. The issue is that currently `MODULE.bazel` uses both approaches, which is confusing because future readers may wonder which one should be used and there might be a reason for using both.

To avoid such a confusion, this commit replaces `archive_override` with `http_archive` in `MODULE.bazel` for now.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - Steps:
   1. GitHub Actions still pass
