### PR TITLE
Bump `actions/upload-artifact` from 4.x to 5.x

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -47,7 +47,7 @@ jobs:
           bazelisk build --config oss_android package --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: native_libs.zip
           path: src/bazel-bin/android/jni/native_libs.zip

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -39,7 +39,7 @@ jobs:
           bazelisk build --config oss_linux package --config release_build
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mozc.zip
           path: src/bazel-bin/unix/mozc.zip

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -49,7 +49,7 @@ jobs:
           bazelisk build --config oss_macos package --macos_cpus=arm64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc_arm64.pkg
           path: src/bazel-bin/mac/Mozc.pkg
@@ -91,7 +91,7 @@ jobs:
           bazelisk build --config oss_macos package --macos_cpus=x86_64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc_intel64.pkg
           path: src/bazel-bin/mac/Mozc.pkg
@@ -133,7 +133,7 @@ jobs:
           bazelisk build --config oss_macos package --macos_cpus=x86_64,arm64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc_universal_binary.pkg
           path: src/bazel-bin/mac/Mozc.pkg

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -70,7 +70,7 @@ jobs:
           python build_mozc.py build -c Release package
 
       - name: upload Mozc64_gyp.msi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc64_gyp.msi
           path: src/out_win/Release/Mozc64.msi
@@ -123,7 +123,7 @@ jobs:
           bazelisk build --config oss_windows --config release_build package
 
       - name: upload Mozc64_x64.msi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc64_x64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
@@ -176,7 +176,7 @@ jobs:
           bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64
 
       - name: upload Mozc64_arm64.msi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Mozc64_arm64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi


### PR DESCRIPTION
## Description
With this commit `actions/upload-artifact` will be updated to v5.x.

As of v5.0.0, there seems to be no incompatible changes for our existing workflows.

 * https://github.com/actions/upload-artifact/releases/tag/v5.0.0

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Trigger GitHub Actions
   2. Confirm artifacts are uploaded successfully in GitHub Actions.
