### PR TITLE
Restore `{SELECT,HIGHLIGHT}_CANDIDATE` handling

### DIFF
--- a/src/renderer/renderer_server.cc
+++ b/src/renderer/renderer_server.cc
@@ -102,6 +102,20 @@ class RendererServerSendCommand : public client::SendCommandInterface {
       // Unsupported command.
       return false;
     }
+
+    HWND target = WinUtil::DecodeWindowHandle(receiver_handle_);
+    if (target == nullptr) {
+      LOG(ERROR) << "target window is nullptr";
+      return false;
+    }
+    UINT mozc_msg = ::RegisterWindowMessageW(kMessageReceiverMessageName);
+    if (mozc_msg == 0) {
+      LOG(ERROR) << "RegisterWindowMessage failed: " << ::GetLastError();
+      return false;
+    }
+    WPARAM type = static_cast<WPARAM>(command.type());
+    LPARAM id = static_cast<LPARAM>(command.id());
+    ::PostMessage(target, mozc_msg, type, id);
 #endif  // _WIN32
 
     // TODO(all): implementation for Mac/Linux


### PR DESCRIPTION
## Description
This commit restores `{SELECT,HIGHLIGHT}_CANDIDATE` command handlings, which were accidentally removed in our previous commit (289147804bc9203b89a8598264ce4e505922606c) that aimed to remove unused code around the usage stats feature.

Closes #1372.

## Issue IDs

 * https://github.com/google/mozc/issues/1372

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build and install Mozc on Windows.
   2. Open notepad
   3. Type kyouto
   4. Hit space key
   5. Select any candidate on the candidate window.
