### PR TITLE
Remove unused `ServerLauncher::set_server_program`

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -432,10 +432,6 @@ void Client::EnableCascadingWindow(const bool enable) {
 
 void Client::set_timeout(absl::Duration timeout) { timeout_ = timeout; }
 
-void Client::set_server_program(const absl::string_view program_path) {
-  server_launcher_->set_server_program(program_path);
-}
-
 void Client::set_suppress_error_dialog(bool suppress) {
   server_launcher_->set_suppress_error_dialog(suppress);
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -74,12 +74,6 @@ class ServerLauncher : public ServerLauncherInterface {
 
   void OnFatal(ServerLauncherInterface::ServerErrorType type) override;
 
-  // specify server program. On Mac, we need to specify the server path
-  // using this method.
-  void set_server_program(const absl::string_view server_program) override {
-    strings::Assign(server_program_, server_program);
-  }
-
   // return server program
   zstring_view server_program() const override { return server_program_; }
 
@@ -155,7 +149,6 @@ class Client : public ClientInterface {
   void EnableCascadingWindow(bool enable) override;
 
   void set_timeout(absl::Duration timeout) override;
-  void set_server_program(absl::string_view program_path) override;
   void set_suppress_error_dialog(bool suppress) override;
   void set_client_capability(const commands::Capability &capability) override;
 

--- a/src/client/client_interface.h
+++ b/src/client/client_interface.h
@@ -72,9 +72,6 @@ class ServerLauncherInterface {
   // called when fatal error occurred.
   virtual void OnFatal(ServerErrorType type) = 0;
 
-  // set the full path of server program.
-  virtual void set_server_program(absl::string_view server_program) = 0;
-
   // return the full path of server program
   // This is used for making IPC connection.
   virtual zstring_view server_program() const = 0;
@@ -192,10 +189,6 @@ class ClientInterface {
 
   // Sets the time out in milli second used for the IPC connection.
   virtual void set_timeout(absl::Duration timeout) = 0;
-
-  // Sets server program path.
-  // mainly for unittesting.
-  virtual void set_server_program(absl::string_view program_path) = 0;
 
   // Sets the flag of error dialog suppression.
   virtual void set_suppress_error_dialog(bool suppress) = 0;

--- a/src/client/client_mock.h
+++ b/src/client/client_mock.h
@@ -84,8 +84,6 @@ class ClientMock : public client::ClientInterface {
   MOCK_METHOD(bool, NoOperation, (), (override));
   MOCK_METHOD(void, EnableCascadingWindow, (bool enable), (override));
   MOCK_METHOD(void, set_timeout, (absl::Duration timeout), (override));
-  MOCK_METHOD(void, set_server_program, (absl::string_view program_path),
-              (override));
   MOCK_METHOD(void, set_suppress_error_dialog, (bool suppress), (override));
   MOCK_METHOD(void, set_client_capability,
               (const commands::Capability &capability), (override));

--- a/src/client/client_test.cc
+++ b/src/client/client_test.cc
@@ -138,8 +138,6 @@ class TestServerLauncher : public ServerLauncherInterface {
     force_terminate_server_called_ = force_terminate_server_called;
   }
 
-  void set_server_program(const absl::string_view server_path) override {}
-
   zstring_view server_program() const override {
     return placeholder_server_program_path_;
   }
@@ -933,8 +931,6 @@ class SessionPlaybackTestServerLauncher : public ServerLauncherInterface {
   bool WaitServer(uint32_t pid) override { return true; }
 
   void OnFatal(ServerLauncherInterface::ServerErrorType type) override {}
-
-  void set_server_program(const absl::string_view server_path) override {}
 
   void set_suppress_error_dialog(bool suppress) override {}
 

--- a/src/win32/base/keyevent_handler_test.cc
+++ b/src/win32/base/keyevent_handler_test.cc
@@ -139,8 +139,6 @@ class TestServerLauncher : public client::ServerLauncherInterface {
 
   void set_suppress_error_dialog(bool suppress) override {}
 
-  void set_server_program(const absl::string_view server_path) override {}
-
   zstring_view server_program() const override { return ""; }
 
   void set_start_server_result(const bool result) {


### PR DESCRIPTION
## Description
This is a preparation to switch the installation directory of Mozc from "Program Files (x86)" to "Program Files" for 64-bit Windows.

It turns out `ServerLauncher::server_program()` is the last blocker for us to switch the installation directory, because the path of the server program needs to be updated after a new version of Mozc is installed into "Program Files" instead of "Program Files (x86)".

To cleanly implement this change, let's first remove `ServerLauncher::set_server_program()` method, which is currently unused.

There must be no observable change as the method is completely unused.

## Issue IDs

 * https://github.com/google/mozc/issues/1086

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm all GitHub Actions still pass.
