### PR TITLE
Simplify Win LLVM path under `src/third_party`

### DIFF
--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -4,8 +4,8 @@ set TMP_MOZC_BAZEL_WRAPPER_DIR=%~dp0
 set TMP_MOZC_SRC_DIR=%TMP_MOZC_BAZEL_WRAPPER_DIR:~0,-21%
 
 rem set BAZEL_LLVM only if clang-cl exists under third_party/llvm.
-set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\third_party\llvm\clang+llvm-20.1.1-x86_64-pc-windows-msvc
-if exist %TMP_MOZC_LLVM_DIR% set BAZEL_LLVM=%TMP_MOZC_LLVM_DIR%
+set TMP_MOZC_LLVM_DIR=%TMP_MOZC_SRC_DIR%\third_party\llvm
+if exist %TMP_MOZC_LLVM_DIR%\bin\clang-cl.exe set BAZEL_LLVM=%TMP_MOZC_LLVM_DIR%
 set TMP_MOZC_LLVM_DIR=
 
 rem set BAZEL_SH only if MSYS2 exists under third_party/msys64/bin/bash.exe.

--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -294,11 +294,12 @@ class StatefulLLVMExtractionFilter:
       skipping = False
     elif len(paths) >= 2 and paths[1] in ['include', 'lib']:
       skipping = False
+    new_path = '/'.join(paths[1:])
     if skipping:
-      self.printer.print_line('skipping   ' + member.name)
+      self.printer.print_line('skipping   ' + new_path)
       return None
-    self.printer.print_line('extracting ' + member.name)
-    return member
+    self.printer.print_line('extracting ' + new_path)
+    return member.replace(name=new_path, deep=False)
 
 
 def extract_llvm(dryrun: bool = False) -> None:


### PR DESCRIPTION
## Description
As a preparation to support Windows ARM64 build hosts, with this commit Windows LLVM archives are extracted as
```
src/third_party/llvm/bin/...
src/third_party/llvm/lib/...
src/third_party/llvm/include/...
```
rather than
```
src/third_party/llvm/clang+llvm-20.1.1-x86_64-pc-windows-msvc/bin/...
src/third_party/llvm/clang+llvm-20.1.1-x86_64-pc-windows-msvc/lib/...
src/third_party/llvm/clang+llvm-20.1.1-x86_64-pc-windows-msvc/include/...
```

This simplification will allow `src/bazel/bazel_wrapper/bazel.bat` to use the same `BAZEL_LLVM` environment variable even after we start using a different LLVM archive only on Windows ARM64 hosts.

This is just a code refactoring and should not change any behavior in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1296

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Confirm GitHub Actions still pass

## Additional context
Add any other context about the pull request here.
