### PR TITLE
bzlmod: Update `rules_cc` to 0.2.17

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -34,7 +34,7 @@ build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windo
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
 build:windows_env --host_platform=//:host-windows-clang-cl
-build:windows_env --copt "/D_WIN32_WINNT=0x0A00" --host_copt "/D_WIN32_WINNT=0x0A00"
+build:windows_env --repo_env=BAZEL_WIN32_WINNT=/D_WIN32_WINNT=0x0A00
 
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -119,11 +119,11 @@ bazel_dep(
     repo_name = "build_bazel_rules_swift",
 )
 
-# rules_cc: 0.2.2 2025-08-28
+# rules_cc: 0.2.17 2026-02-18
 # https://github.com/bazelbuild/rules_cc/
 bazel_dep(
     name = "rules_cc",
-    version = "0.2.2",
+    version = "0.2.17",
 )
 single_version_override(
     module_name = "rules_cc",
@@ -134,7 +134,7 @@ single_version_override(
         "bazel/rules_cc_windows_cc_configure.bzl.patch",
         "bazel/rules_cc_windows_cc_toolchain_config.bzl.patch",
     ],
-    version = "0.2.2",
+    version = "0.2.17",
 )
 
 cc_configure = use_extension(

--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -8,7 +8,7 @@
          "x64_windows_msys": ":cc-compiler-x64_windows_msys",
          "x64_windows": ":cc-compiler-x64_windows",
          "x64_x86_windows": ":cc-compiler-x64_x86_windows",
-@@ -621,6 +622,75 @@ toolchain(
+@@ -670,6 +671,75 @@ toolchain(
      toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
  )
  
@@ -84,7 +84,7 @@
  cc_toolchain(
      name = "cc-compiler-arm64_windows-clang-cl",
      toolchain_identifier = "clang_cl_arm64",
-@@ -668,6 +738,7 @@
+@@ -719,6 +789,7 @@
          "strip": "wrapper/bin/msvc_nop.bat",
      },
      archiver_flags = ["/MACHINE:ARM64"],

--- a/src/bazel/rules_cc_windows_cc_configure.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_configure.bzl.patch
@@ -1,7 +1,7 @@
 --- cc/private/toolchain/windows_cc_configure.bzl
 +++ cc/private/toolchain/windows_cc_configure.bzl
-@@ -879,10 +879,12 @@ def configure_windows_toolchain(repository_ctx):
- 
+@@ -920,11 +920,13 @@ def configure_windows_toolchain(repository_ctx):
+
      template_vars = dict()
      msvc_vars_x64 = _get_msvc_vars(repository_ctx, paths, "x64")
 +    msvc_vars_x86 = _get_msvc_vars(repository_ctx, paths, "x86", msvc_vars_x64)
@@ -10,6 +10,7 @@
      template_vars.update(_get_clang_cl_vars(repository_ctx, paths, msvc_vars_x64, "x64"))
 +    template_vars.update(_get_clang_cl_vars(repository_ctx, paths, msvc_vars_x86, "x86"))
      template_vars.update(_get_msys_mingw_vars(repository_ctx))
+     template_vars.update(_get_copts(repository_ctx))
 -    template_vars.update(_get_msvc_vars(repository_ctx, paths, "x86", msvc_vars_x64))
      template_vars.update(_get_msvc_vars(repository_ctx, paths, "arm", msvc_vars_x64))
      msvc_vars_arm64 = _get_msvc_vars(repository_ctx, paths, "arm64", msvc_vars_x64)

--- a/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
@@ -1,28 +1,11 @@
 --- cc/private/toolchain/windows_cc_toolchain_config.bzl
 +++ cc/private/toolchain/windows_cc_toolchain_config.bzl
-@@ -89,7 +89,7 @@ all_link_actions = [
+@@ -100,7 +100,7 @@ all_link_actions = [
  ]
- 
+
  def _use_msvc_toolchain(ctx):
 -    return ctx.attr.cpu in ["x64_windows", "arm64_windows"] and (ctx.attr.compiler == "msvc-cl" or ctx.attr.compiler == "clang-cl")
 +    return ctx.attr.cpu in ["x64_windows", "x64_x86_windows", "arm64_windows"] and (ctx.attr.compiler == "msvc-cl" or ctx.attr.compiler == "clang-cl")
- 
+
  def _impl(ctx):
-     if _use_msvc_toolchain(ctx):
-@@ -752,7 +752,6 @@
-                         flag_group(
-                             flags = [
-                                 "/DNOMINMAX",
--                                "/D_WIN32_WINNT=0x0601",
-                                 "/D_CRT_SECURE_NO_DEPRECATE",
-                                 "/D_CRT_SECURE_NO_WARNINGS",
-                                 "/bigobj",
-@@ -762,7 +761,7 @@
-                                 "/wd4291",
-                                 "/wd4250",
-                                 "/wd4996",
--                            ],
-+                            ] + ctx.attr.default_compile_flags,
-                         ),
-                     ],
-                 ),
+     profile_correction_flags = get_profile_correction_flags(ctx)


### PR DESCRIPTION
## Description
As a preparation for upgrading to Bazel 9 (#1437,) this commit updates `rules_cc` to 0.2.17 with adjusting the patches to be compatible with the new version.

Starting from `rules_cc` 0.2.15, we can rely on `BAZEL_WIN32_WINNT` so that we can specify compiler flags only for Windows build targets (https://github.com/bazelbuild/rules_cc/commit/be107bfeafc5f5ccb35aae9c709625e026f4c965).

## Issue IDs
 * https://github.com/google/mozc/issues/1437

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm `bazelisk build --config oss_windows --config release_build package` succeeds


