### PR TITLE
Make `<RegistrySearch>` work in the repair mode

### DIFF
--- a/src/win32/installer/installer_64bit.wxs
+++ b/src/win32/installer/installer_64bit.wxs
@@ -90,8 +90,11 @@
        Windows 11 22H2      22621
        Windows 11 23H2      22631
        Windows 11 24H2      26100
+
+       Note that this needs to be a secure property. Otherwise, it becomes an unexpected value in
+       the repair/uninstall mode. See https://github.com/google/mozc/issues/1410
     -->
-    <Property Id="OS_BUILD_NUMBER">
+    <Property Id="OS_BUILD_NUMBER" Secure="yes">
       <RegistrySearch Id="CurrentBuildNumberValue" Type="raw" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber" />
     </Property>
     <Launch Condition="(OS_BUILD_NUMBER AND (OS_BUILD_NUMBER &gt;= 10240)) OR (REMOVE=&quot;ALL&quot;)" Message="Google 日本語入力をインストールするには Windows 10 以降にアップグレードする必要があります。" />
@@ -101,7 +104,11 @@
     <Media Id="1" Cabinet="GoogleJapaneseInput.cab" EmbedCab="yes" CompressionLevel="high" />
 
     <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
-      <Property Id="PROCESSOR_ARCHITECTURE">
+      <!--
+        This needs to be a secure property. Otherwise, it becomes an unexpected value in the
+        repair/uninstall mode. See https://github.com/google/mozc/issues/1410
+      -->
+      <Property Id="PROCESSOR_ARCHITECTURE" Secure="yes">
         <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
       </Property>
       <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -91,8 +91,11 @@
        Windows 11 22H2      22621
        Windows 11 23H2      22631
        Windows 11 24H2      26100
+
+       Note that this needs to be a secure property. Otherwise, it becomes an unexpected value in
+       the repair/uninstall mode. See https://github.com/google/mozc/issues/1410
     -->
-    <Property Id="OS_BUILD_NUMBER">
+    <Property Id="OS_BUILD_NUMBER" Secure="yes">
       <RegistrySearch Id="CurrentBuildNumberValue" Type="raw" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentBuildNumber" />
     </Property>
     <Launch Condition="(OS_BUILD_NUMBER AND (OS_BUILD_NUMBER &gt;= 10240)) OR (REMOVE=&quot;ALL&quot;)" Message="Mozc をインストールするには Windows 10 以降にアップグレードする必要があります。" />
@@ -102,7 +105,11 @@
     <Media Id="1" Cabinet="Mozc.cab" EmbedCab="yes" CompressionLevel="high" />
 
     <?if $(var.MozcTIP64ArmPath) == "" and $(var.MozcTIP64XPath) == "" ?>
-      <Property Id="PROCESSOR_ARCHITECTURE">
+      <!--
+        This needs to be a secure property. Otherwise, it becomes an unexpected value in the
+        repair/uninstall mode. See https://github.com/google/mozc/issues/1410
+      -->
+      <Property Id="PROCESSOR_ARCHITECTURE" Secure="yes">
         <RegistrySearch Id="ProcessorArchitectureValue" Type="raw" Root="HKLM" Key="System\CurrentControlSet\Control\Session Manager\Environment" Name="PROCESSOR_ARCHITECTURE" />
       </Property>
       <Launch Condition="(NOT (PROCESSOR_ARCHITECTURE=&quot;ARM64&quot;)) OR UPGRADING OR (REMOVE=&quot;ALL&quot;)" Message="ARM64 環境へのインストールは未対応です" />


### PR DESCRIPTION
## Description
It turns out that `<Property>` with `<RegistrySearch>` does not work in the repair/uninstall mode unless the property is marked as Secure. As a result, if the user tries to install the same version of Mozc again, then they would see a misleading error messages.

Affected conditions are:
 * ARM64 check (7cf33366c344bc351a573c700b201fe82718139a)
 * Windows build number check (f649e70886f896bfc4d3a1f71ca202603b225d70)

This commit marks the relevant properties as Secure to fix the issue.

Closes #1410.

## Issue IDs

 * https://github.com/google/mozc/issues/1410

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Build Mozc with either GYP or Bazel
   2. Click the Mozc installer.
   3. Confirm the installation finishes successfully.
   4. Click the Mozc installer again.
   5. Confirm the installation still finishes successfully.

