### PR TITLE
Remove unused `set_restricted()` method

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -432,10 +432,6 @@ void Client::EnableCascadingWindow(const bool enable) {
 
 void Client::set_timeout(absl::Duration timeout) { timeout_ = timeout; }
 
-void Client::set_restricted(bool restricted) {
-  server_launcher_->set_restricted(restricted);
-}
-
 void Client::set_server_program(const absl::string_view program_path) {
   server_launcher_->set_server_program(program_path);
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -83,8 +83,6 @@ class ServerLauncher : public ServerLauncherInterface {
   // return server program
   zstring_view server_program() const override { return server_program_; }
 
-  void set_restricted(bool restricted) override { restricted_ = restricted; }
-
   // Sets the flag of error dialog suppression.
   void set_suppress_error_dialog(bool suppress) override {
     suppress_error_dialog_ = suppress;
@@ -92,7 +90,6 @@ class ServerLauncher : public ServerLauncherInterface {
 
  private:
   std::string server_program_;
-  bool restricted_;
   bool suppress_error_dialog_;
 };
 
@@ -158,7 +155,6 @@ class Client : public ClientInterface {
   void EnableCascadingWindow(bool enable) override;
 
   void set_timeout(absl::Duration timeout) override;
-  void set_restricted(bool restricted) override;
   void set_server_program(absl::string_view program_path) override;
   void set_suppress_error_dialog(bool suppress) override;
   void set_client_capability(const commands::Capability &capability) override;

--- a/src/client/client_interface.h
+++ b/src/client/client_interface.h
@@ -79,9 +79,6 @@ class ServerLauncherInterface {
   // This is used for making IPC connection.
   virtual zstring_view server_program() const = 0;
 
-  // launch with restricted mode
-  virtual void set_restricted(bool restricted) = 0;
-
   // Sets the flag of error dialog suppression.
   virtual void set_suppress_error_dialog(bool suppress) = 0;
 };
@@ -195,10 +192,6 @@ class ClientInterface {
 
   // Sets the time out in milli second used for the IPC connection.
   virtual void set_timeout(absl::Duration timeout) = 0;
-
-  // Sets restricted mode.
-  // server is launched inside restricted environment.
-  virtual void set_restricted(bool restricted) = 0;
 
   // Sets server program path.
   // mainly for unittesting.

--- a/src/client/client_mock.h
+++ b/src/client/client_mock.h
@@ -84,7 +84,6 @@ class ClientMock : public client::ClientInterface {
   MOCK_METHOD(bool, NoOperation, (), (override));
   MOCK_METHOD(void, EnableCascadingWindow, (bool enable), (override));
   MOCK_METHOD(void, set_timeout, (absl::Duration timeout), (override));
-  MOCK_METHOD(void, set_restricted, (bool restricted), (override));
   MOCK_METHOD(void, set_server_program, (absl::string_view program_path),
               (override));
   MOCK_METHOD(void, set_suppress_error_dialog, (bool suppress), (override));

--- a/src/client/client_test.cc
+++ b/src/client/client_test.cc
@@ -144,8 +144,6 @@ class TestServerLauncher : public ServerLauncherInterface {
     return placeholder_server_program_path_;
   }
 
-  void set_restricted(bool restricted) override {}
-
   void set_suppress_error_dialog(bool suppress) override {}
 
   void set_start_server_result(const bool result) {
@@ -937,8 +935,6 @@ class SessionPlaybackTestServerLauncher : public ServerLauncherInterface {
   void OnFatal(ServerLauncherInterface::ServerErrorType type) override {}
 
   void set_server_program(const absl::string_view server_path) override {}
-
-  void set_restricted(bool restricted) override {}
 
   void set_suppress_error_dialog(bool suppress) override {}
 

--- a/src/client/server_launcher.cc
+++ b/src/client/server_launcher.cc
@@ -97,7 +97,6 @@ const std::string LoadServerFlags() {
 // initialize default path
 ServerLauncher::ServerLauncher()
     : server_program_(SystemUtil::GetServerPath()),
-      restricted_(false),
       suppress_error_dialog_(false) {}
 
 ServerLauncher::~ServerLauncher() = default;
@@ -127,7 +126,7 @@ bool ServerLauncher::StartServer(ClientInterface *client) {
   // with restricted mode.
 
   const bool process_in_job = RunLevel::IsProcessInJob();
-  if (process_in_job || restricted_) {
+  if (process_in_job) {
     LOG(WARNING) << "Parent process is in job. start with restricted mode";
     arg += "--restricted";
   }

--- a/src/win32/base/keyevent_handler_test.cc
+++ b/src/win32/base/keyevent_handler_test.cc
@@ -137,8 +137,6 @@ class TestServerLauncher : public client::ServerLauncherInterface {
     start_server_called_ = start_server_called;
   }
 
-  void set_restricted(bool restricted) override {}
-
   void set_suppress_error_dialog(bool suppress) override {}
 
   void set_server_program(const absl::string_view server_path) override {}


### PR DESCRIPTION
## Description
As a preparation to remove the "restricted mode" (#1376), let's start from removing the following unused methods.

 - `ServerLauncherInterface::set_restricted()`
 - `ClientInterface::set_restricted()`

## Issue IDs

 * https://github.com/google/mozc/issues/1376

## Steps to test new behaviors
 - OS: All
 - Steps:
   1. Confirm all GitHub Actions pass
