### PR TITLE
Also update `last_down_key` in `KeyEventHandler::ImeToAsciiEx`

### DIFF
--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -428,17 +428,19 @@ HRESULT OnKey(TipTextService *text_service, ITfContext *context,
     Context mozc_context;
     FillMozcContextForOnKey(text_service, context, &mozc_context);
 
-    InputState unused_next_state;
+    InputState next_state;
     const KeyEventHandlerResult result = KeyEventHandler::ImeToAsciiEx(
         vk, key_info.GetScanCode(), is_key_down, keyboard_status, behavior,
         ime_state, mozc_context, private_context->GetClient(), keyboard.get(),
-        &unused_next_state, &temporal_output);
+        &next_state, &temporal_output);
 
     if (!result.succeeded) {
       // no message generated.
       *eaten = FALSE;
       return S_OK;
     }
+
+    *private_context->mutable_last_down_key() = next_state.last_down_key;
 
     const TipInputModeManager::Action action =
         text_service->GetThreadContext()->GetInputModeManager()->OnKey(


### PR DESCRIPTION
## Description

As explained in #1415 and code comment copied in this commit, Mozc clients are expected to send isolated modifier key press events to `mozc_server`. This has actually been working fine in IMM32 version of Mozc client, but it turns out that the TSF version of Mozc client may not work as expected. To understand the root cause of the problem, we need to look into how key events are processed in IMM32 and TSF.

  |     IMM32     |    Text Services Framework (TSF)    |
  |---------------|-------------------------------------|
  | `ImeProcessKey` | `ITfKeyEventSink::OnTestKey{Down,Up}` |
  | `ImeToAsciiEx`  | `ITfKeyEventSink::OnKey{Down,Up}`     |

Mozc's `KeyEventHandler` still uses the legacy IMM32 naming as it had been shared between IMM32 and TSF clients until we dropped support for IMM32 client.

The problem is that our `KeyEventHandler::ImeProcessKey` is written with an assumption that it is guaranteed to be called before `KeyEventHandler::ImeToAsciiEx`, but in TSF, this assumption is no longer valid. In TSF, there are three possible scenarios for a key down event:

 * A. `ITfKeyEventSink::OnTestKeyDown` gets called but not consumed by TIP. In this case, `ITfKeyEventSink::OnKeyDown` will not be called thus `OnTestKeyDown` is the last chance to memorize the key down event.
 * B. `ITfKeyEventSink::OnTestKeyDown` gets called and consumed by TIP. In this case, `ITfKeyEventSink::OnKeyDown` will be called for the same key event.
 * C. `ITfKeyEventSink::OnTestKeyDown` is skipped. In this case, `ITfKeyEventSink::OnKeyDown` will be the only chance to memorize the key down event.

We need to handle all the three scenarios correctly to ensure that isolated modifier key press events are sent to `mozc_server` as expected.

In order to minimize the risk of regression, this commit updates `last_down_key` in both `KeyEventHandler::ImeProcessKey` and `KeyEventHandler::ImeToAsciiEx`.

Maybe it will be possible to make `KeyEventHandler::ImeProcessKey` no-op and always return "consumed" for simplicity in the future.

Closes #1415.

## Issue IDs
 * https://github.com/google/mozc/issues/1415

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Install Mozc
   2. Open Notepad
   3. Enable Mozc
   4. Down <kbd>SHIFT</kbd> -> Down <kbd>M</kbd> -> Up <kbd>M</kbd> -> <kbd>SHIFT</kbd>
   5. Down <kbd>O</kbd> -> Up <kbd>O</kbd>
   6. Down <kbd>Z</kbd> -> Up <kbd>Z</kbd>
   7. Down <kbd>C</kbd> -> Up <kbd>C</kbd>
   8. Down <kbd>SHIFT</kbd> -> Up <kbd>SHIFT</kbd>
   9. Confirm the mode indicator is Hiragana mode.
