### PR TITLE
Remove `singleton` dependency from `base::Clock`

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -208,7 +208,6 @@ mozc_cc_library(
     srcs = ["clock.cc"],
     hdrs = ["clock.h"],
     deps = [
-        ":singleton",
         "@com_google_absl//absl/time",
     ],
 )

--- a/src/base/clock.cc
+++ b/src/base/clock.cc
@@ -29,11 +29,11 @@
 
 #include "base/clock.h"
 
+#include <atomic>
 #include <ctime>
 
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "base/singleton.h"
 
 #if defined(OS_CHROMEOS) || defined(_WIN32)
 constexpr bool kUseAbslLocalTimeZone = false;
@@ -45,6 +45,8 @@ constexpr bool kUseAbslLocalTimeZone = true;
 
 namespace mozc {
 namespace {
+
+constinit static std::atomic<ClockInterface*> g_mock = nullptr;
 
 absl::TimeZone GetLocalTimeZone() {
   if constexpr (kUseAbslLocalTimeZone) {
@@ -65,27 +67,26 @@ absl::TimeZone GetLocalTimeZone() {
   }
 }
 
-class ClockImpl : public ClockInterface {
- public:
-  ClockImpl() = default;
-  ~ClockImpl() override = default;
-
-  absl::Time GetAbslTime() override { return absl::Now(); }
-
-  absl::TimeZone GetTimeZone() override { return GetLocalTimeZone(); }
-};
 }  // namespace
 
-using ClockSingleton = SingletonMockable<ClockInterface, ClockImpl>;
-
-absl::Time Clock::GetAbslTime() { return ClockSingleton::Get()->GetAbslTime(); }
+absl::Time Clock::GetAbslTime() {
+  if (ClockInterface* mock = g_mock.load(std::memory_order_acquire);
+      mock != nullptr) {
+    return mock->GetAbslTime();
+  }
+  return absl::Now();
+}
 
 absl::TimeZone Clock::GetTimeZone() {
-  return ClockSingleton::Get()->GetTimeZone();
+  if (ClockInterface* mock = g_mock.load(std::memory_order_acquire);
+      mock != nullptr) {
+    return mock->GetTimeZone();
+  }
+  return GetLocalTimeZone();
 }
 
 void Clock::SetClockForUnitTest(ClockInterface* clock) {
-  ClockSingleton::SetMock(clock);
+  g_mock.store(clock, std::memory_order_release);
 }
 
 }  // namespace mozc


### PR DESCRIPTION
## Description
As part of our on-going efforts to remove the dependency on `Singleton`, this commit rewrites `base::Clock` without the `Singleton` class dependency.

This is purely mechanical refactoring, and there must be no observable behavioral change in production.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
