### PR TITLE
Set `BAZEL_VC` to be consistent with `vs_util.py`

### DIFF
--- a/src/bazel/bazel_wrapper/bazel.bat
+++ b/src/bazel/bazel_wrapper/bazel.bat
@@ -13,12 +13,18 @@ set TMP_MOZC_BASH_PATH=%TMP_MOZC_SRC_DIR%\third_party\msys64\usr\bin\bash.exe
 if exist %TMP_MOZC_BASH_PATH% set BAZEL_SH=%TMP_MOZC_BASH_PATH%
 set TMP_MOZC_BASH_PATH=
 
+rem Inject BAZEL_VC via vs_util.py if the user has not set it explicitly.
+if not defined BAZEL_VC (
+  for /f "usebackq delims=" %%P in (`python "%TMP_MOZC_SRC_DIR%\build_tools\vs_util.py"`) do set BAZEL_VC=%%P
+)
+
 set TMP_MOZC_BAZEL_WRAPPER_DIR=
 set TMP_MOZC_SRC_DIR=
 
 :: For debugging.
 echo BAZEL_LLVM=%BAZEL_LLVM%
 echo BAZEL_REAL=%BAZEL_REAL%
+echo BAZEL_VC=%BAZEL_VC%
 
 %BAZEL_REAL% %* & call:myexit
 

--- a/src/build_tools/vs_util.py
+++ b/src/build_tools/vs_util.py
@@ -30,6 +30,7 @@
 
 """A helper script to use Visual Studio."""
 
+import argparse
 import json
 import os
 import pathlib
@@ -188,3 +189,37 @@ def get_vs_env_vars(
   if exitcode != 0:
     raise ChildProcessError(f'Failed to execute {vcvarsall}')
   return json.loads(stdout.decode('ascii'))
+
+
+def get_vc_dir(
+    arch: str, vcvarsall_path_hint: Union[str, None] = None
+) -> pathlib.Path:
+  """Returns the VC directory path for use as 'BAZEL_VC'.
+
+  Args:
+    arch: host/target architecture
+    vcvarsall_path_hint: optional path to vcvarsall.bat
+
+  Returns:
+    The VC directory path, e.g. 'C:\\...\\Community\\VC'.
+
+  Raises:
+    FileNotFoundError: When 'vcvarsall.bat' cannot be found.
+  """
+  # vcvarsall.bat lives at <VC>\Auxiliary\Build\vcvarsall.bat
+  return get_vcvarsall(arch, vcvarsall_path_hint).parent.parent.parent
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+      description='Print the VC directory (value suitable for BAZEL_VC).'
+  )
+  parser.add_argument('--arch', default='x64')
+  parser.add_argument('--vcvarsall_path', default=None)
+  args = parser.parse_args()
+  print(get_vc_dir(args.arch, args.vcvarsall_path))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
## Description
This is a preparatory change for fully supporting Visual Studio 2026 to build Mozc.

Today, `build_qt.py` (via `vs_util.py`) and Bazel's `rules_cc` use independent Visual Studio detection paths. `vs_util.py` pins via `vswhere`'s `-version` filter; Bazel's `local_config_cc` runs `vswhere` with `-latest` and no filter. On a machine with more than one VS installed, the two can resolve to different toolchains, so Qt and the Mozc binaries end up built against different MSVC runtimes. Furthermore, build_installer.py always tries to bundle `Microsoft.VC143.CRT`, which is for Visual Studio 2022. If the user has Visual Studio 2026 installed, we end up with using Visual Studio 2026 to build Mozc executables but bundling the Visual Studio 2022 CRT. While it generally works, it is not ideal and can cause unexpected issues.

Add a CLI to return `vs_util.get_vc_dir()`, and have `bazel.bat` export the result as `BAZEL_VC` when the user has not already set it. Bazel's detection cascade prefers `BAZEL_VC` over its own `vswhere` call, so both layers converge on the same Visual Studio.

Note that `vs_util.py` is still pinned to Visual Studio 2022, so this change does not yet enable Visual Studio 2026, but it at least fixes the unexpected mixed toolchain issue on machines with both versions installed. Actually enabling Visual Studio 2026 will be done in a subsequent commit.

## Issue IDs

 * https://github.com/google/mozc/issues/1487

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Make sure both Visual Studio 2022 and Visual Studio 2026 are installed
   2. Build `Mozc64.msi`
   3. Confirm it still works.
