### PR TITLE
Delete unused credentials after `actions/checkout`

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: setup
         run: |
@@ -62,6 +63,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
+          persist-credentials: false
 
       - name: Run
         working-directory: ./src

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup
         run: |
@@ -54,6 +55,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -64,6 +65,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -105,6 +107,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -146,6 +149,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -177,6 +181,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up pip
         shell: cmd
@@ -85,6 +86,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -137,6 +139,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -189,6 +192,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up pip
         shell: cmd
@@ -231,6 +235,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4
@@ -266,6 +271,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: false
+          persist-credentials: false
 
       - name: Try to restore update_deps cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Description
While opting out `persist-credentials` in actions/checkout is a widely recommended security best practice, it is somehow not the default behavior.

Let's follow the recommendation to reduce the risk of supply chain attacks.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm all the GitHub Actions still pass.
