### PR TITLE
Fix MSVC extension warnings in `WinAPITestHelper`

### DIFF
--- a/src/base/win32/win_api_test_helper.cc
+++ b/src/base/win32/win_api_test_helper.cc
@@ -114,7 +114,8 @@ class HookTargetInfo {
         continue;
       }
       const FunctionPointer original_proc_address =
-          ::GetProcAddress(module_handle, request.proc_name.c_str());
+          reinterpret_cast<FunctionPointer>(
+              ::GetProcAddress(module_handle, request.proc_name.c_str()));
       if (original_proc_address == nullptr) {
         LOG(FATAL) << "GetProcAddress returned nullptr.";
         continue;

--- a/src/base/win32/win_api_test_helper.h
+++ b/src/base/win32/win_api_test_helper.h
@@ -74,7 +74,7 @@ class WinAPITestHelper {
   class RestoreInfo;
   typedef RestoreInfo* RestoreInfoHandle;
 
-  typedef void* FunctionPointer;
+  using FunctionPointer = void (*)();
   struct HookRequest {
    public:
     HookRequest(const std::string& src_module, const std::string& src_proc_name,
@@ -88,7 +88,8 @@ class WinAPITestHelper {
   static HookRequest MakeHookRequest(const std::string& module,
                                      const std::string& proc_name,
                                      const NewProcType& new_proc_ref) {
-    return HookRequest(module, proc_name, &new_proc_ref);
+    return HookRequest(module, proc_name,
+                       reinterpret_cast<FunctionPointer>(&new_proc_ref));
   }
 
   // Overwrites on-memory Import Address Table (IAT) of |target_module| with


### PR DESCRIPTION
## Description
The implicit function-to-object pointer conversions triggered Clang's `-Wmicrosoft-cast` warning. Let's use the alias to a generic function-pointer type `void (*)()` and `reinterpret_cast` at the two boundaries that produce specific function-pointer types.

`WinAPITestHelper` is used only for unit tests, so there must be no risk in the production code.

## Issue IDs
N/A

## Steps to test new behaviors
 - OS: Windows
 - Steps:
   1. Confirm all tests still pass
