### PR TITLE
Support DPI change in candidate/infolist window

### DIFF
--- a/src/bazel/win32/BUILD.bazel
+++ b/src/bazel/win32/BUILD.bazel
@@ -98,5 +98,9 @@ mozc_win32_lib(
 )
 
 mozc_win32_lib(
+    name = "shcore",
+)
+
+mozc_win32_lib(
     name = "user32",
 )

--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -107,6 +107,7 @@ mozc_cc_library(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        "//bazel/win32:shcore",
         "//bazel/win32:user32",
         "//protocol:renderer_cc_proto",
         "//renderer:renderer_style_handler",
@@ -122,6 +123,7 @@ mozc_cc_library(
     deps = [
         ":resource_h",
         ":text_renderer",
+        ":win32_dpi_util",
         "//base:const",
         "//base:coordinates",
         "//base/win32:wide_char",
@@ -251,6 +253,7 @@ mozc_cc_library(
         ":candidate_window",
         ":indicator_window",
         ":infolist_window",
+        ":win32_dpi_util",
         ":win32_renderer_util",
         "//base:coordinates",
         "//client:client_interface",

--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -35,6 +35,7 @@
 #include <wil/resource.h>
 #include <windows.h>
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -56,9 +57,6 @@ namespace mozc {
 namespace renderer {
 namespace win32 {
 namespace {
-
-// 96 DPI is the default DPI in Windows.
-constexpr int kDefaultDPI = 96;
 
 // layout size constants in pixel unit in the default DPI.
 constexpr int kIndicatorWidthInDefaultDPI = 4;
@@ -239,12 +237,19 @@ CandidateWindow::CandidateWindow()
       footer_logo_display_size_(0, 0),
       send_command_interface_(nullptr),
       table_layout_(std::make_unique<TableLayout>()),
-      text_renderer_(TextRenderer::Create()),
+      dpi_(::GetDpiForSystem()),
+      text_renderer_(TextRenderer::Create(dpi_)),
       indicator_width_(0),
       metrics_changed_(false),
       mouse_moving_(true) {
+  UpdateDpiDependentResources();
+}
+
+CandidateWindow::~CandidateWindow() = default;
+
+void CandidateWindow::UpdateDpiDependentResources() {
+  const double scale_factor = GetDPIScalingFactor(dpi_);
   double image_scale_factor = 1.0;
-  const double scale_factor = GetDPIScalingFactor();
   if (scale_factor < 1.125) {
     footer_logo_.reset(LoadBitmapFromResource(::GetModuleHandle(nullptr),
                                               IDB_FOOTER_LOGO_COLOR_100));
@@ -263,7 +268,7 @@ CandidateWindow::CandidateWindow()
     image_scale_factor = 2.0;
   }
 
-  // If DPI is not default value, re-calculate the size based on the DPI.
+  footer_logo_display_size_ = Size(0, 0);
   if (footer_logo_.is_valid()) {
     BITMAP bm = {};
     if (::GetObject(footer_logo_.get(), sizeof(bm), &bm)) {
@@ -276,11 +281,18 @@ CandidateWindow::CandidateWindow()
   indicator_width_ = kIndicatorWidthInDefaultDPI * scale_factor;
 }
 
-CandidateWindow::~CandidateWindow() {}
-
 LRESULT CandidateWindow::OnCreate(LPCREATESTRUCT create_struct) {
   EnableOrDisableWindowForWorkaround();
   return 0;
+}
+
+void CandidateWindow::UpdateDpi(uint32_t dpi) {
+  if (dpi == dpi_) {
+    return;
+  }
+  dpi_ = dpi;
+  UpdateDpiDependentResources();
+  text_renderer_->OnDpiChanged(dpi_);
 }
 
 void CandidateWindow::EnableOrDisableWindowForWorkaround() {
@@ -300,10 +312,6 @@ void CandidateWindow::OnDestroy() {
   // windows are not closed. WindowManager should close these windows
   // before process termination.
   ::PostQuitMessage(0);
-}
-
-void CandidateWindow::OnDpiChanged(UINT dpiX, UINT dpiY, RECT* rect) {
-  metrics_changed_ = true;
 }
 
 BOOL CandidateWindow::OnEraseBkgnd(HDC dc) {
@@ -839,7 +847,7 @@ void CandidateWindow::DrawSelectedRect(HDC dc) {
 
 void CandidateWindow::DrawInformationIcon(HDC dc) {
   DCHECK(table_layout_->IsLayoutFrozen()) << "Table layout is not frozen.";
-  const double scale_factor = GetDPIScalingFactor();
+  const double scale_factor = GetDPIScalingFactor(dpi_);
   for (size_t i = 0; i < candidate_window_->candidate_size(); ++i) {
     if (candidate_window_->candidate(i).has_information_id()) {
       CRect rect = ToCRect(table_layout_->GetRowRect(i));

--- a/src/renderer/win32/candidate_window.h
+++ b/src/renderer/win32/candidate_window.h
@@ -36,6 +36,7 @@
 #include <wil/resource.h>
 #include <windows.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "base/const.h"
@@ -72,7 +73,6 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   BEGIN_MSG_MAP(CandidateWindow)
   MESSAGE_HANDLER(WM_CREATE, OnCreate)
   MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
-  MESSAGE_HANDLER(WM_DPICHANGED, OnDpiChanged)
   MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBkgnd)
   MESSAGE_HANDLER(WM_GETMINMAXINFO, OnGetMinMaxInfo)
   MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
@@ -89,7 +89,6 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   ~CandidateWindow();
   LRESULT OnCreate(LPCREATESTRUCT create_struct);
   void OnDestroy();
-  void OnDpiChanged(UINT dpiX, UINT dpiY, RECT* rect);
   BOOL OnEraseBkgnd(HDC dc);
   void OnGetMinMaxInfo(MINMAXINFO* min_max_info);
   void OnLButtonDown(UINT nFlags, CPoint point);
@@ -100,6 +99,12 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
 
   void set_mouse_moving(bool moving);
+
+  // If |dpi| differs from the cached DPI, updates the cached DPI, refreshes
+  // DPI-dependent resources, and flags the text renderer for refresh on the
+  // next UpdateLayout. Idempotent — safe to call unconditionally before
+  // UpdateLayout.
+  void UpdateDpi(uint32_t dpi);
 
   void UpdateLayout(const commands::CandidateWindow& candidate_window);
   void SetSendCommandInterface(
@@ -123,6 +128,10 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   void DrawBackground(HDC dc);
   void DrawFrame(HDC dc);
 
+  // Recomputes DPI-dependent cached resources (footer logo and indicator
+  // width) for the current |dpi_|.
+  void UpdateDpiDependentResources();
+
   // Handles candidate selection by mouse.
   void HandleMouseEvent(UINT nFlags, const CPoint& point,
                         bool close_candidatewindow);
@@ -140,13 +149,6 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   inline LRESULT OnDestroy(UINT msg_id, WPARAM wparam, LPARAM lparam,
                            BOOL& handled) {
     OnDestroy();
-    return 0;
-  }
-  inline LRESULT OnDpiChanged(UINT msg_id, WPARAM wparam, LPARAM lparam,
-                              BOOL& handled) {
-    OnDpiChanged(static_cast<UINT>(LOWORD(wparam)),
-                 static_cast<UINT>(HIWORD(wparam)),
-                 reinterpret_cast<RECT*>(lparam));
     return 0;
   }
   inline LRESULT OnEraseBkgnd(UINT msg_id, WPARAM wparam, LPARAM lparam,
@@ -198,6 +200,7 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   Size footer_logo_display_size_;
   client::SendCommandInterface* send_command_interface_;
   std::unique_ptr<TableLayout> table_layout_;
+  uint32_t dpi_;
   std::unique_ptr<TextRenderer> text_renderer_;
   int indicator_width_;
   bool metrics_changed_;

--- a/src/renderer/win32/indicator_window.cc
+++ b/src/renderer/win32/indicator_window.cc
@@ -251,7 +251,7 @@ class IndicatorWindow::WindowImpl
 
   void LoadSprite(int mode) {
     BalloonImage::BalloonImageInfo info;
-    LOGFONT logfont = GetMessageBoxLogFont();
+    LOGFONT logfont = GetMessageBoxLogFont(::GetDpiForSystem());
     info.label_font = mozc::win32::WideToUtf8(logfont.lfFaceName);
 
     info.frame_color = RGBColor(1, 122, 204);

--- a/src/renderer/win32/infolist_window.cc
+++ b/src/renderer/win32/infolist_window.cc
@@ -35,6 +35,7 @@
 #include <wil/resource.h>
 #include <windows.h>
 
+#include <cstdint>
 #include <string>
 
 #include "base/coordinates.h"
@@ -79,24 +80,30 @@ void FillSolidRect(HDC dc, const RECT* rect, COLORREF color) {
 InfolistWindow::InfolistWindow()
     : send_command_interface_(nullptr),
       candidate_window_(new commands::CandidateWindow),
-      text_renderer_(TextRenderer::Create()),
+      dpi_(::GetDpiForSystem()),
+      text_renderer_(TextRenderer::Create(dpi_)),
       style_(new RendererStyle),
       metrics_changed_(false),
       visible_(false) {
-  GetScaledRendererStyle(style_.get());
+  GetScaledRendererStyle(style_.get(), dpi_);
 }
 
 InfolistWindow::~InfolistWindow() {}
+
+void InfolistWindow::UpdateDpi(uint32_t dpi) {
+  if (dpi == dpi_) {
+    return;
+  }
+  dpi_ = dpi;
+  GetScaledRendererStyle(style_.get(), dpi_);
+  text_renderer_->OnDpiChanged(dpi_);
+}
 
 void InfolistWindow::OnDestroy() {
   // PostQuitMessage may stop the message loop even though other
   // windows are not closed. WindowManager should close these windows
   // before process termination.
   ::PostQuitMessage(0);
-}
-
-void InfolistWindow::OnDpiChanged(UINT dpiX, UINT dpiY, RECT* rect) {
-  metrics_changed_ = true;
 }
 
 BOOL InfolistWindow::OnEraseBkgnd(HDC dc) {

--- a/src/renderer/win32/infolist_window.h
+++ b/src/renderer/win32/infolist_window.h
@@ -35,6 +35,7 @@
 #include <atlwin.h>
 #include <windows.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -64,7 +65,6 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
 
   BEGIN_MSG_MAP(InfolistWindow)
   MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
-  MESSAGE_HANDLER(WM_DPICHANGED, OnDpiChanged)
   MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBkgnd)
   MESSAGE_HANDLER(WM_GETMINMAXINFO, OnGetMinMaxInfo)
   MESSAGE_HANDLER(WM_SETTINGCHANGE, OnSettingChange)
@@ -78,13 +78,18 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
   InfolistWindow& operator=(const InfolistWindow&) = delete;
   ~InfolistWindow();
   void OnDestroy();
-  void OnDpiChanged(UINT dpiX, UINT dpiY, RECT* rect);
   BOOL OnEraseBkgnd(HDC dc);
   void OnGetMinMaxInfo(MINMAXINFO* min_max_info);
   void OnPaint(HDC dc);
   void OnPrintClient(HDC dc, UINT uFlags);
   void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
   void OnTimer(UINT_PTR nIDEvent);
+
+  // If |dpi| differs from the cached DPI, updates the cached DPI, re-scales
+  // |style_|, and flags the text renderer for refresh on the next
+  // UpdateLayout. Idempotent — safe to call unconditionally before
+  // UpdateLayout.
+  void UpdateDpi(uint32_t dpi);
 
   void UpdateLayout(const commands::CandidateWindow& candidates);
   void SetSendCommandInterface(
@@ -103,13 +108,6 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
   inline LRESULT OnDestroy(UINT msg_id, WPARAM wparam, LPARAM lparam,
                            BOOL& handled) {
     OnDestroy();
-    return 0;
-  }
-  inline LRESULT OnDpiChanged(UINT msg_id, WPARAM wparam, LPARAM lparam,
-                              BOOL& handled) {
-    OnDpiChanged(static_cast<UINT>(LOWORD(wparam)),
-                 static_cast<UINT>(HIWORD(wparam)),
-                 reinterpret_cast<RECT*>(lparam));
     return 0;
   }
   inline LRESULT OnEraseBkgnd(UINT msg_id, WPARAM wparam, LPARAM lparam,
@@ -145,6 +143,7 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
 
   client::SendCommandInterface* send_command_interface_;
   std::unique_ptr<commands::CandidateWindow> candidate_window_;
+  uint32_t dpi_;
   std::unique_ptr<TextRenderer> text_renderer_;
   std::unique_ptr<renderer::RendererStyle> style_;
   bool metrics_changed_;

--- a/src/renderer/win32/text_renderer.cc
+++ b/src/renderer/win32/text_renderer.cc
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -66,7 +67,7 @@ CRect ToCRect(const Rect& rect) {
   return CRect(rect.Left(), rect.Top(), rect.Right(), rect.Bottom());
 }
 
-COLORREF GetTextColor(TextRenderer::FONT_TYPE type) {
+COLORREF GetTextColor(TextRenderer::FONT_TYPE type, uint32_t dpi) {
   switch (type) {
     case TextRenderer::FONTSET_SHORTCUT:
       return RGB(0x61, 0x61, 0x61);
@@ -87,7 +88,7 @@ COLORREF GetTextColor(TextRenderer::FONT_TYPE type) {
   // TODO(horo): Not only infolist fonts but also candidate fonts
   //             should be created from RendererStyle
   RendererStyle style;
-  GetScaledRendererStyle(&style);
+  GetScaledRendererStyle(&style, dpi);
   const auto& infostyle = style.infolist_style();
   switch (type) {
     case TextRenderer::FONTSET_INFOLIST_CAPTION:
@@ -110,8 +111,8 @@ COLORREF GetTextColor(TextRenderer::FONT_TYPE type) {
   return RGB(0, 0, 0);
 }
 
-LOGFONT GetLogFont(TextRenderer::FONT_TYPE type) {
-  LOGFONT font = GetMessageBoxLogFont();
+LOGFONT GetLogFont(TextRenderer::FONT_TYPE type, uint32_t dpi) {
+  LOGFONT font = GetMessageBoxLogFont(dpi);
 
   switch (type) {
     case TextRenderer::FONTSET_SHORTCUT: {
@@ -138,7 +139,7 @@ LOGFONT GetLogFont(TextRenderer::FONT_TYPE type) {
   // TODO(horo): Not only infolist fonts but also candidate fonts
   //             should be created from RendererStyle
   RendererStyle style;
-  GetScaledRendererStyle(&style);
+  GetScaledRendererStyle(&style, dpi);
   const auto& infostyle = style.infolist_style();
   switch (type) {
     case TextRenderer::FONTSET_INFOLIST_CAPTION: {
@@ -190,9 +191,10 @@ DWORD GetGdiDrawTextStyle(TextRenderer::FONT_TYPE type) {
 
 class GdiTextRenderer : public TextRenderer {
  public:
-  GdiTextRenderer()
+  explicit GdiTextRenderer(uint32_t dpi)
       : render_info_(SIZE_OF_FONT_TYPE),
-        mem_dc_(::CreateCompatibleDC(nullptr)) {
+        mem_dc_(::CreateCompatibleDC(nullptr)),
+        dpi_(dpi) {
     OnThemeChanged();
   }
 
@@ -215,11 +217,19 @@ class GdiTextRenderer : public TextRenderer {
 
     for (size_t i = 0; i < SIZE_OF_FONT_TYPE; ++i) {
       const auto font_type = static_cast<FONT_TYPE>(i);
-      const auto& log_font = GetLogFont(font_type);
+      const auto& log_font = GetLogFont(font_type, dpi_);
       render_info_[i].style = GetGdiDrawTextStyle(font_type);
       render_info_[i].font.reset(::CreateFontIndirectW(&log_font));
-      render_info_[i].color = GetTextColor(font_type);
+      render_info_[i].color = GetTextColor(font_type, dpi_);
     }
+  }
+
+  void OnDpiChanged(uint32_t dpi) override {
+    if (dpi == dpi_) {
+      return;
+    }
+    dpi_ = dpi;
+    OnThemeChanged();
   }
 
   Size MeasureString(FONT_TYPE font_type,
@@ -269,6 +279,7 @@ class GdiTextRenderer : public TextRenderer {
 
   std::vector<RenderInfo> render_info_;
   wil::unique_hdc mem_dc_;
+  uint32_t dpi_;
 };
 
 class DirectWriteTextRenderer : public TextRenderer {
@@ -276,14 +287,15 @@ class DirectWriteTextRenderer : public TextRenderer {
   DirectWriteTextRenderer(
       wil::com_ptr_nothrow<ID2D1Factory> d2d2_factory,
       wil::com_ptr_nothrow<IDWriteFactory> dwrite_factory,
-      wil::com_ptr_nothrow<IDWriteGdiInterop> dwrite_interop)
+      wil::com_ptr_nothrow<IDWriteGdiInterop> dwrite_interop, uint32_t dpi)
       : d2d2_factory_(std::move(d2d2_factory)),
         dwrite_factory_(std::move(dwrite_factory)),
-        dwrite_interop_(std::move(dwrite_interop)) {
+        dwrite_interop_(std::move(dwrite_interop)),
+        dpi_(dpi) {
     OnThemeChanged();
   }
 
-  static std::unique_ptr<DirectWriteTextRenderer> Create() {
+  static std::unique_ptr<DirectWriteTextRenderer> Create(uint32_t dpi) {
     HRESULT hr = S_OK;
     wil::com_ptr_nothrow<ID2D1Factory> d2d_factory;
     hr = ::D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED,
@@ -304,8 +316,9 @@ class DirectWriteTextRenderer : public TextRenderer {
     if (FAILED(hr)) {
       return nullptr;
     }
-    return std::make_unique<DirectWriteTextRenderer>(
-        std::move(d2d_factory), std::move(dwrite_factory), std::move(interop));
+    return std::make_unique<DirectWriteTextRenderer>(std::move(d2d_factory),
+                                                     std::move(dwrite_factory),
+                                                     std::move(interop), dpi);
   }
 
  private:
@@ -324,8 +337,8 @@ class DirectWriteTextRenderer : public TextRenderer {
 
     for (size_t i = 0; i < SIZE_OF_FONT_TYPE; ++i) {
       const auto font_type = static_cast<FONT_TYPE>(i);
-      const auto& log_font = GetLogFont(font_type);
-      render_info_[i].color = GetTextColor(font_type);
+      const auto& log_font = GetLogFont(font_type, dpi_);
+      render_info_[i].color = GetTextColor(font_type, dpi_);
       render_info_[i].format = CreateFormat(log_font);
       render_info_[i].format_to_render = CreateFormat(log_font);
       const auto style = GetGdiDrawTextStyle(font_type);
@@ -343,6 +356,14 @@ class DirectWriteTextRenderer : public TextRenderer {
         render_font->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING);
       }
     }
+  }
+
+  void OnDpiChanged(uint32_t dpi) override {
+    if (dpi == dpi_) {
+      return;
+    }
+    dpi_ = dpi;
+    OnThemeChanged();
   }
 
   // Retrieves the bounding box for a given string.
@@ -528,18 +549,19 @@ class DirectWriteTextRenderer : public TextRenderer {
   mutable wil::com_ptr_nothrow<ID2D1DCRenderTarget> dc_render_target_;
   wil::com_ptr_nothrow<IDWriteGdiInterop> dwrite_interop_;
   std::vector<RenderInfo> render_info_;
+  uint32_t dpi_;
 };
 
 }  // namespace
 
 // static
-std::unique_ptr<TextRenderer> TextRenderer::Create() {
+std::unique_ptr<TextRenderer> TextRenderer::Create(uint32_t dpi) {
   std::unique_ptr<TextRenderer> dwrite_text_renderer =
-      DirectWriteTextRenderer::Create();
+      DirectWriteTextRenderer::Create(dpi);
   if (dwrite_text_renderer != nullptr) {
     return dwrite_text_renderer;
   }
-  return std::make_unique<GdiTextRenderer>();
+  return std::make_unique<GdiTextRenderer>(dpi);
 }
 
 }  // namespace win32

--- a/src/renderer/win32/text_renderer.h
+++ b/src/renderer/win32/text_renderer.h
@@ -32,6 +32,7 @@
 
 #include <windows.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -77,10 +78,14 @@ class TextRenderer {
   virtual ~TextRenderer() = default;
 
   // Returns an instance of TextRenderer.
-  static std::unique_ptr<TextRenderer> Create();
+  static std::unique_ptr<TextRenderer> Create(uint32_t dpi);
 
   // Updates font cache.
   virtual void OnThemeChanged() = 0;
+
+  // If |dpi| differs from the previously seen DPI, updates the stored DPI
+  // and rebuilds the font cache. No-op otherwise.
+  virtual void OnDpiChanged(uint32_t dpi) = 0;
 
   // Retrieves the bounding box for a given string.
   virtual Size MeasureString(FONT_TYPE font_type,

--- a/src/renderer/win32/win32_dpi_util.cc
+++ b/src/renderer/win32/win32_dpi_util.cc
@@ -29,7 +29,10 @@
 
 #include "renderer/win32/win32_dpi_util.h"
 
+#include <shellscalingapi.h>
 #include <windows.h>
+
+#include <cstdint>
 
 #include "protocol/renderer_style.pb.h"
 #include "renderer/renderer_style_handler.h"
@@ -39,10 +42,7 @@ namespace renderer {
 namespace win32 {
 namespace {
 
-constexpr int kDefaultDPI = 96;
-
-void ScaleTextStyle(RendererStyle::TextStyle* text_style,
-                    double scale_factor) {
+void ScaleTextStyle(RendererStyle::TextStyle* text_style, double scale_factor) {
   text_style->set_font_size(text_style->font_size() * scale_factor);
   text_style->set_left_padding(text_style->left_padding() * scale_factor);
   text_style->set_right_padding(text_style->right_padding() * scale_factor);
@@ -50,13 +50,24 @@ void ScaleTextStyle(RendererStyle::TextStyle* text_style,
 
 }  // namespace
 
-double GetDPIScalingFactor() {
-  const UINT dpi = ::GetDpiForSystem();
-  return static_cast<double>(dpi) / kDefaultDPI;
+double GetDPIScalingFactor(uint32_t dpi) {
+  return static_cast<double>(dpi) / USER_DEFAULT_SCREEN_DPI;
 }
 
-void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style) {
-  const double scale_factor = GetDPIScalingFactor();
+uint32_t GetDpiForPoint(int x, int y) {
+  const POINT point = {x, y};
+  const HMONITOR monitor = ::MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+  UINT dpi_x = USER_DEFAULT_SCREEN_DPI;
+  UINT dpi_y = USER_DEFAULT_SCREEN_DPI;
+  if (FAILED(::GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y))) {
+    return USER_DEFAULT_SCREEN_DPI;
+  }
+  return dpi_x;
+}
+
+void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style,
+                            uint32_t dpi) {
+  const double scale_factor = GetDPIScalingFactor(dpi);
 
   RendererStyleHandler::GetRendererStyle(style);
 

--- a/src/renderer/win32/win32_dpi_util.h
+++ b/src/renderer/win32/win32_dpi_util.h
@@ -30,17 +30,24 @@
 #ifndef MOZC_RENDERER_WIN32_WIN32_DPI_UTIL_H_
 #define MOZC_RENDERER_WIN32_WIN32_DPI_UTIL_H_
 
+#include <cstdint>
+
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
 namespace renderer {
 namespace win32 {
 
-// Returns DPI scaling factor on Windows.
-double GetDPIScalingFactor();
+// Returns the DPI scaling factor for |dpi| (i.e. |dpi| / 96.0).
+double GetDPIScalingFactor(uint32_t dpi);
 
-// Get RendererStyle adjusted with the DPI scaling factor on Windows.
-void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style);
+// Returns the effective DPI of the monitor containing the given screen
+// coordinates. Falls back to USER_DEFAULT_SCREEN_DPI on failure.
+uint32_t GetDpiForPoint(int x, int y);
+
+// Populates |style| with the default RendererStyle, scaled for |dpi|.
+void GetScaledRendererStyle(::mozc::renderer::RendererStyle* style,
+                            uint32_t dpi);
 
 }  // namespace win32
 }  // namespace renderer

--- a/src/renderer/win32/win32_font_util.h
+++ b/src/renderer/win32/win32_font_util.h
@@ -33,14 +33,17 @@
 #include <commctrl.h>  // for CCSIZEOF_STRUCT
 #include <windows.h>
 
+#include <cstdint>
+
 namespace mozc {
 namespace renderer {
 namespace win32 {
 
-inline LOGFONT GetMessageBoxLogFont() {
+inline LOGFONT GetMessageBoxLogFont(uint32_t dpi) {
   NONCLIENTMETRICS info = {};
   info.cbSize = CCSIZEOF_STRUCT(NONCLIENTMETRICS, iPaddedBorderWidth);
-  if (::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(info), &info, 0)) {
+  if (::SystemParametersInfoForDpi(SPI_GETNONCLIENTMETRICS, sizeof(info), &info,
+                                   0, dpi)) {
     return info.lfMessageFont;
   } else {
     // Fallback font.

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -44,6 +44,7 @@
 #include "renderer/win32/candidate_window.h"
 #include "renderer/win32/indicator_window.h"
 #include "renderer/win32/infolist_window.h"
+#include "renderer/win32/win32_dpi_util.h"
 #include "renderer/win32/win32_renderer_util.h"
 #include "renderer/window_util.h"
 
@@ -228,14 +229,24 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   // Currently, we do not use finger print.
   bool candidate_changed = true;
 
+  const Point target_point(candidate_layout.position().x,
+                           candidate_layout.position().y);
+
+  // Sync both windows to the DPI of the monitor where the candidate window
+  // is about to be placed. This makes their first-frame layout correct when
+  // the target app is on a different-DPI monitor than where the windows were
+  // last shown — WM_DPICHANGED would otherwise fire only during the
+  // subsequent SetWindowPos, after the size has already been computed at
+  // the stale DPI.
+  const uint32_t target_dpi = GetDpiForPoint(target_point.x, target_point.y);
+  main_window_->UpdateDpi(target_dpi);
+  infolist_window_->UpdateDpi(target_dpi);
+
   if (candidate_changed &&
       (candidate_window.display_type() == commands::MAIN)) {
     main_window_->UpdateLayout(candidate_window);
   }
   const Size main_window_size = main_window_->GetLayoutSize();
-
-  const Point target_point(candidate_layout.position().x,
-                           candidate_layout.position().y);
 
   // Obtain the monitor's working area
   Rect working_area;


### PR DESCRIPTION
## Description
This is part of our ongoing effort to fully conform Per-Monitor DPI v2 protocol in Windows (#831).

With this commit, both the candidate window and the infolist window become fully aware of dynamic DPI changes. The indicator window and icons managed by text input processor (TIP) DLLs remain unchanged.

The key implementation idea is to not rely on `WM_DPICHANGED` message. It is really tempting to implement `WM_DPICHANGED` handler, but it turns out to be redundant for our use cases. Consider the following two cases explained in the` WM_DPICHANGED` message [document](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-dpichanged).

 1. When the candidate/infolist window is moving into the monitor with a different DPI. In this case, `win32::WindowManager` should be aware of which monitor the candidate/infolist window will be displayed on, and can let the candidate/infolist window know the new DPI without relying on the `WM_DPICHANGED` message.

 2. When the DPI of the current monitor changes while the candidate/infolist window is visible. In this case, the target application window typically re-renders to adapt to the new DPI, which then triggers a fresh layout pass on our candidate/infolist window. As explained above, `win32::WindowManager` always checks the DPI of the target monitor without relying on the `WM_DPICHANGED` message.

Both cases arise because the candidate and infolist windows behave like popups anchored to the cursor location in the target application window; `WM_DPICHANGED` is primarily meaningful for top-level windows that users can drag and move across the monitors.

Other than that, the implementation is rather straightforward: we just need to make sure to keep propagating the DPI information to the text renderer and to update the DPI-dependent resources when the DPI changes.

Closes #1459.

## Issue IDs

 * https://github.com/google/mozc/issues/831
 * https://github.com/google/mozc/issues/1459

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Install Mozc
   2. Change the text scaling on the monitor to 200%
   3. Open Nodepad
   4. Type something to confirm that Mozc's candidate window uses the scaled font size
   5. Change the text scaling on the monitor to 300%
   6. Type something to confirm that Mozc's candidate window uses the scaled font size
