### PR TITLE
Remove redundant build options from instructions

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: bazel build
         working-directory: ./src
         run: |
-          bazelisk build --config oss_linux package --config release_build
+          bazelisk build package --config release_build
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v6
@@ -68,4 +68,4 @@ jobs:
       - name: bazel test
         working-directory: ./src
         run: |
-          bazelisk test ... --config oss_linux -c dbg
+          bazelisk test ... -c dbg

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,12 +41,11 @@ jobs:
         working-directory: ./src
         run: |
           python3 build_tools/build_qt.py --release --confirm_license --macos_cpus=arm64
-          echo "MOZC_QT_PATH=${PWD}/third_party/qt" >> $GITHUB_ENV
 
       - name: bazel build
         working-directory: ./src
         run: |
-          bazelisk build --config oss_macos package --macos_cpus=arm64 --config release_build
+          bazelisk build package --macos_cpus=arm64 --config release_build
 
       - name: upload artifacts
         uses: actions/upload-artifact@v6
@@ -83,12 +82,11 @@ jobs:
         working-directory: ./src
         run: |
           python3 build_tools/build_qt.py --release --confirm_license --macos_cpus=x86_64
-          echo "MOZC_QT_PATH=${PWD}/third_party/qt" >> $GITHUB_ENV
 
       - name: bazel build
         working-directory: ./src
         run: |
-          bazelisk build --config oss_macos package --macos_cpus=x86_64 --config release_build
+          bazelisk build package --macos_cpus=x86_64 --config release_build
 
       - name: upload artifacts
         uses: actions/upload-artifact@v6
@@ -125,12 +123,11 @@ jobs:
         working-directory: ./src
         run: |
           python3 build_tools/build_qt.py --release --confirm_license --macos_cpus=x86_64,arm64
-          echo "MOZC_QT_PATH=${PWD}/third_party/qt" >> $GITHUB_ENV
 
       - name: bazel build
         working-directory: ./src
         run: |
-          bazelisk build --config oss_macos package --macos_cpus=x86_64,arm64 --config release_build
+          bazelisk build package --macos_cpus=x86_64,arm64 --config release_build
 
       - name: upload artifacts
         uses: actions/upload-artifact@v6
@@ -166,7 +163,7 @@ jobs:
       - name: bazel test
         working-directory: ./src
         run: |
-          bazelisk test ... --config oss_macos --build_tests_only -c dbg
+          bazelisk test ... --build_tests_only -c dbg
 
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build --config oss_windows --config release_build package
+          bazelisk build --config release_build package
 
       - name: upload Mozc64_x64.msi
         uses: actions/upload-artifact@v6
@@ -110,7 +110,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build --config oss_windows --config release_build --config win_universal_installer package
+          bazelisk build --config release_build --config win_universal_installer package
 
       - name: upload Mozc64_universal.msi
         uses: actions/upload-artifact@v6
@@ -163,7 +163,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build package --config oss_windows --config release_build --platforms=//:windows-arm64
+          bazelisk build package --config release_build --platforms=//:windows-arm64
 
       - name: upload Mozc64_arm64.msi
         uses: actions/upload-artifact@v6
@@ -203,7 +203,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk test ... --config oss_windows -c dbg --build_tests_only
+          bazelisk test ... -c dbg --build_tests_only
 
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".

--- a/docs/build_mozc_for_linux.md
+++ b/docs/build_mozc_for_linux.md
@@ -13,7 +13,7 @@ descriptions below and make sure the operations before running them.
 git clone https://github.com/google/mozc.git
 cd mozc/src
 
-bazelisk build package --config oss_linux --config release_build
+bazelisk build package --config release_build
 ```
 
 `bazel-bin/unix/mozc.zip` contains built files.
@@ -114,7 +114,7 @@ You should be able to build Mozc for Linux desktop as follows, assuming
 `bazelisk` is in your `$PATH`.
 
 ```sh
-bazelisk build package --config oss_linux --config release_build
+bazelisk build package --config release_build
 ```
 
 `package` is an alias to build Mozc executables and archive them into
@@ -172,7 +172,7 @@ git update-index --no-assume-unchanged src/config.bzl
 ### Run all tests
 
 ```sh
-bazelisk test ... --config oss_linux --build_tests_only -c dbg
+bazelisk test ... --build_tests_only -c dbg
 ```
 
 *   `...` means all targets under the current and subdirectories.
@@ -180,7 +180,7 @@ bazelisk test ... --config oss_linux --build_tests_only -c dbg
 ### Run tests under the specific directories
 
 ```sh
