### PR TITLE
Re-introduce `TsfRegistrar::RegisterCOMServer`

### DIFF
--- a/src/win32/base/tsf_registrar.h
+++ b/src/win32/base/tsf_registrar.h
@@ -44,6 +44,12 @@ class TsfRegistrar {
   TsfRegistrar(const TsfRegistrar &) = delete;
   TsfRegistrar &operator=(const TsfRegistrar &) = delete;
 
+  // Registers the DLL specified with |path| as a COM server.
+  static HRESULT RegisterCOMServer(const wchar_t *path, DWORD length);
+
+  // Unregisters the DLL from registry.
+  static void UnregisterCOMServer();
+
   // Registers this COM server to the profile store for input processors.
   // The caller is responsible for initializing COM before call this function.
   static HRESULT RegisterProfiles(std::wstring_view resource_dll_path);


### PR DESCRIPTION
## Description
To support both x64 and ARM64 machines with the same MSI file (#1430), x64 TIP DLL needs to be registered only when being installed on x64 machine, and ARM64X TIP DLL needs to be registered when being installed on ARM64 environment. The challenge is that Windows Installer does not seem to natively support conditional COM server registration based on the target CPU architecture.

As a preparation for that, this commit re-introduces `TsfRegistrar::RegisterCOMServer` function by partially reverting the previous commit e4679076baef1babf8b945ae5ab6212a1be6011d.

Note that `TsfRegistrar::{Register,Unregister}COMServer` are not used yet. They will be used in a subsequent commit.

## Issue IDs

 * https://github.com/google/mozc/issues/1430

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm all the GitHub Actions pass
