### PR TITLE
Rely on RAII around `SECURITY_ATTRIBUTES`

### DIFF
--- a/src/base/win32/win_sandbox.cc
+++ b/src/base/win32/win_sandbox.cc
@@ -382,14 +382,12 @@ std::wstring Sid::GetAccountName() const {
   return StrCatW(domain_name_buffer.get(), L"/", name_buffer.get());
 }
 
-// make SecurityAttributes for the named pipe.
-bool WinSandbox::MakeSecurityAttributes(
-    ObjectSecurityType shareble_object_type,
-    SECURITY_ATTRIBUTES* security_attributes) {
+wil::unique_hlocal_security_descriptor WinSandbox::MakeSecurityDescriptor(
+    ObjectSecurityType shareble_object_type) {
   std::wstring token_user_sid;
   std::wstring token_primary_group_sid;
   if (!GetUserSid(token_user_sid, token_primary_group_sid)) {
-    return false;
+    return nullptr;
   }
 
   const std::wstring& sddl =
@@ -402,15 +400,10 @@ bool WinSandbox::MakeSecurityAttributes(
     LOG(ERROR)
         << "ConvertStringSecurityDescriptorToSecurityDescriptorW failed: "
         << ::GetLastError();
-    return false;
+    return nullptr;
   }
 
-  // Set up security attributes
-  security_attributes->nLength = sizeof(SECURITY_ATTRIBUTES);
-  security_attributes->lpSecurityDescriptor = self_relative_desc.release();
-  security_attributes->bInheritHandle = FALSE;
-
-  return true;
+  return self_relative_desc;
 }
 
 bool WinSandbox::AddKnownSidToKernelObject(HANDLE object, const SID* known_sid,
@@ -562,11 +555,9 @@ std::optional<wil::unique_process_information> CreateSuspendedRestrictedProcess(
     return std::nullopt;
   }
 
-  PSECURITY_ATTRIBUTES security_attributes_ptr = nullptr;
-  SECURITY_ATTRIBUTES security_attributes = {};
-  if (WinSandbox::MakeSecurityAttributes(WinSandbox::kIPCServerProcess,
-                                         &security_attributes)) {
-    security_attributes_ptr = &security_attributes;
+  wil::unique_hlocal_security_descriptor security_descriptor =
+      WinSandbox::MakeSecurityDescriptor(WinSandbox::kIPCServerProcess);
+  if (security_descriptor) {
     // Override the impersonation thread token's DACL to avoid http://b/1728895
     // On Windows Server, the objects created by a member of
     // the built-in administrators group do not always explicitly
@@ -579,9 +570,9 @@ std::optional<wil::unique_process_information> CreateSuspendedRestrictedProcess(
     // That prevents GetRunLevel() from verifying its own thread identity.
     // Note: Overriding the thread token's
     // DACL will not elevate the thread's running context.
-    if (!::SetKernelObjectSecurity(
-            impersonation_token.get(), DACL_SECURITY_INFORMATION,
-            security_attributes_ptr->lpSecurityDescriptor)) {
+    if (!::SetKernelObjectSecurity(impersonation_token.get(),
+                                   DACL_SECURITY_INFORMATION,
+                                   security_descriptor.get())) {
       const DWORD last_error = ::GetLastError();
       DLOG(ERROR) << "SetKernelObjectSecurity failed. Error: " << last_error;
       return std::nullopt;
@@ -598,6 +589,14 @@ std::optional<wil::unique_process_information> CreateSuspendedRestrictedProcess(
   const wchar_t* startup_directory =
       (info.in_system_dir ? SystemUtil::GetSystemDir() : nullptr);
 
+  SECURITY_ATTRIBUTES security_attributes = {
+      .nLength = sizeof(SECURITY_ATTRIBUTES),
+      .lpSecurityDescriptor = security_descriptor.get(),
+      .bInheritHandle = FALSE,
+  };
+  SECURITY_ATTRIBUTES* security_attributes_ptr =
+      (security_descriptor ? &security_attributes : nullptr);
+
   STARTUPINFO startup_info = {sizeof(STARTUPINFO)};
   wil::unique_process_information process_info;
   // 3rd parameter of CreateProcessAsUser must be a writable buffer.
@@ -613,10 +612,6 @@ std::optional<wil::unique_process_information> CreateSuspendedRestrictedProcess(
     const DWORD last_error = ::GetLastError();
     DLOG(ERROR) << "CreateProcessAsUser failed. Error: " << last_error;
     return std::nullopt;
-  }
-
-  if (security_attributes_ptr != nullptr) {
-    ::LocalFree(security_attributes_ptr->lpSecurityDescriptor);
   }
 
   // Change the token of the main thread of the new process for the

--- a/src/base/win32/win_sandbox.h
+++ b/src/base/win32/win_sandbox.h
@@ -92,25 +92,29 @@ class WinSandbox {
     USER_UNPROTECTED,
   };
 
-  // Make a security attributes that only permit current user and system
-  // to access the target resource.
-  // return true if a valid securityAttributes is generated.
-  // Please call ::LocalFree() to release the attributes.
+  // Returns a security descriptor that only permit current user and system to
+  // access the target resource.
   //
   // Usage:
-  // SECURITY_ATTRIBUTES security_attributes;
-  // if (!MakeSecurityAttributes(WinSandbox::kSharablePipe,
-  //                             &security_attributes)) {
-  //  LOG(ERROR) << "Cannot make SecurityAttributes";
+  // auto security_descriptor =
+  //     MakeSecurityDescriptor(WinSandbox::kSharablePipe);
+  // if (!security_descriptor) {
+  //  LOG(ERROR) << "Cannot make SecurityDescriptor";
   //  return;
   // }
+  //
+  // SECURITY_ATTRIBUTES security_attributes = {
+  //    .nLength = sizeof(SECURITY_ATTRIBUTES),
+  //    .lpSecurityDescriptor = security_descriptor.get(),
+  //    .bInheritHandle = FALSE,
+  // };
+  //
   // handle_ = ::CreateNamedPipe(..
   //                             PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED |
   //                             FILE_FLAG_FIRST_PIPE_INSTANCE,
   //                             PIPE_REJECT_REMOTE_CLIENTS | ...,
   //                             ...
   //                             &security_attributes);
-  // ::LocalFree(security_attributes.lpSecurityDescriptor);
   enum ObjectSecurityType {
     // Used for an object that is inaccessible from lower sandbox level.
     kPrivateObject = 0,
@@ -129,8 +133,8 @@ class WinSandbox {
     // level.
     kIPCServerProcess,
   };
-  static bool MakeSecurityAttributes(ObjectSecurityType shareble_object_type,
-                                     SECURITY_ATTRIBUTES* security_attributes);
+  static wil::unique_hlocal_security_descriptor MakeSecurityDescriptor(
+      ObjectSecurityType shareble_object_type);
 
   // Adds an ACE represented by |known_sid| and |access| to the dacl of the
   // kernel object referenced by |object|. |inheritance_flag| is a set of bit

--- a/src/ipc/BUILD.bazel
+++ b/src/ipc/BUILD.bazel
@@ -220,6 +220,7 @@ mozc_cc_library(
         windows = [
             "//base/win32:win_sandbox",
             "//base/win32:wide_char",
+            "@com_microsoft_wil//:wil",
         ],
     ),
 )

--- a/src/ipc/win32_ipc.cc
+++ b/src/ipc/win32_ipc.cc
@@ -116,14 +116,19 @@ class IPCClientMutexBase {
                      ipc_channel_name, ".ipc");
     std::wstring wmutex_name = Utf8ToWide(mutex_name);
 
-    LPSECURITY_ATTRIBUTES security_attributes_ptr = nullptr;
-    SECURITY_ATTRIBUTES security_attributes;
-    if (!WinSandbox::MakeSecurityAttributes(WinSandbox::kSharableMutex,
-                                            &security_attributes)) {
-      LOG(ERROR) << "Cannot make SecurityAttributes";
-    } else {
-      security_attributes_ptr = &security_attributes;
+    wil::unique_hlocal_security_descriptor security_descriptor =
+        WinSandbox::MakeSecurityDescriptor(WinSandbox::kSharableMutex);
+    if (!security_descriptor) {
+      LOG(ERROR) << "Cannot make SecurityDescriptor";
     }
+
+    SECURITY_ATTRIBUTES security_attributes = {
+        .nLength = sizeof(SECURITY_ATTRIBUTES),
+        .lpSecurityDescriptor = security_descriptor.get(),
+        .bInheritHandle = FALSE,
+    };
+    LPSECURITY_ATTRIBUTES security_attributes_ptr =
+        (security_descriptor ? &security_attributes : nullptr);
 
     // http://msdn.microsoft.com/en-us/library/ms682411(VS.85).aspx:
     // Two or more processes can call CreateMutex to create the same named
@@ -137,9 +142,6 @@ class IPCClientMutexBase {
     // certain which process has initial ownership.
     ipc_mutex_.reset(
         ::CreateMutex(security_attributes_ptr, FALSE, wmutex_name.c_str()));
-    if (security_attributes_ptr != nullptr) {
-      ::LocalFree(security_attributes_ptr->lpSecurityDescriptor);
-    }
 
     const DWORD create_mutex_error = ::GetLastError();
     if (ipc_mutex_.get() == nullptr) {
@@ -461,12 +463,18 @@ IPCServer::IPCServer(const std::string &name, int32_t num_connections,
   }
   DCHECK(!server_address.empty());
 
-  SECURITY_ATTRIBUTES security_attributes;
-  if (!WinSandbox::MakeSecurityAttributes(WinSandbox::kSharablePipe,
-                                          &security_attributes)) {
-    LOG(ERROR) << "Cannot make SecurityAttributes";
+  wil::unique_hlocal_security_descriptor security_descriptor =
+      WinSandbox::MakeSecurityDescriptor(WinSandbox::kSharablePipe);
+  if (!security_descriptor) {
+    LOG(ERROR) << "Cannot make SecurityDescriptor";
     return;
   }
+
+  SECURITY_ATTRIBUTES security_attributes = {
+      .nLength = sizeof(SECURITY_ATTRIBUTES),
+      .lpSecurityDescriptor = security_descriptor.get(),
+      .bInheritHandle = FALSE,
+  };
 
   // Create a named pipe.
   std::wstring wserver_address = Utf8ToWide(server_address);
@@ -479,7 +487,6 @@ IPCServer::IPCServer(const std::string &name, int32_t num_connections,
       IPC_INITIAL_READ_BUFFER_SIZE, IPC_INITIAL_READ_BUFFER_SIZE, 0,
       &security_attributes);
   const DWORD create_named_pipe_error = ::GetLastError();
-  ::LocalFree(security_attributes.lpSecurityDescriptor);
 
   if (INVALID_HANDLE_VALUE == handle) {
     LOG(FATAL) << "CreateNamedPipe failed" << create_named_pipe_error;


### PR DESCRIPTION
## Description
This is a semi-mechanical refactoring to improve the error handling around `SECURITY_ATTRIBUTES` as a preparation to start using `PROC_THREAD_ATTRIBUTE_JOB_LIST` (#1377).

The issue is that the current method signature of
```cpp
static bool WinSandbox::MakeSecurityAttributes(
    ObjectSecurityType shareble_object_type,
    SECURITY_ATTRIBUTES* security_attributes);
```
makes it difficult to ensure that
```cpp
::LocalFree(security_attributes->lpSecurityDescriptor);
```
is always called. The idea here is to change that method signature to directly return an RAII wrapper `wil::unique_hlocal_security_descriptor` instead of updating `SECURITY_ATTRIBUTES` in-place.

```cpp
static wil::unique_hlocal_security_descriptor WinSandbox::MakeSecurityDescriptor(
    ObjectSecurityType shareble_object_type);
```

With that, the caller can simply create `SECURITY_ATTRIBUTES` with making it clear that `wil::unique_hlocal_security_descriptor` takes care of the cleanup as follows:

```cpp
auto security_descriptor =
    MakeSecurityDescriptor(WinSandbox::kSharablePipe);
if (!security_descriptor) {
  LOG(ERROR) << "Cannot make SecurityDescriptor";
  return;
}
SECURITY_ATTRIBUTES security_attributes = {
    .nLength = sizeof(SECURITY_ATTRIBUTES),
    .lpSecurityDescriptor = security_descriptor.get(),
    .bInheritHandle = FALSE,
};
auto handle = ::CreateNamedPipe(..., &security_attributes);
if (handle == INVALID_HANDLE_VALUE) {
  return;
}
```

There must be no behavior change in the successful paths. For error cases, the new behavior should be more appropriate as `LocalFree` is now guaranteed to be called.

## Issue IDs

 * https://github.com/google/mozc/issues/1377

## Steps to test new behaviors (if any)
 - OS: Windows 11 24H2
 - Steps:
   1. Build `Mozc64.msi` with Bazel then install it.
   2. Confirm that you can still input Japanese with Mozc.
