### PR TITLE
Update Android NDK from r28 to r29

### DIFF
--- a/docs/build_mozc_for_android.md
+++ b/docs/build_mozc_for_android.md
@@ -57,7 +57,7 @@ python3 build_tools/update_deps.py
 
 In this step, additional build dependencies will be downloaded.
 
-*   [Android NDK r28](https://github.com/android/ndk/wiki/Home/24fe2d7ee3591346e0e8ae615977a15c0a4fba40#ndk-r28)
+*   [Android NDK r29](https://github.com/android/ndk/wiki/Home/da2aa451f142a10203894c58fd1af78248fb06b4#ndk-r29)
 *   [git submodules](../.gitmodules)
 
 ### Build `libmozc.so` for Android

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -166,7 +166,7 @@ android_ndk_repository_extension = use_extension(
     "android_ndk_repository_extension",
 )
 android_ndk_repository_extension.configure(
-    path = "$WORKSPACE_ROOT/third_party/ndk/android-ndk-r28",
+    path = "$WORKSPACE_ROOT/third_party/ndk/android-ndk-r29",
 )
 use_repo(android_ndk_repository_extension, "androidndk")
 

--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -89,15 +89,15 @@ QT6 = ArchiveInfo(
 )
 
 NDK_LINUX = ArchiveInfo(
-    url='https://dl.google.com/android/repository/android-ndk-r28-linux.zip',
-    size=723148067,
-    sha256='a186b67e8810cb949514925e4f7a2255548fb55f5e9b0824a6430d012c1b695b',
+    url='https://dl.google.com/android/repository/android-ndk-r29-linux.zip',
+    size=783549481,
+    sha256='4abbbcdc842f3d4879206e9695d52709603e52dd68d3c1fff04b3b5e7a308ecf',
 )
 
 NDK_MAC = ArchiveInfo(
-    url='https://dl.google.com/android/repository/android-ndk-r28-darwin.zip',
-    size=950413046,
-    sha256='19b16241e8e8d4c8e4f3729b8a0a625dd240394e1f1cd072596df891317e22a9',
+    url='https://dl.google.com/android/repository/android-ndk-r29-darwin.zip',
+    size=1049519838,
+    sha256='ce5e4b100ec5fe5be4eb3edcb2c02528824ff9cda3860f5304619be6c3da34d3',
 )
 
 NINJA_MAC = ArchiveInfo(


### PR DESCRIPTION
## Description
Android NDK r29 was released on Oct 7, 2025. With that r28 now reaches to EOL and is no longer supported.

 * https://github.com/android/ndk/releases/tag/r29

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: GitHub Actions
 - Steps:
   1. Confirm builds for Android are still successful.

