### PR TITLE
Remove `Singleton` from `ModeSwitchingHandler`

### DIFF
--- a/src/composer/BUILD.bazel
+++ b/src/composer/BUILD.bazel
@@ -399,8 +399,6 @@ mozc_cc_library(
     srcs = ["mode_switching_handler.cc"],
     hdrs = ["mode_switching_handler.h"],
     deps = [
-        "//base:singleton",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/src/composer/composer.cc
+++ b/src/composer/composer.cc
@@ -1110,8 +1110,7 @@ void Composer::AutoSwitchMode() {
       GetTransliterator(transliteration::HALF_ASCII));
 
   const ModeSwitchingHandler::Rule mode_switching =
-      ModeSwitchingHandler::GetModeSwitchingHandler()->GetModeSwitchingRule(
-          key);
+      ModeSwitchingHandler::GetModeSwitchingRule(key);
 
   // |display_mode| affects the existing composition the user typed.
   switch (mode_switching.display_mode) {

--- a/src/composer/mode_switching_handler.cc
+++ b/src/composer/mode_switching_handler.cc
@@ -32,33 +32,25 @@
 
 #include "composer/mode_switching_handler.h"
 
-#include "absl/container/flat_hash_map.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
-#include "base/singleton.h"
 
 namespace mozc {
 namespace composer {
 
-ModeSwitchingHandler::ModeSwitchingHandler() {
-  // Default patterns are fixed right now.
-  // AddRule(key, {display_mode, input_mode});
-  AddRule("google", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("Google", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("Chrome", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("chrome", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("Android", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("android", {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE});
-  AddRule("http", {HALF_ALPHANUMERIC, HALF_ALPHANUMERIC});
-  AddRule("www.", {HALF_ALPHANUMERIC, HALF_ALPHANUMERIC});
-  AddRule("\\\\", {HALF_ALPHANUMERIC, HALF_ALPHANUMERIC});
-}
-
 ModeSwitchingHandler::Rule ModeSwitchingHandler::GetModeSwitchingRule(
-    absl::string_view key) const {
-  const auto it = patterns_.find(key);
-  if (it != patterns_.end()) {
-    return it->second;
+    absl::string_view key) {
+  // Modern compilers are smart enough to optimize this kind of multiple string
+  // comparisons. Neither flat_hash_map nor sorted array is necessary for this
+  // small number of patterns.
+  if (key == "google" || key == "Google" ||
+      key == "Chrome" || key == "chrome" ||
+      key == "Android" || key == "android") {
+      return {PREFERRED_ALPHANUMERIC, REVERT_TO_PREVIOUS_MODE};
+  }
+
+  if (key == "http" || key == "www." || key == "\\\\") {
+      return {HALF_ALPHANUMERIC, HALF_ALPHANUMERIC};
   }
 
   if (IsDriveLetter(key)) {
@@ -71,14 +63,6 @@ ModeSwitchingHandler::Rule ModeSwitchingHandler::GetModeSwitchingRule(
 bool ModeSwitchingHandler::IsDriveLetter(absl::string_view key) {
   return key.size() == 3 && absl::ascii_isalpha(key[0]) && key[1] == ':' &&
          key[2] == '\\';
-}
-
-void ModeSwitchingHandler::AddRule(absl::string_view key, const Rule rule) {
-  patterns_.emplace(key, rule);
-}
-
-ModeSwitchingHandler* ModeSwitchingHandler::GetModeSwitchingHandler() {
-  return Singleton<ModeSwitchingHandler>::get();
 }
 
 }  // namespace composer

--- a/src/composer/mode_switching_handler.h
+++ b/src/composer/mode_switching_handler.h
@@ -33,9 +33,6 @@
 #ifndef MOZC_COMPOSER_MODE_SWITCHING_HANDLER_H_
 #define MOZC_COMPOSER_MODE_SWITCHING_HANDLER_H_
 
-#include <string>
-
-#include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 
 namespace mozc {
@@ -43,8 +40,8 @@ namespace composer {
 
 class ModeSwitchingHandler {
  public:
-  ModeSwitchingHandler();
-  ~ModeSwitchingHandler() = default;
+  ModeSwitchingHandler() = delete;
+  ~ModeSwitchingHandler() = delete;
 
   enum ModeSwitching {
     NO_CHANGE,
@@ -65,21 +62,12 @@ class ModeSwitchingHandler {
   // Returns a Rule for the current preedit. |key| is the string which the user
   // actually typed. display_mode and input_mode are stored rules controlling
   // the composer. Returns NO_CHANGE if the key doesn't match the stored rules.
-  Rule GetModeSwitchingRule(absl::string_view key) const;
-
-  // Gets the singleton instance of this class.
-  static ModeSwitchingHandler* GetModeSwitchingHandler();
+  static Rule GetModeSwitchingRule(absl::string_view key);
 
   // Matcher to Windows drive letters like "C:\".
   // TODO(team): This static method is internal use only.  It's public for
   // testing purpose.
   static bool IsDriveLetter(absl::string_view key);
-
- private:
-  // Adds a rule for mode switching. The rule is passed by value as it's small.
-  void AddRule(absl::string_view key, Rule rule);
-
-  absl::flat_hash_map<std::string, Rule> patterns_;
 };
 
 }  // namespace composer

--- a/src/composer/mode_switching_handler_test.cc
+++ b/src/composer/mode_switching_handler_test.cc
@@ -48,51 +48,49 @@ MATCHER_P2(RuleEq, display_mode, input_mode,
 }
 
 TEST(ModeSwitchingHandlerTest, GetModeSwitchingRule) {
-  ModeSwitchingHandler handler;
-
-  EXPECT_THAT(handler.GetModeSwitchingRule("google"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("google"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("Google"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("Google"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("Chrome"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("Chrome"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("chrome"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("chrome"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("Android"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("Android"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("android"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("android"),
               RuleEq(ModeSwitchingHandler::PREFERRED_ALPHANUMERIC,
                      ModeSwitchingHandler::REVERT_TO_PREVIOUS_MODE));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("http"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("http"),
               RuleEq(ModeSwitchingHandler::HALF_ALPHANUMERIC,
                      ModeSwitchingHandler::HALF_ALPHANUMERIC));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("www."),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("www."),
               RuleEq(ModeSwitchingHandler::HALF_ALPHANUMERIC,
                      ModeSwitchingHandler::HALF_ALPHANUMERIC));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("\\\\"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("\\\\"),
               RuleEq(ModeSwitchingHandler::HALF_ALPHANUMERIC,
                      ModeSwitchingHandler::HALF_ALPHANUMERIC));
 
-  EXPECT_THAT(handler.GetModeSwitchingRule("C:\\"),
+  EXPECT_THAT(ModeSwitchingHandler::GetModeSwitchingRule("C:\\"),
               RuleEq(ModeSwitchingHandler::HALF_ALPHANUMERIC,
                      ModeSwitchingHandler::HALF_ALPHANUMERIC));
 
   // Normal text should return NO_CHANGE.
   EXPECT_THAT(
-      handler.GetModeSwitchingRule("foobar"),
+      ModeSwitchingHandler::GetModeSwitchingRule("foobar"),
       RuleEq(ModeSwitchingHandler::NO_CHANGE, ModeSwitchingHandler::NO_CHANGE));
 }
 


### PR DESCRIPTION
## Description
As part of our ongoing efforts to remove the dependency on `Singleton`, this commit rewrites `composer::ModeSwitchingHandler` without the `Singleton` class dependency.

This is purely mechanical refactoring, and there must be no observable behavioral change in production.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. `bazelisk test //composer:mode_switching_handler_test`
