### PR TITLE
Remove singleton dependency from environ

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -413,7 +413,6 @@ mozc_cc_library(
     hdrs = ["environ.h"],
     visibility = ["//:__subpackages__"],
     deps = [
-        ":singleton",
         "//base/strings:zstring_view",
     ],
 )

--- a/src/base/environ.cc
+++ b/src/base/environ.cc
@@ -29,35 +29,31 @@
 
 #include "base/environ.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <string>
 
-#include "base/singleton.h"
 #include "base/strings/zstring_view.h"
 
 namespace mozc {
 
 namespace {
-class EnvironImpl : public EnvironInterface {
- public:
-  EnvironImpl() = default;
-  ~EnvironImpl() override = default;
 
-  std::string GetEnv(zstring_view env_var) override {
-    const char* value = std::getenv(env_var.data());
-    return value == nullptr ? "" : value;
-  }
-};
+constinit static std::atomic<EnvironInterface*> g_mock = nullptr;
 
-using EnvironSingleton = SingletonMockable<EnvironInterface, EnvironImpl>;
 }  // namespace
 
 std::string Environ::GetEnv(zstring_view env_var) {
-  return EnvironSingleton::Get()->GetEnv(env_var.data());
+  if (EnvironInterface* mock = g_mock.load(std::memory_order_acquire);
+      mock != nullptr) {
+    return mock->GetEnv(env_var);
+  }
+  const char* value = std::getenv(env_var.data());
+  return value == nullptr ? "" : value;
 }
 
 void Environ::SetMockForUnitTest(EnvironInterface* mock) {
-  EnvironSingleton::SetMock(mock);
+  g_mock.store(mock, std::memory_order_release);
 }
 
 }  // namespace mozc


### PR DESCRIPTION
## Description
As part of our on-going efforts to remove the dependency on `Singleton`, this commit rewrites `base::Environ` without the `Singleton` class dependency.

This is purely mechanical refactoring, and there must be no observable behavioral change in production.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
