### PR TITLE
Minimize read permissions in GitHub Actions

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -4,7 +4,8 @@ name: CI for Android
 # Run on push.
 on: push
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Prevent previous workflows from running.
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,8 @@ name: CI for Lint checks
 # Run on push.
 on: push
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Prevent previous workflows from running.
 concurrency:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -4,7 +4,8 @@ name: CI for Linux
 # Run on push.
 on: push
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Prevent previous workflows from running.
 concurrency:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -4,7 +4,8 @@ name: CI for macOS
 # Run on push.
 on: push
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Prevent previous workflows from running.
 concurrency:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -4,7 +4,8 @@ name: CI for Windows
 # Run on push.
 on: push
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Prevent previous workflows from running.
 concurrency:


### PR DESCRIPTION
## Description
This follows up to my previous commit that removed write permissions from the workflows (46e24b83b3481d45adfcac5d8d0384bb7386286d). With this commit, the following read permissions are also removed as they are not needed for the workflows to function:

  - Actions: read
  - Attestations: read
  - Checks: read
  - Deployments: read
  - Discussions: read
  - Issues: read
  - Metadata: read
  - Models: read
  - Packages: read
  - Pages: read
  - PullRequests: read
  - RepositoryProjects: read
  - SecurityEvents: read
  - Statuses: read

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm GitHub Actions still pass.

## Additional context

 * https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/