### PR TITLE
Always evaluate `ServerLauncher::server_program()`

### DIFF
--- a/src/client/BUILD.bazel
+++ b/src/client/BUILD.bazel
@@ -48,7 +48,6 @@ mozc_cc_library(
         "//win32:__subpackages__",
     ],
     deps = [
-        "//base/strings:zstring_view",
         "//ipc",
         "//protocol:commands_cc_proto",
         "//protocol:config_cc_proto",
@@ -90,7 +89,6 @@ mozc_cc_library(
         "//base:version",
         "//base:vlog",
         "//base/strings:assign",
-        "//base/strings:zstring_view",
         "//composer:key_event_util",
         "//config:config_handler",
         "//ipc",
@@ -128,7 +126,6 @@ mozc_cc_test(
         "//base:number_util",
         "//base:version",
         "//base/strings:assign",
-        "//base/strings:zstring_view",
         "//composer:key_parser",
         "//config:config_handler",
         "//ipc",

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -42,7 +42,6 @@
 #include "absl/time/time.h"
 #include "base/run_level.h"
 #include "base/strings/assign.h"
-#include "base/strings/zstring_view.h"
 #include "client/client_interface.h"
 #include "composer/key_event_util.h"
 #include "ipc/ipc.h"
@@ -75,7 +74,7 @@ class ServerLauncher : public ServerLauncherInterface {
   void OnFatal(ServerLauncherInterface::ServerErrorType type) override;
 
   // return server program
-  zstring_view server_program() const override { return server_program_; }
+  std::string server_program() const override;
 
   // Sets the flag of error dialog suppression.
   void set_suppress_error_dialog(bool suppress) override {
@@ -83,7 +82,6 @@ class ServerLauncher : public ServerLauncherInterface {
   }
 
  private:
-  std::string server_program_;
   bool suppress_error_dialog_;
 };
 

--- a/src/client/client_interface.h
+++ b/src/client/client_interface.h
@@ -38,7 +38,6 @@
 
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
-#include "base/strings/zstring_view.h"
 #include "ipc/ipc.h"
 #include "protocol/commands.pb.h"
 #include "protocol/config.pb.h"
@@ -74,7 +73,7 @@ class ServerLauncherInterface {
 
   // return the full path of server program
   // This is used for making IPC connection.
-  virtual zstring_view server_program() const = 0;
+  virtual std::string server_program() const = 0;
 
   // Sets the flag of error dialog suppression.
   virtual void set_suppress_error_dialog(bool suppress) = 0;

--- a/src/client/client_test.cc
+++ b/src/client/client_test.cc
@@ -43,7 +43,6 @@
 #include "absl/strings/string_view.h"
 #include "base/number_util.h"
 #include "base/strings/assign.h"
-#include "base/strings/zstring_view.h"
 #include "base/version.h"
 #include "client/client_interface.h"
 #include "composer/key_parser.h"
@@ -138,7 +137,7 @@ class TestServerLauncher : public ServerLauncherInterface {
     force_terminate_server_called_ = force_terminate_server_called;
   }
 
-  zstring_view server_program() const override {
+  std::string server_program() const override {
     return placeholder_server_program_path_;
   }
 
@@ -938,7 +937,7 @@ class SessionPlaybackTestServerLauncher : public ServerLauncherInterface {
     start_server_result_ = result;
   }
 
-  zstring_view server_program() const override { return ""; }
+  std::string server_program() const override { return ""; }
 
  private:
   IPCClientFactoryMock *factory_;

--- a/src/client/server_launcher.cc
+++ b/src/client/server_launcher.cc
@@ -95,8 +95,7 @@ const std::string LoadServerFlags() {
 
 // initialize default path
 ServerLauncher::ServerLauncher()
-    : server_program_(SystemUtil::GetServerPath()),
-      suppress_error_dialog_(false) {}
+    : suppress_error_dialog_(false) {}
 
 ServerLauncher::~ServerLauncher() = default;
 
@@ -248,5 +247,15 @@ void ServerLauncher::OnFatal(ServerLauncherInterface::ServerErrorType type) {
     Process::LaunchErrorMessageDialog(error_type);
   }
 }
+
+std::string ServerLauncher::server_program() const {
+  // Until the migration from  from "Program Files (x86)" to "Program Files" on
+  // Windows is fully completed, we cannot treat the server program path as a
+  // constant value that does not change during the execution of the client
+  // process.
+  // https://github.com/google/mozc/issues/1086
+  return SystemUtil::GetServerPath();
+}
+
 }  // namespace client
 }  // namespace mozc

--- a/src/win32/base/BUILD.bazel
+++ b/src/win32/base/BUILD.bazel
@@ -265,7 +265,6 @@ mozc_cc_test(
         ":keyboard",
         ":keyevent_handler",
         "//base:version",
-        "//base/strings:zstring_view",
         "//client",
         "//client:client_interface",
         "//composer:key_event_util",

--- a/src/win32/base/keyevent_handler_test.cc
+++ b/src/win32/base/keyevent_handler_test.cc
@@ -44,7 +44,6 @@
 
 #include "absl/log/log.h"
 #include "absl/strings/string_view.h"
-#include "base/strings/zstring_view.h"
 #include "base/version.h"
 #include "client/client.h"
 #include "client/client_interface.h"
@@ -139,7 +138,7 @@ class TestServerLauncher : public client::ServerLauncherInterface {
 
   void set_suppress_error_dialog(bool suppress) override {}
 
-  zstring_view server_program() const override { return ""; }
+  std::string server_program() const override { return ""; }
 
   void set_start_server_result(const bool result) {
     start_server_result_ = result;


### PR DESCRIPTION
## Description
This is the final preparation step towards switching the installation directory of Mozc for Windows from `"Program Files (x86)"` to `"Program Files"`.

With this commit, `ServerLauncher::server_program()` always return the correct path to `mozc_server.exe` even when its installation directory is moved from `"Program Files (x86)"` to `"Program Files"` while the client app is running. To summarize, remaining steps are:

 1. Release a new version of Mozc for Windows with this change.
 2. Wait for a while until most of the users receive the update.
 3. Release another new version of Mozc for Windows with the installation directory switched to `"Program Files"`.
 4. At this point, we can treat `ServerLauncher::server_program()` as a constant function again.

## Issue IDs

 * https://github.com/google/mozc/issues/1086

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm no observable behavior change at this moment.
