### PR TITLE
bzlmod: Update `googletest` and `rules_android_ndk`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -47,9 +47,11 @@ bazel_dep(
 
 # googletest: 1.17.0 2025-05-01
 # https://github.com/google/googletest
+# We need to use 1.17.0.bcr.2 for Bazel 9 compatibility.
+# https://github.com/bazelbuild/bazel-central-registry/pull/6395
 bazel_dep(
     name = "googletest",
-    version = "1.17.0",
+    version = "1.17.0.bcr.2",
     repo_name = "com_google_googletest",
 )
 
@@ -125,24 +127,51 @@ use_repo(cc_configure, "local_config_cc")
 
 register_toolchains("@local_config_cc//:all")
 
-# rules_android_ndk: 0.1.3 2025-01-31
+# rules_go: 0.60.0 2026-02-09
+# https://github.com/bazel-contrib/rules_go
+# This is not a direct dependency of mozc, but is added to override the
+# transitive dependency (protobuf -> rules_jvm_external -> rules_android ->
+# rules_go) to a version that supports Bazel 9.
+bazel_dep(
+    name = "rules_go",
+    version = "0.60.0",
+    repo_name = "io_bazel_rules_go",
+)
+
+# gazelle: 0.48.0 2026-03-26
+# https://github.com/bazel-contrib/bazel-gazelle
+# This is not a direct dependency of mozc, but is added to override the
+# transitive dependency to a version that supports Bazel 9.
+bazel_dep(
+    name = "gazelle",
+    version = "0.48.0",
+    repo_name = "bazel_gazelle",
+)
+
+# rules_android: 0.7.1 2026-01-27
+# https://github.com/bazelbuild/rules_android
+# This is not a direct dependency of mozc, but is added to override the
+# transitive dependency (protobuf -> rules_jvm_external -> rules_android)
+# to a version that supports Bazel 9.
+bazel_dep(
+    name = "rules_android",
+    version = "0.7.1",
+)
+
+# rules_android_ndk: 0.1.5 2026-03-27
 # https://github.com/bazelbuild/rules_android_ndk
-#
-# Note, 0.1.5 has been already released, but it's not available at Bazel-central-registry yet.
-# https://github.com/bazelbuild/rules_android_ndk/tags
-# https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/rules_android_ndk
 bazel_dep(
     name = "rules_android_ndk",
-    version = "0.1.3",
+    version = "0.1.5",
 )
 single_version_override(
     module_name = "rules_android_ndk",
     patches = [
-        # Might be removed after the folloing PR.
+        # Might be removed after the following PR.
         # https://github.com/bazelbuild/rules_android_ndk/pull/63
         "bazel/rules_android_ndk.patch",
     ],
-    version = "0.1.3",
+    version = "0.1.5",
 )
 
 android_ndk_repository_extension = use_extension(

--- a/src/bazel/rules_android_ndk.patch
+++ b/src/bazel/rules_android_ndk.patch
@@ -4,11 +4,11 @@
      Returns:
          A final dict of configuration attributes and values.
      """
--    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", None)
+-    ndk_path = ctx.attr.path or ctx.getenv("ANDROID_NDK_HOME", None)
 -    if not ndk_path:
 -        fail("Either the ANDROID_NDK_HOME environment variable or the " +
 -             "path attribute of android_ndk_repository must be set.")
-+    ndk_path = ctx.attr.path or ctx.os.environ.get("ANDROID_NDK_HOME", "")
++    ndk_path = ctx.attr.path or ctx.getenv("ANDROID_NDK_HOME", "")
      if ndk_path.startswith("$WORKSPACE_ROOT"):
          ndk_path = str(ctx.workspace_root) + ndk_path.removeprefix("$WORKSPACE_ROOT")
 


### PR DESCRIPTION
## Description
As a preparation to Bazel 9 migration, this commit makes `MODULE.bazel` compatible with both Bazel 8.6 and 9.0 by updating dependencies as follows:

 * `googletest`: 1.17.0 -> 1.17.0.bcr.2
 * `rules_android_ndk`: 0.1.3 -> 0.1.5

Also, to take care of transitive dependencies, the following dependencies are updated as well:

 * `gazelle`: 0.40.0 -> 0.48.0
 * `rules_go`: 0.51.0-rc2 -> 0.60.0
 * `rules_android`: 0.6.4 -> 0.7.1

There must be no change in the final artifacts.

## Issue IDs

 * https://github.com/google/mozc/issues/1437

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
