### PR TITLE
Fix name shadowing in QtIpcServer constructor

### DIFF
--- a/src/renderer/qt/qt_ipc_server.cc
+++ b/src/renderer/qt/qt_ipc_server.cc
@@ -44,7 +44,7 @@ constexpr int kNumConnections = 10;
 constexpr absl::Duration kIPCServerTimeOut = absl::Milliseconds(1000);
 constexpr char kServiceName[] = "renderer";
 
-[[maybe_unused]] std::string GetServiceName() {
+std::string MakeServiceName() {
   std::string name = kServiceName;
   const std::string desktop_name = SystemUtil::GetDesktopNameAsString();
   if (!desktop_name.empty()) {
@@ -56,7 +56,7 @@ constexpr char kServiceName[] = "renderer";
 }  // namespace
 
 QtIpcServer::QtIpcServer()
-    : IPCServer(GetServiceName(), kNumConnections, kIPCServerTimeOut) {}
+    : IPCServer(MakeServiceName(), kNumConnections, kIPCServerTimeOut) {}
 QtIpcServer::~QtIpcServer() = default;
 
 bool QtIpcServer::Process(absl::string_view request, std::string *response) {


### PR DESCRIPTION
IPCServer::GetServiceName() was added in 858f8c0b2 as a public member returning name_.
In QtIpcServer's constructor initializer list, the call to GetServiceName() resolved to the member function rather than the free function in the anonymous namespace, returning a reference to the not-yet-initialized name_ member. This caused name_ to be copy-constructed from itself with a garbage size, throwing std::bad_alloc and crashing mozc_renderer on startup.

Rename the free function to MakeServiceName() to eliminate the clash.

## Description


## Issue IDs
Issue and/or discussion IDs related to this pull request.

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: [Ubuntu 26.04]
 - C Compiler: [Clang 21.0.0]
 - Steps:
   1. Install from source
   2. Attempt to start mozc-renderer
   3. get `std::bad_alloc` error and no completion window display

## Additional context
I was getting a bad alloc and it seemed strange, therefore I went on doing some debugging and it seems like the funcion `GetServiceName()` is duplicated, once in `src/ipc/ipc.h:265` as `IPCServer::GetServiceName()` ill call it (1) and again in `src/renderer/qt_icp_server.cc:47` as `GetServiceName()` all call it (2), assuming that in `src/renderer/qt/qt_ipc_server.cc:47` in the constructor for `QtIpcServer::QtIpcServer()` intended to call (2) i.e. the internal function described in that same file, yet I found that under Clang 21.0.0 the function called is (1) i.e. the IPCServer one.

For the fix i just changed the name and removed the `[[maybe unused]]` (it was no longer showing a compilation error since it was now used) since im not quite sure what naming convention should be recomended, regardless something should probably be done towards deduplicating that call.

First PR here, sorry if I did something wrong.

