### PR TITLE
Simplify `RendererClient`

### DIFF
--- a/src/gui/tool/prelauncher_libmain.cc
+++ b/src/gui/tool/prelauncher_libmain.cc
@@ -61,7 +61,7 @@ int RunPrelaunchProcesses(int argc, char *argv[]) {
 
   {
     std::unique_ptr<mozc::renderer::RendererClient> renderer_client =
-        std::make_unique<mozc::renderer::RendererClient>();
+        mozc::renderer::RendererClient::Create();
     renderer_client->set_suppress_error_dialog(true);
     renderer_client->Activate();
   }

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -222,7 +222,7 @@ bool CanSurroundingText(absl::string_view bundle_id) {
   mode_ = mozc::commands::DIRECT;
   suppressSuggestion_ = false;
   yenSignCharacter_ = mozc::config::Config::YEN_SIGN;
-  mozcRenderer_ = std::make_unique<mozc::renderer::RendererClient>();
+  mozcRenderer_ = mozc::renderer::RendererClient::Create();
   mozcClient_ = mozc::client::ClientFactory::NewClient();
   lastKeyDownTime_ = 0;
   lastKeyCode_ = 0;

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -69,7 +69,9 @@ mozc_cc_library(
         "//ipc:named_event",
         "//protocol:renderer_cc_proto",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/time",
     ] + mozc_select(

--- a/src/renderer/renderer_server_test.cc
+++ b/src/renderer/renderer_server_test.cc
@@ -129,25 +129,25 @@ TEST_F(RendererServerTest, IPCTest) {
   absl::SleepFor(absl::Seconds(1));
 
   DummyRendererLauncher launcher;
-  RendererClient client;
-  client.SetIPCClientFactory(&on_memory_client_factory);
-  client.DisableRendererServerCheck();
-  client.SetRendererLauncherInterface(&launcher);
+  std::unique_ptr<RendererClient> client = RendererClient::CreateForTesting(
+      &on_memory_client_factory, &launcher,
+      RendererClient::RendererPathCheckMode::DISABLED);
+
   commands::RendererCommand command;
   command.set_type(commands::RendererCommand::NOOP);
 
   // renderer is called via IPC
-  client.ExecCommand(command);
+  client->ExecCommand(command);
   EXPECT_EQ(renderer.counter(), 1);
 
-  client.ExecCommand(command);
-  client.ExecCommand(command);
-  client.ExecCommand(command);
+  client->ExecCommand(command);
+  client->ExecCommand(command);
+  client->ExecCommand(command);
   EXPECT_EQ(renderer.counter(), 4);
 
   // Gracefully shutdown the server.
   renderer.Shutdown();
-  client.ExecCommand(command);
+  client->ExecCommand(command);
   server->Wait();
 }
 

--- a/src/renderer/win32/win32_renderer_client.cc
+++ b/src/renderer/win32/win32_renderer_client.cc
@@ -104,7 +104,8 @@ class SenderThread {
       return;
     }
 
-    RendererClient renderer_client;
+    std::unique_ptr<mozc::renderer::RendererClient> renderer_client =
+        mozc::renderer::RendererClient::Create();
     while (true) {
       const HANDLE handles[] = {quit_event_.get(), command_event_.get()};
       const DWORD wait_result = ::WaitForMultipleObjects(
@@ -130,7 +131,7 @@ class SenderThread {
         command.Swap(&renderer_command_);
         command_event_.ResetEvent();
       }
-      if (!renderer_client.ExecCommand(command)) {
+      if (!renderer_client->ExecCommand(command)) {
         DLOG(ERROR) << "RendererClient::ExecCommand failed.";
       }
     }

--- a/src/unix/ibus/mozc_engine.cc
+++ b/src/unix/ibus/mozc_engine.cc
@@ -236,8 +236,7 @@ MozcEngine::MozcEngine()
       client_(CreateAndConfigureClient()),
       preedit_handler_(std::make_unique<PreeditHandler>()),
       use_mozc_candidate_window_(false),
-      mozc_candidate_window_handler_(
-          std::make_unique<renderer::RendererClient>()),
+      mozc_candidate_window_handler_(renderer::RendererClient::Create()),
       preedit_method_(config::Config::ROMAN) {
   ibus_config_.Initialize();
   use_mozc_candidate_window_ = UseMozcCandidateWindow(ibus_config_);

--- a/src/win32/broker/prelauncher.cc
+++ b/src/win32/broker/prelauncher.cc
@@ -63,8 +63,8 @@ int RunPrelaunchProcesses(int argc, char *argv[]) {
   }
 
   {
-    std::unique_ptr<renderer::RendererClient> renderer_client(
-        new mozc::renderer::RendererClient);
+    std::unique_ptr<renderer::RendererClient> renderer_client =
+        renderer::RendererClient::Create();
     renderer_client->set_suppress_error_dialog(true);
     renderer_client->Activate();
   }

--- a/src/win32/custom_action/custom_action.cc
+++ b/src/win32/custom_action/custom_action.cc
@@ -251,8 +251,9 @@ UINT __stdcall ShutdownServer(MSIHANDLE msi_handle) {
       LOG_ERROR_FOR_OMAHA();
     }
   }
-  mozc::renderer::RendererClient renderer_client;
-  if (!renderer_client.Shutdown(true)) {
+  std::unique_ptr<mozc::renderer::RendererClient> renderer_client =
+      mozc::renderer::RendererClient::Create();
+  if (!renderer_client->Shutdown(true)) {
     // This is not fatal as Windows Installer can replace executables even when
     // they are still running. Just log error then go ahead.
     LOG_ERROR_FOR_OMAHA();


### PR DESCRIPTION
## Description
As a preparation before fixing #1421, this commit aims to simplify `RendererClient` without changing its behavior.

Major updates are:

 * Optional member fields to override default behaviors for testing purposes now have suffix "_for_testing" and are explicitly injected via `CreateForTesting()` factory method.
 * Removed unnecessary nullptr checks.
 * Removed unused `SetSendCommandInterface()`.

Main motivation is to make it possible to inject a custom service name for testing purpose in the next change for #1421, as the current design uses hard-coded service name even in the test code.

Other than above, there should be no functional changes in the production code.

## Issue IDs

 * https://github.com/google/mozc/issues/1421

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
