### PR TITLE
Make build rules compatible with Bazel 8.6 and 9.0

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -137,7 +137,7 @@ platform(
         "@platforms//os:windows",
         "@bazel_tools//tools/cpp:clang-cl",
     ],
-    parents = ["@local_config_platform//:host"],
+    parents = ["@platforms//host"],
 )
 
 platform(

--- a/src/bazel/BUILD.google_toolbox_for_mac.bazel
+++ b/src/bazel/BUILD.google_toolbox_for_mac.bazel
@@ -30,6 +30,8 @@
 # Test runner for MacOS.
 # https://github.com/google/google-toolbox-for-mac
 
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 objc_library(

--- a/src/bazel/BUILD.qt.bazel
+++ b/src/bazel/BUILD.qt.bazel
@@ -31,6 +31,7 @@ load(
     "@build_bazel_rules_apple//apple:apple.bzl",
     "apple_dynamic_framework_import",
 )
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/src/bazel/BUILD.qt_win.bazel
+++ b/src/bazel/BUILD.qt_win.bazel
@@ -27,6 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/src/bazel/BUILD.wil.bazel
+++ b/src/bazel/BUILD.wil.bazel
@@ -29,6 +29,8 @@
 
 # Windows Implementation Library (WIL)
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/bazel/pkg_config_repository.bzl
+++ b/src/bazel/pkg_config_repository.bzl
@@ -53,6 +53,8 @@ cc_library(
 """
 
 BUILD_TEMPLATE = """
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Description
As a preparation to Bazel 9 migration, this commit makes the build rules compatible with both Bazel 8.6 and 9.0.

 * Added missing includes for `cc_library` and `objc_library`
 * Removed the dependency on deprecated `local_config_platform`

There must be no change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1437

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
