### PR TITLE
Avoid flickering of composing text on Windows

### DIFF
--- a/src/win32/tip/tip_edit_session_impl.cc
+++ b/src/win32/tip/tip_edit_session_impl.cc
@@ -225,35 +225,31 @@ HRESULT UpdateComposition(TipTextService *text_service, ITfContext *context,
                           TfEditCookie write_cookie, const Output &output) {
   HRESULT result = S_OK;
 
-  // Clear composition
-  if (composition) {
-    wil::com_ptr_nothrow<ITfRange> composition_range;
-    result = composition->GetRange(&composition_range);
-    if (FAILED(result)) {
-      return result;
-    }
-    BOOL is_empty = FALSE;
-    result = composition_range->IsEmpty(write_cookie, &is_empty);
-    if (FAILED(result)) {
-      return result;
-    }
-    if (is_empty != TRUE) {
-      std::wstring str;
-      TipRangeUtil::GetText(composition_range.get(), write_cookie, &str);
-      result = composition_range->SetText(write_cookie, 0, L"", 0);
-      if (FAILED(result)) {
-        return result;
-      }
-      result = ClearReadingProperties(context, composition_range.get(),
-                                      write_cookie);
-      if (FAILED(result)) {
-        return result;
-      }
-    }
-  }
-
   if (!output.has_preedit()) {
     if (composition) {
+      wil::com_ptr_nothrow<ITfRange> composition_range;
+      result = composition->GetRange(&composition_range);
+      if (FAILED(result)) {
+        return result;
+      }
+      BOOL is_empty = FALSE;
+      result = composition_range->IsEmpty(write_cookie, &is_empty);
+      if (FAILED(result)) {
+        return result;
+      }
+      if (is_empty != TRUE) {
+        std::wstring str;
+        TipRangeUtil::GetText(composition_range.get(), write_cookie, &str);
+        result = composition_range->SetText(write_cookie, 0, L"", 0);
+        if (FAILED(result)) {
+          return result;
+        }
+        result = ClearReadingProperties(context, composition_range.get(),
+                                        write_cookie);
+        if (FAILED(result)) {
+          return result;
+        }
+      }
       result = composition->EndComposition(write_cookie);
       if (FAILED(result)) {
         return result;
@@ -445,6 +441,7 @@ HRESULT UpdatePreeditAndComposition(TipTextService *text_service,
       TipCompositionUtil::GetComposition(context, write_cookie);
 
   // Clear the display attributes first.
+  // TODO(https://github.com/google/mozc/discussions/1388): Revisit here.
   if (composition) {
     const HRESULT result = TipCompositionUtil::ClearDisplayAttributes(
         context, composition.get(), write_cookie);
@@ -614,6 +611,7 @@ HRESULT TipEditSessionImpl::OnCompositionTerminated(
   }
 
   // Clear the display attributes first.
+  // TODO(https://github.com/google/mozc/discussions/1388): Revisit here.
   if (composition) {
     const HRESULT result = TipCompositionUtil::ClearDisplayAttributes(
         context, composition, write_cookie);


### PR DESCRIPTION
## Description
This is a quick fix for the flickering issue of composing text on certain Windows apps such as Notepad (#1386).

Previously, we have called
```cpp
composition_range->SetText(write_cookie, 0, L"", 0);
```
not only when the composing text becomes empty but also when the composing text is just updated to a non-empty string. This seems to cause flickering on certain Windows apps.

Ideally the entire logic here should be audited and redesigned. It will be discussed in https://github.com/google/mozc/discussions/1388.

Closes #1386.

## Issue IDs

 * https://github.com/google/mozc/issues/1386

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Build and install Mozc.
   2. Open Nodepad.
   3. Confirm flickering of composing text is no longer reproducible.

|Before|After|
|----------|-------|
|![Image](https://github.com/user-attachments/assets/9898a07f-122c-4beb-8ec6-62025630d1ac)|![Image](https://github.com/user-attachments/assets/7ce01ac7-c7b3-453b-afec-4d1ccd690e12)|