### PR TITLE
Make `RendererStyleHandler` platform-neutral

### DIFF
--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -239,11 +239,7 @@ mozc_cc_library(
     deps = [
         "//base:singleton",
         "//protocol:renderer_cc_proto",
-    ] + mozc_select(
-        windows = [
-            "//bazel/win32:user32",
-        ],
-    ),
+    ],
 )
 
 mozc_cc_test(

--- a/src/renderer/renderer_style_handler.cc
+++ b/src/renderer/renderer_style_handler.cc
@@ -29,19 +29,12 @@
 
 #include "renderer/renderer_style_handler.h"
 
-#if defined(_WIN32)
-#include <windows.h>
-#endif  // _WIN32
-
 #include "base/singleton.h"
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
 namespace renderer {
 namespace {
-#if defined(_WIN32)
-constexpr int kDefaultDPI = 96;
-#endif  // _WIN32
 
 class RendererStyleHandlerImpl {
  public:
@@ -74,57 +67,55 @@ bool RendererStyleHandlerImpl::SetRendererStyle(const RendererStyle& style) {
   return true;
 }
 void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
-  const double scale_factor = RendererStyleHandler::GetDPIScalingFactor();
-
   // TODO(horo): Change to read from human-readable ASCII format protobuf.
   style->Clear();
-  style->set_window_border(1);  // non-scalable
-  style->set_scrollbar_width(4 * scale_factor);
-  style->set_row_rect_padding(0 * scale_factor);
+  style->set_window_border(1);
+  style->set_scrollbar_width(4);
+  style->set_row_rect_padding(0);
   style->mutable_border_color()->set_r(0x96);
   style->mutable_border_color()->set_g(0x96);
   style->mutable_border_color()->set_b(0x96);
 
   RendererStyle::TextStyle* shortcutStyle = style->add_text_styles();
-  shortcutStyle->set_font_size(14 * scale_factor);
+  shortcutStyle->set_font_size(14);
   shortcutStyle->mutable_foreground_color()->set_r(0x77);
   shortcutStyle->mutable_foreground_color()->set_g(0x77);
   shortcutStyle->mutable_foreground_color()->set_b(0x77);
   shortcutStyle->mutable_background_color()->set_r(0xf3);
   shortcutStyle->mutable_background_color()->set_g(0xf4);
   shortcutStyle->mutable_background_color()->set_b(0xff);
-  shortcutStyle->set_left_padding(8 * scale_factor);
-  shortcutStyle->set_right_padding(8 * scale_factor);
+  shortcutStyle->set_left_padding(8);
+  shortcutStyle->set_right_padding(8);
 
   RendererStyle::TextStyle* gap1Style = style->add_text_styles();
-  gap1Style->set_font_size(14 * scale_factor);
+  gap1Style->set_font_size(14);
 
   RendererStyle::TextStyle* candidateStyle = style->add_text_styles();
-  candidateStyle->set_font_size(14 * scale_factor);
+  candidateStyle->set_font_size(14);
 
   RendererStyle::TextStyle* descriptionStyle = style->add_text_styles();
-  descriptionStyle->set_font_size(12 * scale_factor);
+  descriptionStyle->set_font_size(12);
   descriptionStyle->mutable_foreground_color()->set_r(0x88);
   descriptionStyle->mutable_foreground_color()->set_g(0x88);
   descriptionStyle->mutable_foreground_color()->set_b(0x88);
-  descriptionStyle->set_right_padding(8 * scale_factor);
+  descriptionStyle->set_right_padding(8);
 
   // We want to ensure that the candidate window is at least wide
   // enough to render "そのほかの文字種  " as a candidate.
   style->set_column_minimum_width_string("そのほかの文字種  ");
 
-  style->mutable_footer_style()->set_font_size(14 * scale_factor);
-  style->mutable_footer_style()->set_left_padding(4 * scale_factor);
-  style->mutable_footer_style()->set_right_padding(4 * scale_factor);
+  style->mutable_footer_style()->set_font_size(14);
+  style->mutable_footer_style()->set_left_padding(4);
+  style->mutable_footer_style()->set_right_padding(4);
 
   RendererStyle::TextStyle* footer_sub_label_style =
       style->mutable_footer_sub_label_style();
-  footer_sub_label_style->set_font_size(10 * scale_factor);
+  footer_sub_label_style->set_font_size(10);
   footer_sub_label_style->mutable_foreground_color()->set_r(167);
   footer_sub_label_style->mutable_foreground_color()->set_g(167);
   footer_sub_label_style->mutable_foreground_color()->set_b(167);
-  footer_sub_label_style->set_left_padding(4 * scale_factor);
-  footer_sub_label_style->set_right_padding(4 * scale_factor);
+  footer_sub_label_style->set_left_padding(4);
+  footer_sub_label_style->set_right_padding(4);
 
   RendererStyle::RGBAColor* color = style->add_footer_border_colors();
   color->set_r(96);
@@ -159,21 +150,21 @@ void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
 
   RendererStyle::InfolistStyle* infostyle = style->mutable_infolist_style();
   infostyle->set_caption_string("用例");
-  infostyle->set_caption_height(20 * scale_factor);
+  infostyle->set_caption_height(20);
   infostyle->set_caption_padding(1);
-  infostyle->mutable_caption_style()->set_font_size(12 * scale_factor);
-  infostyle->mutable_caption_style()->set_left_padding(2 * scale_factor);
+  infostyle->mutable_caption_style()->set_font_size(12);
+  infostyle->mutable_caption_style()->set_left_padding(2);
   infostyle->mutable_caption_background_color()->set_r(0xec);
   infostyle->mutable_caption_background_color()->set_g(0xf0);
   infostyle->mutable_caption_background_color()->set_b(0xfa);
 
-  infostyle->set_window_border(1);  // non-scalable
-  infostyle->set_row_rect_padding(2 * scale_factor);
-  infostyle->set_window_width(300 * scale_factor);
-  infostyle->mutable_title_style()->set_font_size(15 * scale_factor);
-  infostyle->mutable_title_style()->set_left_padding(5 * scale_factor);
-  infostyle->mutable_description_style()->set_font_size(12 * scale_factor);
-  infostyle->mutable_description_style()->set_left_padding(15 * scale_factor);
+  infostyle->set_window_border(1);
+  infostyle->set_row_rect_padding(2);
+  infostyle->set_window_width(300);
+  infostyle->mutable_title_style()->set_font_size(15);
+  infostyle->mutable_title_style()->set_left_padding(5);
+  infostyle->mutable_description_style()->set_font_size(12);
+  infostyle->mutable_description_style()->set_left_padding(15);
   infostyle->mutable_border_color()->set_r(0x96);
   infostyle->mutable_border_color()->set_g(0x96);
   infostyle->mutable_border_color()->set_b(0x96);
@@ -184,6 +175,7 @@ void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
   infostyle->mutable_focused_border_color()->set_g(0xac);
   infostyle->mutable_focused_border_color()->set_b(0xdd);
 }
+
 }  // namespace
 
 bool RendererStyleHandler::GetRendererStyle(RendererStyle* style) {
@@ -194,15 +186,6 @@ bool RendererStyleHandler::SetRendererStyle(const RendererStyle& style) {
 }
 void RendererStyleHandler::GetDefaultRendererStyle(RendererStyle* style) {
   return GetRendererStyleHandlerImpl()->GetDefaultRendererStyle(style);
-}
-
-double RendererStyleHandler::GetDPIScalingFactor() {
-#ifdef _WIN32
-  const UINT dpi = ::GetDpiForSystem();
-  return static_cast<double>(dpi) / kDefaultDPI;
-#else   // _WIN32
-  return 1.0;
-#endif  // !_WIN32
 }
 
 }  // namespace renderer

--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -101,6 +101,19 @@ mozc_cc_binary(
 )
 
 mozc_cc_library(
+    name = "win32_dpi_util",
+    srcs = ["win32_dpi_util.cc"],
+    hdrs = ["win32_dpi_util.h"],
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//bazel/win32:user32",
+        "//protocol:renderer_cc_proto",
+        "//renderer:renderer_style_handler",
+    ],
+)
+
+mozc_cc_library(
     name = "candidate_window",
     srcs = ["candidate_window.cc"],
     hdrs = ["candidate_window.h"],
@@ -109,6 +122,7 @@ mozc_cc_library(
     deps = [
         ":resource_h",
         ":text_renderer",
+        ":win32_dpi_util",
         "//base:const",
         "//base:coordinates",
         "//base/win32:wide_char",
@@ -119,7 +133,6 @@ mozc_cc_library(
         "//protocol:candidate_window_cc_proto",
         "//protocol:commands_cc_proto",
         "//protocol:renderer_cc_proto",
-        "//renderer:renderer_style_handler",
         "//renderer:table_layout",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
@@ -175,12 +188,12 @@ mozc_cc_library(
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:private"],
     deps = [
+        ":win32_dpi_util",
         ":win32_font_util",
         "//base:coordinates",
         "//bazel/win32:d2d1",
         "//bazel/win32:dwrite",
         "//protocol:renderer_cc_proto",
-        "//renderer:renderer_style_handler",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/types:span",
         "@com_microsoft_wil//:wil",
@@ -214,6 +227,7 @@ mozc_cc_library(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":text_renderer",
+        ":win32_dpi_util",
         "//base:const",
         "//base:coordinates",
         "//base:vlog",
@@ -224,7 +238,6 @@ mozc_cc_library(
         "//protocol:candidate_window_cc_proto",
         "//protocol:commands_cc_proto",
         "//protocol:renderer_cc_proto",
-        "//renderer:renderer_style_handler",
         "@com_microsoft_wil//:wil",
     ],
 )

--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -50,6 +50,7 @@
 #include "renderer/table_layout.h"
 #include "renderer/win32/resource.h"
 #include "renderer/win32/text_renderer.h"
+#include "renderer/win32/win32_dpi_util.h"
 
 namespace mozc {
 namespace renderer {
@@ -243,7 +244,7 @@ CandidateWindow::CandidateWindow()
       metrics_changed_(false),
       mouse_moving_(true) {
   double image_scale_factor = 1.0;
-  const double scale_factor = RendererStyleHandler::GetDPIScalingFactor();
+  const double scale_factor = GetDPIScalingFactor();
   if (scale_factor < 1.125) {
     footer_logo_.reset(LoadBitmapFromResource(::GetModuleHandle(nullptr),
                                               IDB_FOOTER_LOGO_COLOR_100));
@@ -838,7 +839,7 @@ void CandidateWindow::DrawSelectedRect(HDC dc) {
 
 void CandidateWindow::DrawInformationIcon(HDC dc) {
   DCHECK(table_layout_->IsLayoutFrozen()) << "Table layout is not frozen.";
-  const double scale_factor = RendererStyleHandler::GetDPIScalingFactor();
+  const double scale_factor = GetDPIScalingFactor();
   for (size_t i = 0; i < candidate_window_->candidate_size(); ++i) {
     if (candidate_window_->candidate(i).has_information_id()) {
       CRect rect = ToCRect(table_layout_->GetRowRect(i));

--- a/src/renderer/win32/infolist_window.cc
+++ b/src/renderer/win32/infolist_window.cc
@@ -45,8 +45,8 @@
 #include "protocol/commands.pb.h"
 #include "protocol/renderer_command.pb.h"
 #include "protocol/renderer_style.pb.h"
-#include "renderer/renderer_style_handler.h"
 #include "renderer/win32/text_renderer.h"
+#include "renderer/win32/win32_dpi_util.h"
 
 namespace mozc {
 namespace renderer {
@@ -83,7 +83,7 @@ InfolistWindow::InfolistWindow()
       style_(new RendererStyle),
       metrics_changed_(false),
       visible_(false) {
-  mozc::renderer::RendererStyleHandler::GetRendererStyle(style_.get());
+  GetScaledRendererStyle(style_.get());
 }
 
 InfolistWindow::~InfolistWindow() {}

--- a/src/renderer/win32/text_renderer.cc
+++ b/src/renderer/win32/text_renderer.cc
@@ -51,7 +51,7 @@
 #include "absl/types/span.h"
 #include "base/coordinates.h"
 #include "protocol/renderer_style.pb.h"
-#include "renderer/renderer_style_handler.h"
+#include "renderer/win32/win32_dpi_util.h"
 #include "renderer/win32/win32_font_util.h"
 
 namespace mozc {
@@ -59,7 +59,6 @@ namespace renderer {
 namespace win32 {
 
 using ::mozc::renderer::RendererStyle;
-using ::mozc::renderer::RendererStyleHandler;
 
 namespace {
 
@@ -88,7 +87,7 @@ COLORREF GetTextColor(TextRenderer::FONT_TYPE type) {
   // TODO(horo): Not only infolist fonts but also candidate fonts
   //             should be created from RendererStyle
   RendererStyle style;
-  RendererStyleHandler::GetRendererStyle(&style);
+  GetScaledRendererStyle(&style);
   const auto& infostyle = style.infolist_style();
   switch (type) {
     case TextRenderer::FONTSET_INFOLIST_CAPTION:
@@ -139,7 +138,7 @@ LOGFONT GetLogFont(TextRenderer::FONT_TYPE type) {
   // TODO(horo): Not only infolist fonts but also candidate fonts
   //             should be created from RendererStyle
   RendererStyle style;
-  RendererStyleHandler::GetRendererStyle(&style);
+  GetScaledRendererStyle(&style);
   const auto& infostyle = style.infolist_style();
   switch (type) {
     case TextRenderer::FONTSET_INFOLIST_CAPTION: {

--- a/src/renderer/win32/win32_dpi_util.cc
+++ b/src/renderer/win32/win32_dpi_util.cc
@@ -1,0 +1,113 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "renderer/win32/win32_dpi_util.h"
+
+#include <windows.h>
+
+#include "protocol/renderer_style.pb.h"
+#include "renderer/renderer_style_handler.h"
+
+namespace mozc {
+namespace renderer {
+namespace win32 {
+namespace {
+
+constexpr int kDefaultDPI = 96;
+
+}  // namespace
+
+double GetDPIScalingFactor() {
+  const UINT dpi = ::GetDpiForSystem();
+  return static_cast<double>(dpi) / kDefaultDPI;
+}
+
+void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style) {
+  const double scale_factor = GetDPIScalingFactor();
+
+  RendererStyleHandler::GetDefaultRendererStyle(style);
+
+  // style->window_border is non-scalable.
+  style->set_scrollbar_width(style->scrollbar_width() * scale_factor);
+  style->set_row_rect_padding(style->row_rect_padding() * scale_factor);
+
+  for (RendererStyle::TextStyle& text_style : *style->mutable_text_styles()) {
+    text_style.set_font_size(text_style.font_size() * scale_factor);
+    text_style.set_left_padding(text_style.left_padding() * scale_factor);
+    text_style.set_right_padding(text_style.right_padding() * scale_factor);
+  }
+
+  {
+    RendererStyle::TextStyle* footer_style = style->mutable_footer_style();
+    footer_style->set_font_size(footer_style->font_size() * scale_factor);
+    footer_style->set_left_padding(footer_style->left_padding() * scale_factor);
+    footer_style->set_right_padding(footer_style->right_padding() *
+                                    scale_factor);
+  }
+
+  {
+    RendererStyle::TextStyle* footer_sub_label_style =
+        style->mutable_footer_sub_label_style();
+    footer_sub_label_style->set_font_size(footer_sub_label_style->font_size() *
+                                          scale_factor);
+    footer_sub_label_style->set_left_padding(
+        footer_sub_label_style->left_padding() * scale_factor);
+    footer_sub_label_style->set_right_padding(
+        footer_sub_label_style->right_padding() * scale_factor);
+  }
+
+  {
+    RendererStyle::InfolistStyle* infostyle = style->mutable_infolist_style();
+    // infostyle->window_border and infostyle->caption_padding are non-scalable.
+    infostyle->set_caption_height(infostyle->caption_height() * scale_factor);
+    infostyle->set_row_rect_padding(infostyle->row_rect_padding() *
+                                    scale_factor);
+    infostyle->set_window_width(infostyle->window_width() * scale_factor);
+
+    RendererStyle::TextStyle* caption_style = infostyle->mutable_caption_style();
+    caption_style->set_font_size(caption_style->font_size() * scale_factor);
+    caption_style->set_left_padding(caption_style->left_padding() *
+                                    scale_factor);
+
+    RendererStyle::TextStyle* title_style = infostyle->mutable_title_style();
+    title_style->set_font_size(title_style->font_size() * scale_factor);
+    title_style->set_left_padding(title_style->left_padding() * scale_factor);
+
+    RendererStyle::TextStyle* description_style =
+        infostyle->mutable_description_style();
+    description_style->set_font_size(description_style->font_size() *
+                                     scale_factor);
+    description_style->set_left_padding(description_style->left_padding() *
+                                        scale_factor);
+  }
+}
+
+}  // namespace win32
+}  // namespace renderer
+}  // namespace mozc

--- a/src/renderer/win32/win32_dpi_util.h
+++ b/src/renderer/win32/win32_dpi_util.h
@@ -27,28 +27,23 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef MOZC_RENDERER_RENDERER_STYLE_HANDLER_H_
-#define MOZC_RENDERER_RENDERER_STYLE_HANDLER_H_
+#ifndef MOZC_RENDERER_WIN32_WIN32_DPI_UTIL_H_
+#define MOZC_RENDERER_WIN32_WIN32_DPI_UTIL_H_
 
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
 namespace renderer {
+namespace win32 {
 
-// this is pure static class
-class RendererStyleHandler {
- public:
-  RendererStyleHandler() = delete;
+// Returns DPI scaling factor on Windows.
+double GetDPIScalingFactor();
 
-  // return current Style
-  static bool GetRendererStyle(RendererStyle* style);
-  // set Style
-  static bool SetRendererStyle(const RendererStyle& style);
-  // get default Style
-  static void GetDefaultRendererStyle(RendererStyle* style);
-};
+// Get RendererStyle adjusted with the DPI scaling factor on Windows.
+void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style);
 
+}  // namespace win32
 }  // namespace renderer
 }  // namespace mozc
 
-#endif  // MOZC_RENDERER_RENDERER_STYLE_HANDLER_H_
+#endif  // MOZC_RENDERER_WIN32_WIN32_DPI_UTIL_H_


### PR DESCRIPTION
## Description
This is a mechanical refactoring commit as a preparation to fully support Per-Monitor DPI v2 in the candidate window for Windows.

Unlike other platforms such as Linux desktop and macOS, RendererStyleHandler has taken care of DPI scaling on Windows in two ways:

 A. `RendererStyleHandler::GetDPIScalingFactor()` is used only on Windows.
 B. `RendererStyleHandler::GetDefaultRendererStyle()` internally takes care of DPI scaling factor for certain style parameters.

Such discrepancy makes it harder to fully support Per-Monitor DPI v2 on Windows because:

 * `RendererStyleHandler::GetDPIScalingFactor()` assumes there is a single DPI scaling factor, which is no longer valid when each monitor may have different DPI scaling factors.
 * We do not want further Windows-specific requirements to be added to `RendererStyleHandler::GetDefaultRendererStyle()`.

With this commit, `RendererStyleHandler` becomes fully platform-neutral, which protects it from upcoming Windows-specific code changes.

There must be no observable behavior change.

## Issue IDs

 * https://github.com/google/mozc/issues/1459

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm there is no behavior change.
