### PR TITLE
Use unique service names in `renderer_server_test`

### DIFF
--- a/src/ipc/ipc.h
+++ b/src/ipc/ipc.h
@@ -261,7 +261,10 @@ class IPCServer {
   }
 #endif  // __APPLE__
 
+  const std::string& GetServiceName() const { return name_; }
+
  private:
+  std::string name_;
   bool connected_;
 #ifdef _WIN32
   wil::unique_event_nothrow quit_event_;
@@ -274,7 +277,6 @@ class IPCServer {
   wil::unique_hfile pipe_handle_;
   wil::unique_event_nothrow pipe_event_;
 #elif defined(__APPLE__)
-  std::string name_;
   MachPortManagerInterface *mach_port_manager_;
 #else   // _WIN32
   int socket_;

--- a/src/ipc/unix_ipc.cc
+++ b/src/ipc/unix_ipc.cc
@@ -338,7 +338,10 @@ bool IPCClient::Connected() const { return connected_; }
 // Server
 IPCServer::IPCServer(const std::string &name, int32_t num_connections,
                      absl::Duration timeout)
-    : connected_(false), socket_(kInvalidSocket), timeout_(timeout) {
+    : name_(name),
+      connected_(false),
+      socket_(kInvalidSocket),
+      timeout_(timeout) {
   IPCPathManager *manager = IPCPathManager::GetIPCPathManager(name);
   if (!manager->CreateNewPathName() && !manager->LoadPathName()) {
     LOG(ERROR) << "Cannot prepare IPC path name";

--- a/src/ipc/win32_ipc.cc
+++ b/src/ipc/win32_ipc.cc
@@ -445,7 +445,8 @@ void MaybeDisableFileCompletionNotification(HANDLE device_handle) {
 
 IPCServer::IPCServer(const std::string &name, int32_t num_connections,
                      absl::Duration timeout)
-    : connected_(false),
+    : name_(name),
+      connected_(false),
       quit_event_(CreateManualResetEvent()),
       pipe_event_(CreateManualResetEvent()),
       timeout_(timeout) {

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -113,6 +113,7 @@ mozc_cc_library(
     deps = [
         ":renderer_interface",
         "//base:const",
+        "//base:random",
         "//base:system_util",
         "//base:vlog",
         "//client:client_interface",

--- a/src/renderer/renderer_client.cc
+++ b/src/renderer/renderer_client.cc
@@ -512,19 +512,20 @@ std::unique_ptr<IPCClientInterface> RendererClient::CreateIPCClient() const {
 }
 
 std::unique_ptr<RendererClient> RendererClient::Create() {
-  return RendererClient::CreateForTesting(nullptr, nullptr,
-                                          RendererPathCheckMode::ENABLED);
-}
-
-std::unique_ptr<RendererClient> RendererClient::CreateForTesting(
-    IPCClientFactoryInterface* absl_nullable ipc_client_factory_for_testing,
-    RendererLauncherInterface* absl_nullable renderer_launcher_for_testing,
-    RendererPathCheckMode renderer_path_check_mode) {
   std::string name = kServiceName;
   const std::string desktop_name = SystemUtil::GetDesktopNameAsString();
   if (!desktop_name.empty()) {
     absl::StrAppend(&name, ".", desktop_name);
   }
+  return std::unique_ptr<RendererClient>(new RendererClient(
+      name, nullptr, nullptr, false));
+}
+
+std::unique_ptr<RendererClient> RendererClient::CreateForTesting(
+    const std::string& name,
+    IPCClientFactoryInterface* absl_nullable ipc_client_factory_for_testing,
+    RendererLauncherInterface* absl_nullable renderer_launcher_for_testing,
+    RendererPathCheckMode renderer_path_check_mode) {
   const bool disable_renderer_path_check_for_testing =
       (renderer_path_check_mode == RendererPathCheckMode::DISABLED);
   return std::unique_ptr<RendererClient>(new RendererClient(

--- a/src/renderer/renderer_client.h
+++ b/src/renderer/renderer_client.h
@@ -87,6 +87,7 @@ class RendererClient final : public RendererInterface {
   static std::unique_ptr<RendererClient> Create();
 
   static std::unique_ptr<RendererClient> CreateForTesting(
+      const std::string& name,
       IPCClientFactoryInterface* absl_nullable ipc_client_factory_for_testing,
       RendererLauncherInterface* absl_nullable renderer_launcher_for_testing,
       RendererPathCheckMode renderer_path_check_mode);

--- a/src/renderer/renderer_client_test.cc
+++ b/src/renderer/renderer_client_test.cc
@@ -51,6 +51,8 @@ namespace mozc {
 namespace renderer {
 namespace {
 
+constexpr char kTestServiceName[] = "renderer_test";
+
 std::string UpdateVersion(int diff) {
   std::vector<std::string> tokens =
       absl::StrSplit(Version::GetMozcVersion(), '.', absl::SkipEmpty());
@@ -188,7 +190,8 @@ class RendererClientTest : public ::testing::Test {
 
   std::unique_ptr<RendererClient> NewClient() {
     return RendererClient::CreateForTesting(
-        &factory_, &launcher_, RendererClient::RendererPathCheckMode::ENABLED);
+        kTestServiceName, &factory_, &launcher_,
+        RendererClient::RendererPathCheckMode::ENABLED);
   }
 
   void Reset() { client_params_.counter = 0; }

--- a/src/renderer/renderer_server.h
+++ b/src/renderer/renderer_server.h
@@ -76,6 +76,9 @@ class RendererServer : public IPCServer {
   virtual bool AsyncExecCommand(absl::string_view proto_message) = 0;
 
  protected:
+  // For testing purposes where a custom service name needs to be specified.
+  explicit RendererServer(bool for_testing);
+
   // implement Message Loop function.
   // This function should be blocking.
   // The return value is supposed to be used for the arg of exit().

--- a/src/renderer/renderer_server_test.cc
+++ b/src/renderer/renderer_server_test.cc
@@ -76,6 +76,8 @@ class TestRenderer : public RendererInterface {
 
 class TestRendererServer : public RendererServer {
  public:
+  TestRendererServer() : RendererServer(true /* for_testing */) {}
+
   int StartMessageLoop() override { return 0; }
 
   // Not async for testing
@@ -130,7 +132,7 @@ TEST_F(RendererServerTest, IPCTest) {
 
   DummyRendererLauncher launcher;
   std::unique_ptr<RendererClient> client = RendererClient::CreateForTesting(
-      &on_memory_client_factory, &launcher,
+      server->GetServiceName(), &on_memory_client_factory, &launcher,
       RendererClient::RendererPathCheckMode::DISABLED);
 
   commands::RendererCommand command;


### PR DESCRIPTION
## Description
Previously, `RendererServer`/`RendererClient` used within `renderer_server_test` were relying on the production service name, which could lead to test failures if a real `mozc_renderer` process was running.

In order to avoid such conflicts, this commit modifies the test to use a unique service name for testing as follows:

  - `RendererServer` is now responsible for generating a random service name when instantiated via `RendererServer::CreateForTesting()`.

  - `RendererServer` now exposes its service name via `GetServiceName()` method.

  - `RendererClient::CreateForTesting()` now takes a service name as an argument, which closes the loop for using the same unique service name in tests.

This is anyway only for fixing a test. There must be no observable change in production code.

Closes #1421.

## Issue IDs

 * https://github.com/google/mozc/issues/1421

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
  1. Build `Mozc64.msi` and install it.
  2. Enable Mozc in some applications and make sure that Mozc's candidate window is shown.
  3. `bazelisk test --config oss_windows -c dbg //renderer:renderer_server_test --nocache_test_results --test_output=streamed`
