### PR TITLE
Always use "en-US" in `HResult::ToString()`

### DIFF
--- a/src/base/win32/hresult.cc
+++ b/src/base/win32/hresult.cc
@@ -92,7 +92,7 @@ std::string HResult::ToStringSlow() const {
   DWORD result = FormatMessageW(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      nullptr, hr_, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      nullptr, hr_, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
       reinterpret_cast<wchar_t*>(message.put()), 0, nullptr);
   if (result == 0) {
     return absl::StrFormat(


### PR DESCRIPTION
## Description
While it's tempting to use the user's locale to get the error message, in reality `HResult::ToString()` is not (and should not be) designed for user facing error messages. Instead, let's always use `"en-US"` to get the error message, so that the error message is consistent regardless of the user's locale.

## Issue IDs

 * https://github.com/google/mozc/issues/1420

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Change the user locale to Japanese.
   2. `bazelisk test --config oss_windows -c dbg //base/win32:hresult_test --nocache_test_results --test_output=streamed`
