### PR TITLE
Build `libmozc.so` with 16 KB alignment

### DIFF
--- a/src/android/jni/BUILD.bazel
+++ b/src/android/jni/BUILD.bazel
@@ -70,6 +70,11 @@ mozc_cc_library(
 mozc_cc_binary(
     name = "mozc",
     srcs = [],
+    linkopts = [
+        # 16 KB page size support is a requirement to target Android 15+.
+        # https://developer.android.com/guide/practices/page-sizes
+        "-Wl,-z,max-page-size=16384",
+    ],
     linkshared = 1,
     tags = MOZC_TAGS.ANDROID_ONLY,
     target_compatible_with = _TARGET_COMPATIBLE_WITH,


### PR DESCRIPTION
## Description
While the document says that NDK version r28 and higher compile 16 KB-aligned by default, it seems that we still need to explicitly set linker options to ensure 16 KB alignment.

 * https://developer.android.com/guide/practices/page-sizes

Closes #1364.

## Issue IDs

 * https://github.com/google/mozc/issues/1364

## Steps to test new behaviors (if any)
 - OS: Ubuntu 24.04
 - Steps:
   1. `bazelisk build --config oss_android package --config release_build`
   2. `unzip -p bazel-bin/android/jni/native_libs.zip libs/x86_64/libmozc.so | third_party/ndk/android-ndk-r28/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-objdump -p - | grep LOAD | awk '{ print $NF }' | head -1`
   3. `unzip -p bazel-bin/android/jni/native_libs.zip libs/arm64-v8a/libmozc.so | third_party/ndk/android-ndk-r28/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-objdump -p - | grep LOAD | awk '{ print $NF }' | head -1`
   4. Make sure `2**14` is shown at the both step 2 and step 3.

