### PR TITLE
Always let server/renderer run in Win32 Jobs

### DIFF
--- a/src/base/run_level.cc
+++ b/src/base/run_level.cc
@@ -276,32 +276,6 @@ RunLevel::RunLevelType RunLevel::GetRunLevel(RunLevel::RequestType type) {
 #endif  // _WIN32
 }
 
-bool RunLevel::IsProcessInJob() {
-#ifdef _WIN32
-  // Check to see if we're in a job where
-  // we can't create a child in our sandbox
-
-  JOBOBJECT_EXTENDED_LIMIT_INFORMATION JobExtLimitInfo;
-  // Get the job information of the current process
-  if (!::QueryInformationJobObject(nullptr, JobObjectExtendedLimitInformation,
-                                   &JobExtLimitInfo, sizeof(JobExtLimitInfo),
-                                   nullptr)) {
-    return false;
-  }
-
-  // Check to see if we can break away from the current job
-  if (JobExtLimitInfo.BasicLimitInformation.LimitFlags &
-      (JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)) {
-    // We're in a job, but it allows to break away.
-    return false;
-  }
-
-  return true;
-#else   // _WIN32
-  return false;
-#endif  // _WIN32
-}
-
 bool RunLevel::IsElevatedByUAC() {
 #ifdef _WIN32
   // Get process token

--- a/src/base/run_level.h
+++ b/src/base/run_level.h
@@ -65,10 +65,6 @@ class RunLevel {
     return (GetRunLevel(RunLevel::CLIENT) <= RunLevel::RESTRICTED);
   }
 
-  // return true if the current process is in other JOB.
-  // returns always false on Linux/Mac
-  static bool IsProcessInJob();
-
   // return true the current process is elevated by UAC.
   // return false if the function failed to determine it.
   // return false on Mac/Linux

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -77,7 +77,6 @@ mozc_cc_library(
         macos = ["//base/mac:mac_util"],
         windows = [
             "//base/win32:win_sandbox",
-            "//base:run_level",
         ],
     ),
 )

--- a/src/renderer/renderer_client.cc
+++ b/src/renderer/renderer_client.cc
@@ -57,7 +57,6 @@
 #endif  // __APPLE__
 
 #ifdef _WIN32
-#include "base/run_level.h"
 #include "base/win32/win_sandbox.h"
 #endif  // _WIN32
 
@@ -227,23 +226,19 @@ class RendererLauncher : public RendererLauncherInterface {
 
 #ifdef _WIN32
     DWORD pid = 0;
-    const bool process_in_job = RunLevel::IsProcessInJob();
-    const std::string arg = process_in_job ? "--restricted" : "";
 
     WinSandbox::SecurityInfo info;
     info.primary_level = WinSandbox::USER_INTERACTIVE;
     info.impersonation_level = WinSandbox::USER_RESTRICTED_SAME_ACCESS;
     info.integrity_level = WinSandbox::INTEGRITY_LEVEL_LOW;
-    // If the current process is in a job, you cannot use
-    // CREATE_BREAKAWAY_FROM_JOB. b/1571395
-    info.use_locked_down_job = !process_in_job;
+    info.use_locked_down_job = true;
     info.allow_ui_operation = true;  // skip UI protection
     info.in_system_dir = true;  // use system dir not to lock current directory
     info.creation_flags = CREATE_DEFAULT_ERROR_MODE;
 
     // start renderer process
     const bool result =
-        WinSandbox::SpawnSandboxedProcess(path_, arg, info, &pid);
+        WinSandbox::SpawnSandboxedProcess(path_, "", info, &pid);
 #elif defined(__APPLE__)  // _WIN32
     // Start renderer process by using launch_msg API.
     pid_t pid = 0;

--- a/src/win32/broker/prelauncher.cc
+++ b/src/win32/broker/prelauncher.cc
@@ -31,7 +31,6 @@
 
 #include <memory>
 
-#include "base/run_level.h"
 #include "base/win32/win_util.h"
 #include "client/client.h"
 #include "client/client_interface.h"
@@ -47,10 +46,6 @@ constexpr int kErrorLevelGeneralError = 1;
 }  // namespace
 
 int RunPrelaunchProcesses(int argc, char *argv[]) {
-  if (RunLevel::IsProcessInJob()) {
-    return kErrorLevelGeneralError;
-  }
-
   bool is_service_process = false;
   if (!WinUtil::IsServiceProcess(&is_service_process)) {
     // Returns DENY conservatively.


### PR DESCRIPTION
## Description
As the initial step towards removing "restricted mode" (#1376), this commit simplifies the codebase by taking advantage of the fact that Windows 8 and later allows Win32 processes to belong to multiple jobs.

Before Windows 8, Win32 processes cannot belong to multiple jobs. Due to this limitation, there is a case when `mozc_{server,renderer}` cannot be launched in a restricted job. This is why `WinSandboxSecurityInfo::use_locked_down_job` has been determined at runtime with `RunLevel::IsProcessInJob()`.

Now that Mozc only supports Windows 10 and later, `use_locked_down_job` can be initialized as the compile time constant.

To minimize the compatibility impact, `CREATE_BREAKAWAY_FROM_JOB` flag continues to be specified if possible. This means that when Mozc server/renderer is launched from a process in a job which allows breakaway, the user observable behavior remains unchanged before and after this commit.

## Issue IDs

 * https://github.com/google/mozc/issues/1376

## Steps to test new behaviors
 - OS: Windows 11 24H2
 - Steps:
   1. Build and install Mozc
   2. Open Notepad
   3. Confirm you can still enable Mozc and use it.
