### PR TITLE
Remove unused dependency on `singleton` from `mozcjni`

### DIFF
--- a/src/android/jni/BUILD.bazel
+++ b/src/android/jni/BUILD.bazel
@@ -51,7 +51,6 @@ mozc_cc_library(
     # Scheuklappen: keep
     visibility = ["//visibility:private"],
     deps = [
-        "//base:singleton",
         "//base:system_util",
         "//base:util",
         "//data_manager",

--- a/src/android/jni/mozcjni.cc
+++ b/src/android/jni/mozcjni.cc
@@ -44,7 +44,6 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "base/singleton.h"
 #include "base/system_util.h"
 #include "base/util.h"
 #include "data_manager/data_manager.h"


### PR DESCRIPTION
## Description
`mozcjni.cc` no longer uses `singleton`. Let's remove the unnecessary include and the dependency from `BUILD.bazel`.

## Issue IDs

N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm all the GitHub Actions still pass
