### PR TITLE
Fix text reconversions on Excel for Windows

### DIFF
--- a/src/win32/tip/tip_composition_util.h
+++ b/src/win32/tip/tip_composition_util.h
@@ -54,6 +54,11 @@ class TipCompositionUtil {
   static wil::com_ptr_nothrow<ITfCompositionView> GetCompositionView(
       ITfContext *context, TfEditCookie edit_cookie);
 
+  // Returns composition view object if there is a composition which belongs
+  // to Mozc in |range|. Otherwise returns nullptr.
+  static wil::com_ptr_nothrow<ITfCompositionView> GetCompositionViewFromRange(
+      ITfRange *range, TfEditCookie edit_cookie);
+
   // Removes display attributes from |composition|. Returns the result.
   static HRESULT ClearDisplayAttributes(ITfContext *context,
                                         ITfComposition *composition,

--- a/src/win32/tip/tip_edit_session.h
+++ b/src/win32/tip/tip_edit_session.h
@@ -106,7 +106,7 @@ class TipEditSession {
 
   // Begins a sync edit session to retrieve the text from |range|.
   static bool GetTextSync(TipTextService *text_service, ITfRange *range,
-                          std::wstring *text);
+                          std::wstring *text, bool *is_composing);
 
   // Begins an async edit session to set |text| to |range|.
   static bool SetTextAsync(TipTextService *text_service, std::wstring_view text,

--- a/src/win32/tip/tip_linguistic_alternates.cc
+++ b/src/win32/tip/tip_linguistic_alternates.cc
@@ -95,7 +95,8 @@ TipLinguisticAlternates::GetAlternates(
   }
   *candidate_list = nullptr;
   std::wstring query;
-  if (!TipEditSession::GetTextSync(text_service_.get(), range, &query)) {
+  if (!TipEditSession::GetTextSync(text_service_.get(), range, &query,
+                                   nullptr)) {
     return E_FAIL;
   }
   std::vector<std::wstring> candidates;

--- a/src/win32/tip/tip_reconvert_function.cc
+++ b/src/win32/tip/tip_reconvert_function.cc
@@ -83,18 +83,20 @@ STDMETHODIMP TipReconvertFunction::QueryRange(
     return E_FAIL;
   }
 
-  TipSurroundingTextInfo info;
-  if (!TipSurroundingText::Get(text_service_.get(), context.get(), &info)) {
+  std::wstring selected_text;
+  bool is_composing = false;
+  if (!TipEditSession::GetTextSync(text_service_.get(), range,
+                                   &selected_text, &is_composing)) {
     return E_FAIL;
   }
 
-  if (info.in_composition) {
+  if (is_composing) {
     // on-going composition is found.
     SaveToOptionalOutParam(FALSE, opt_convertible);
     return S_OK;
   }
 
-  if (info.selected_text.find(static_cast<wchar_t>(TS_CHAR_EMBEDDED)) !=
+  if (selected_text.find(static_cast<wchar_t>(TS_CHAR_EMBEDDED)) !=
       std::wstring::npos) {
     // embedded object is found.
     SaveToOptionalOutParam(FALSE, opt_convertible);
@@ -120,7 +122,8 @@ TipReconvertFunction::GetReconversion(
     return E_FAIL;
   }
   std::wstring query;
-  if (!TipEditSession::GetTextSync(text_service_.get(), range, &query)) {
+  if (!TipEditSession::GetTextSync(text_service_.get(), range, &query,
+                                   nullptr)) {
     return E_FAIL;
   }
   std::vector<std::wstring> candidates;

--- a/src/win32/tip/tip_surrounding_text.cc
+++ b/src/win32/tip/tip_surrounding_text.cc
@@ -338,6 +338,13 @@ bool TipSurroundingText::PrepareForReconversionFromIme(
   if (!GetSurroundingTextImm32(context,
                                ReconvertString::RequestType::kReconvertString,
                                info)) {
+    // Certain apps such as Excel do start reconversions by using
+    // ITfFnReconversion protocol upon receiving IMR_RECONVERTSTRING message,
+    // even though they return 0 (== failure) to the message.
+    // See https://github.com/google/mozc/issues/1384 for details.
+    // In this sense, seeing failure here is still a necessary step to support
+    // reconversions in such apps. We just need to wait for the app to call into
+    // TipReconvertFunction::Reconvert later.
     return false;
   }
   // IMM32-like reconversion requires async edit session.


### PR DESCRIPTION
## Description
This follows up my previous commit (a2af4322f5863e14495291fdcdf5b9bad62d7e6a) , which aimed to support surrounding text retrieval on Chromium-based apps. However, it turned out that it broke text reconversion on Excel. This commit aims to fix the text reconversion on Excel while keeping the support for surrounding text retrieval on Chromium-based apps.

A short takeaway is that Excel has relied on `ITfFnReconversion`, where the application (Excel) is responsible for providing `ITfRange` object from which IMEs can retrieve the surrounding text. Special rules implemented in `TipSurroundingText::Get` are not necessary when a valid `ITfRange` object is already given. This is what I have overlooked even before the culprit commit.

This commit utilizes the existing `TipEditSession::GetTextSync` as it already takes an `ITfRange` object to return the selected text. For now reusing it would be the simplest solution.

Closes #1384.

## Issue IDs

 * https://github.com/google/mozc/issues/1384

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2,  Excel 2509
 - Steps:
![reconvert_excel_expected](https://github.com/user-attachments/assets/0d5f4c48-0f21-4409-803e-b63aea5024e3)
