### PR TITLE
Prefer VS2022 when VS2026 is also installed

### DIFF
--- a/src/build_tools/vs_util.py
+++ b/src/build_tools/vs_util.py
@@ -85,6 +85,9 @@ def get_vcvarsall(
       'Microsoft.VisualStudio.Product.BuildTools',
       '-find',
       'VC/Auxiliary/Build/vcvarsall.bat',
+      '-version',
+      '[17,18)',  # See https://github.com/microsoft/vswhere/wiki/Versions
+      '-latest',
       '-utf8',
   ]
   cmd += [


### PR DESCRIPTION
## Description
Now that Visual Studio 2026 is publicly available and can be installed alongside Visual Studio 2022, we need to make sure that Mozc can still be built with VS2022 as before at least. Without this commit, the build fails because `src/build_tools/vs_util.py` may return `vcvarsall.bat` for Visual Studio 2026.

Closes #1401.

## Issue IDs

 * https://github.com/google/mozc/issues/1401

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Install both Visual Studio 2022 and Visual Studio 2026
   2. Try to build Mozc with either Bazel or GYP
   3. Confirm you can build Mozc
