### PR TITLE
Remove `Singleton` from `RendererStyleHandler`

### DIFF
--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -237,7 +237,6 @@ mozc_cc_library(
     hdrs = ["renderer_style_handler.h"],
     visibility = ["//renderer:__subpackages__"],
     deps = [
-        "//base:singleton",
         "//protocol:renderer_cc_proto",
     ],
 )

--- a/src/renderer/renderer_style_handler.cc
+++ b/src/renderer/renderer_style_handler.cc
@@ -29,44 +29,12 @@
 
 #include "renderer/renderer_style_handler.h"
 
-#include "base/singleton.h"
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
 namespace renderer {
-namespace {
 
-class RendererStyleHandlerImpl {
- public:
-  RendererStyleHandlerImpl();
-  ~RendererStyleHandlerImpl() = default;
-  bool GetRendererStyle(RendererStyle* style);
-  bool SetRendererStyle(const RendererStyle& style);
-  void GetDefaultRendererStyle(RendererStyle* style);
-
- private:
-  RendererStyle style_;
-};
-
-RendererStyleHandlerImpl* GetRendererStyleHandlerImpl() {
-  return Singleton<RendererStyleHandlerImpl>::get();
-}
-
-RendererStyleHandlerImpl::RendererStyleHandlerImpl() {
-  RendererStyle style;
-  GetDefaultRendererStyle(&style);
-  SetRendererStyle(style);
-}
-
-bool RendererStyleHandlerImpl::GetRendererStyle(RendererStyle* style) {
-  *style = this->style_;
-  return true;
-}
-bool RendererStyleHandlerImpl::SetRendererStyle(const RendererStyle& style) {
-  style_ = style;
-  return true;
-}
-void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
+void RendererStyleHandler::GetRendererStyle(RendererStyle* style) {
   // TODO(horo): Change to read from human-readable ASCII format protobuf.
   style->Clear();
   style->set_window_border(1);
@@ -174,18 +142,6 @@ void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
   infostyle->mutable_focused_border_color()->set_r(0x7f);
   infostyle->mutable_focused_border_color()->set_g(0xac);
   infostyle->mutable_focused_border_color()->set_b(0xdd);
-}
-
-}  // namespace
-
-bool RendererStyleHandler::GetRendererStyle(RendererStyle* style) {
-  return GetRendererStyleHandlerImpl()->GetRendererStyle(style);
-}
-bool RendererStyleHandler::SetRendererStyle(const RendererStyle& style) {
-  return GetRendererStyleHandlerImpl()->SetRendererStyle(style);
-}
-void RendererStyleHandler::GetDefaultRendererStyle(RendererStyle* style) {
-  return GetRendererStyleHandlerImpl()->GetDefaultRendererStyle(style);
 }
 
 }  // namespace renderer

--- a/src/renderer/renderer_style_handler.h
+++ b/src/renderer/renderer_style_handler.h
@@ -41,11 +41,7 @@ class RendererStyleHandler {
   RendererStyleHandler() = delete;
 
   // return current Style
-  static bool GetRendererStyle(RendererStyle* style);
-  // set Style
-  static bool SetRendererStyle(const RendererStyle& style);
-  // get default Style
-  static void GetDefaultRendererStyle(RendererStyle* style);
+  static void GetRendererStyle(RendererStyle* style);
 };
 
 }  // namespace renderer

--- a/src/renderer/renderer_style_handler_test.cc
+++ b/src/renderer/renderer_style_handler_test.cc
@@ -35,19 +35,11 @@
 namespace mozc {
 namespace renderer {
 
-TEST(RendererStyleHandlerTest, SetAndGetRendererStyleTest1) {
+TEST(RendererStyleHandlerTest, GetRendererStyle) {
   RendererStyle style;
-  style.set_window_border(99);
-  EXPECT_TRUE(RendererStyleHandler::SetRendererStyle(style));
-  RendererStyle style2;
-  EXPECT_NE(style2.window_border(), 99);
-  EXPECT_TRUE(RendererStyleHandler::GetRendererStyle(&style2));
-  EXPECT_EQ(style2.window_border(), 99);
-}
-TEST(RendererStyleHandlerTest, GetDefaultRendererStyleTest) {
-  RendererStyle style;
-  RendererStyleHandler::GetDefaultRendererStyle(&style);
+  RendererStyleHandler::GetRendererStyle(&style);
   EXPECT_TRUE(style.has_window_border());
 }
+
 }  // namespace renderer
 }  // namespace mozc

--- a/src/renderer/win32/win32_dpi_util.cc
+++ b/src/renderer/win32/win32_dpi_util.cc
@@ -58,7 +58,7 @@ double GetDPIScalingFactor() {
 void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style) {
   const double scale_factor = GetDPIScalingFactor();
 
-  RendererStyleHandler::GetDefaultRendererStyle(style);
+  RendererStyleHandler::GetRendererStyle(style);
 
   // style->window_border is non-scalable.
   style->set_scrollbar_width(style->scrollbar_width() * scale_factor);


### PR DESCRIPTION
## Description
As part of our on-going efforts to remove the dependency on `Singleton`, this commit rewrites `renderer::RendererStyleHandler` without the Singleton class dependency.

This is purely mechanical refactoring, and there must be no observable behavioral change in production.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