-bazelisk test base/... composer/... --config oss_linux --build_tests_only -c dbg
+bazelisk test base/... composer/... --build_tests_only -c dbg
 ```
 
 *   `<dir>/...` means all targets under the `<dir>/` directory.
@@ -188,7 +188,7 @@ bazelisk test base/... composer/... --config oss_linux --build_tests_only -c dbg
 ### Run tests without the specific directories
 
 ```sh
-bazelisk test ... --config oss_linux --build_tests_only -c dbg -- -base/...
+bazelisk test ... --build_tests_only -c dbg -- -base/...
 ```
 
 *   `--` means the end of the flags which start from `-`.
@@ -197,7 +197,7 @@ bazelisk test ... --config oss_linux --build_tests_only -c dbg -- -base/...
 ### Run the specific test
 
 ```sh
-bazelisk test base:util_test --config oss_linux -c dbg
+bazelisk test base:util_test -c dbg
 ```
 
 *   `util_test` is defined in `base/BUILD.bazel`.
@@ -205,7 +205,7 @@ bazelisk test base:util_test --config oss_linux -c dbg
 ### Output logs to stderr
 
 ```
-bazelisk test base:util_test --config oss_linux --test_arg=--stderrthreshold=0 --test_output=all
+bazelisk test base:util_test --test_arg=--stderrthreshold=0 --test_output=all
 ```
 
 *   The `--test_arg=--stderrthreshold=0 --test_output=all` flags show the

--- a/docs/build_mozc_in_osx.md
+++ b/docs/build_mozc_in_osx.md
@@ -18,7 +18,7 @@ python3 build_tools/update_deps.py
 # CMake is also required to build Qt.
 python3 build_tools/build_qt.py --release --confirm_license
 
-MOZC_QT_PATH=${PWD}/third_party/qt bazelisk build package --config oss_macos --config release_build
+bazelisk build package --config release_build
 open bazel-bin/mac/Mozc.pkg
 ```
 
@@ -120,7 +120,7 @@ brew install cmake
 ### Build installer
 
 ```
-MOZC_QT_PATH=${PWD}/third_party/qt bazelisk build package --config oss_macos --config release_build
+bazelisk build package --config release_build
 open bazel-bin/mac/Mozc.pkg
 ```
 
@@ -130,7 +130,7 @@ To build an Intel64 macOS binary regardless of the host CPU architecture.
 
 ```
 python3 build_tools/build_qt.py --release --debug --confirm_license --macos_cpus=x64_64
-MOZC_QT_PATH=${PWD}/third_party/qt bazelisk build package --config oss_macos --config release_build --macos_cpus=x64_64
+bazelisk build package --config release_build --macos_cpus=x64_64
 open bazel-bin/mac/Mozc.pkg
 ```
 
@@ -138,14 +138,14 @@ To build a Universal macOS Binary both x86_64 and arm64.
 
 ```
 python3 build_tools/build_qt.py --release --debug --confirm_license --macos_cpus=x86_64,arm64
-MOZC_QT_PATH=${PWD}/third_party/qt bazelisk build package --config oss_macos --config release_build --macos_cpus=x86_64,arm64
+bazelisk build package --config release_build --macos_cpus=x86_64,arm64
 open bazel-bin/mac/Mozc.pkg
 ```
 
 ### Unit tests
 
 ```
-MOZC_QT_PATH=${PWD}/third_party/qt bazelisk test ... --config oss_macos --build_tests_only -c dbg
+bazelisk test ... --build_tests_only -c dbg
 ```
 
 See [build Mozc in Docker](build_mozc_in_docker.md#unittests) for details.

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -15,7 +15,7 @@ cd mozc\src
 
 python build_tools/update_deps.py
 python build_tools/build_qt.py --release --confirm_license
-bazelisk build --config oss_windows --config release_build package
+bazelisk build --config release_build package
 
 python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 ```


### PR DESCRIPTION
## Description
With recent commits (51ee0a77d00709ebbb977ac723ce131ed4d1fbe2)(5d460978ef0ba5509651016168930de02a999386), we can remove redundant build options from our build instructions and GitHub Actions workflows.

Key changes are:
 - Removed `--config oss_{linux,macos,windows}` from build instructions and workflows as `--enable_platform_specific_config` option automatically now sets them.
 - Removed `MOZC_QT_PATH` environment variable from build instructions and workflows from macOS build instructions and workflows as its default value is already set to `third_party/qt`, where `build_qt.py` deploys Qt by default.

There must be no functional change in the final artifacts, but the instructions and workflows are now simplified.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. GitHub Actions still pass
