### PR TITLE
Use ARM64-native Ninja binaries on Windows ARM64

### DIFF
--- a/src/build_tools/update_deps.py
+++ b/src/build_tools/update_deps.py
@@ -112,6 +112,12 @@ NINJA_WIN = ArchiveInfo(
     sha256='07fc8261b42b20e71d1720b39068c2e14ffcee6396b76fb7a795fb460b78dc65',
 )
 
+NINJA_WIN_ARM64 = ArchiveInfo(
+    url='https://github.com/ninja-build/ninja/releases/download/v1.13.2/ninja-winarm64.zip',
+    size=270354,
+    sha256='e52f0bdef9dfb1003229dbd6508a508c4073fd017247002adc66e5e806cb0391',
+)
+
 LLVM_WIN = ArchiveInfo(
     url='https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.1/clang+llvm-20.1.1-x86_64-pc-windows-msvc.tar.xz',
     size=939286624,
@@ -447,18 +453,17 @@ def extract_msys2(archive: ArchiveInfo, dryrun: bool = False) -> None:
         f.extractall(path=dest, members=msys2_extract_filter(f))
 
 
-def extract_ninja(dryrun: bool = False) -> None:
+def extract_ninja(archive: ArchiveInfo, dryrun: bool = False) -> None:
   """Extract ninja-win archive.
 
   Args:
+    archive: Ninja archive
     dryrun: True if this is a dry-run.
   """
   dest = ABS_THIRD_PARTY_DIR.joinpath('ninja').absolute()
   if is_mac():
-    archive = NINJA_MAC
     exe = 'ninja'
   elif is_windows():
-    archive = NINJA_WIN
     exe = 'ninja.exe'
   else:
     return
@@ -597,7 +602,10 @@ def main():
     if is_mac():
       archives.append(NINJA_MAC)
     elif is_windows():
-      archives.append(NINJA_WIN)
+      if platform.machine().lower() == 'arm64':
+        archives.append(NINJA_WIN_ARM64)
+      else:
+        archives.append(NINJA_WIN)
   if not args.nondk:
     if is_linux():
       archives.append(NDK_LINUX)
@@ -629,8 +637,10 @@ def main():
   if (not args.nowix) and is_windows():
     restore_dotnet_tools(args.dryrun)
 
-  if (NINJA_WIN in archives) or (NINJA_MAC in archives):
-    extract_ninja(args.dryrun)
+  for ninja in [NINJA_MAC, NINJA_WIN, NINJA_WIN_ARM64]:
+    if ninja in archives:
+      extract_ninja(ninja, args.dryrun)
+      break
 
   for ndk in [NDK_LINUX, NDK_MAC]:
     if ndk in archives:


### PR DESCRIPTION
## Description
Previously, `update_deps.py` always downloaded x86_64 Ninja executable for Windows, even on ARM64 machines. While these binaries can still run under WoA emulation, it is preferable to use ARM64-native binaries when possible for better performance. Let's do so as part of the ongoing efforts to support ARM64 Windows machines.

With this commit, `update_deps.py` starts downloading platform-native Ninja executable rather than always downloading x86_64 one.

Note that Ninja version remains unchanged to be 1.13.2. Thus there should be no bit-level differences for the generated binaries.

## Issue IDs

 * https://github.com/google/mozc/issues/1296

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2 ARM64
 - Steps:
   1. `python build_tools/update_deps.py`
   2. `python build_tools/build_qt.py --release --confirm_license`
   3. Confirm `ninja.exe` is running as an ARM64 process.