### PR TITLE
PoC: Add mozc_client_cli

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -173,6 +173,12 @@ class Client : public ClientInterface {
 
   bool OpenBrowser(const std::string &url) override;
 
+  // The most primitive Call method
+  // This method won't change the server_status_ even
+  // when version mismatch happens. In this case,
+  // just return false.
+  bool Call(const commands::Input &input, commands::Output *output);
+
  private:
   friend class ClientTestPeer;
 
@@ -215,12 +221,6 @@ class Client : public ClientInterface {
   // This method automatically re-launch mozc_server and
   // re-issue session id if it is not available.
   bool EnsureCallCommand(commands::Input *input, commands::Output *output);
-
-  // The most primitive Call method
-  // This method won't change the server_status_ even
-  // when version mismatch happens. In this case,
-  // just return false.
-  bool Call(const commands::Input &input, commands::Output *output);
 
   // first invoke Call() command and check the
   // protocol_version. When protocol version mismatch,

--- a/src/unix/BUILD.bazel
+++ b/src/unix/BUILD.bazel
@@ -92,6 +92,7 @@ genrule(
         ":icons",
         "//gui/tool:mozc_tool",
         "//server:mozc_server",
+        "//unix/cli:mozc_client_cli",
         "//unix/emacs:mozc_emacs_helper",
         "//unix/ibus:gen_mozc_xml",
         "//unix/ibus:ibus_mozc",

--- a/src/unix/cli/BUILD.bazel
+++ b/src/unix/cli/BUILD.bazel
@@ -1,0 +1,54 @@
+# Copyright 2010-2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+load(
+    "//:build_defs.bzl",
+    "mozc_cc_binary",
+    "mozc_cc_library",
+    "mozc_cc_test",
+)
+
+package(default_visibility = ["//visibility:private"])
+
+mozc_cc_binary(
+    name = "mozc_client_cli",
+    srcs = ["mozc_client_cli.cc"],
+    visibility = ["//unix:__subpackages__"],
+    deps = [
+        "//base:init_mozc",
+        "//base:version",
+        "//client",
+        "//config:config_handler",
+        "//protocol:commands_cc_proto",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/src/unix/cli/mozc_client_cli.cc
+++ b/src/unix/cli/mozc_client_cli.cc
@@ -1,0 +1,94 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "base/init_mozc.h"
+#include "client/client.h"
+#include "google/protobuf/json/json.h"
+#include "protocol/commands.pb.h"
+
+ABSL_FLAG(std::string, format, "jsonl", "Format for input/output");
+
+namespace mozc::cli {
+namespace {
+// Main loop, which takes JSON Lines as "mozc.commands.Input"s and
+// print corresponding results returned by Mozc server in JSON lines.
+bool ProcessLoopJSONL() {
+  client::Client client;
+  std::string line;
+  while (std::getline(std::cin, line)) {
+    mozc::commands::Input input;
+    auto status = google::protobuf::json::JsonStringToMessage(line, &input);
+    if (!status.ok()) {
+      std::cerr << "Failed to parse an input JSON as mozc.commands.Input: <"
+                << line << ">: " << status.ToString() << std::endl;
+      return false;
+    }
+    mozc::commands::Output output;
+    if (!client.Call(input, &output)) {
+      return false;
+    }
+    std::string outputJSON;
+    status = google::protobuf::json::MessageToJsonString(output, &outputJSON);
+    if (!status.ok()) {
+      std::cerr << "Failed to generate an output JSON for mozc.commands.Output: "
+                << status.ToString() << std::endl;
+      return false;
+    }
+    std::cout << outputJSON << std::endl;
+  }
+  return true;
+}
+
+}  // namespace
+}  // namespace mozc::cli
+
+int main(int argc, char **argv) {
+  mozc::InitMozc(argv[0], &argc, &argv);
+
+  bool success = false;
+  const auto& format = absl::GetFlag(FLAGS_format);
+  if (format == "jsonl") {
+    success = mozc::cli::ProcessLoopJSONL();
+  } else if (format == "text") {
+    // TODO
+  } else if (format == "binary") {
+    // TODO
+  } else if (format == "s-expressionl") {
+    // TODO
+  } else {
+    std::cerr << "Unsupported format: <" << format << ">" << std::endl;
+  }
+
+  return success ? 0 : 1;
+}


### PR DESCRIPTION
## Description

Add a CLI client command.

This is for decoupling third party Mozc clients such as uim and Fcitx5.

Mozc doesn't provide a client library. So third party Mozc clients can't be implemented without bundling Mozc. If we provide a CLI client command, third party Mozc clients can be implemented out of Mozc source.

This just:

1. accepts mozc.commands.Input as input from stdin,
2. sends the input to mozc_server as-is,
3. receives mozc.commands.Output as output from mozc_server and
4. outputs the output to stdout.

This may convert the protobuf binary format to/from something such as JSON Lines. This PoC just implements JSON Lines input/output. (No the protobuf binary format support.)

mozc_emacs_helper manages a client pool but this doesn't manage a client pool. If users need it, they must spawn multiple mozc_client_cli processes by themselves.

If there is any input error, mozc_client_cli exits with non-0 (1 in this implementation). Users can get error message from stderr.

## Issue IDs

https://github.com/google/mozc/discussions/1362#discussioncomment-14369849 as a related discussion.

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Debian GNU/Linux sid
 - Steps:
   1. `bazelisk build package --config oss_linux --config release_build` 
   2. `bazel-bin/unix/cli/mozc_client_cli`
   3. Input `mozc.commands.Input` as JSON Lines to stdin


Example:

```console
$ bazel-bin/unix/cli/mozc_client_cli
{"type": "GET_CONFIG"}
{"id":"0",...(GET_CONFIG response in JSON)}
{"type": "CREATE_SESSION"}
{"id":"1968337769025405287"}
^D
$
```

```console
$ bazel-bin/unix/cli/mozc_client_cli
"X"
Failed to parse an input JSON as mozc.commands.Input: <"X">: INVALID_ARGUMENT: invalid JSON in mozc.commands.Input, near 1:1 (offset 0): unexpected character: '"'; expected '{'
$ echo $?
1
```

## Additional context

This is just a PoC to discuss this direction.