### PR TITLE
Remove `--timeout`/`--restricted` from renderer

### DIFF
--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -122,7 +122,6 @@ mozc_cc_library(
         "//protocol:commands_cc_proto",
         "//protocol:config_cc_proto",
         "//protocol:renderer_cc_proto",
-        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
@@ -338,6 +337,5 @@ mozc_cc_library(
         "//base:init_mozc",
         "//base:run_level",
         "//base:system_util",
-        "@com_google_absl//absl/flags:flag",
     ],
 )

--- a/src/renderer/init_mozc_renderer.cc
+++ b/src/renderer/init_mozc_renderer.cc
@@ -31,13 +31,9 @@
 
 #include <cstdlib>
 
-#include "absl/flags/declare.h"
-#include "absl/flags/flag.h"
 #include "base/init_mozc.h"
 #include "base/run_level.h"
 #include "base/system_util.h"
-
-ABSL_DECLARE_FLAG(bool, restricted);
 
 namespace mozc::renderer {
 
@@ -50,10 +46,6 @@ void InitMozcRenderer(const char* argv0, int* argc, char*** argv) {
 
   mozc::SystemUtil::DisableIME();
 
-  // restricted mode
-  if (run_level == mozc::RunLevel::RESTRICTED) {
-    absl::SetFlag(&FLAGS_restricted, true);
-  }
   mozc::InitMozc(argv0, argc, argv);
 }
 

--- a/src/renderer/qt/BUILD.bazel
+++ b/src/renderer/qt/BUILD.bazel
@@ -99,7 +99,6 @@ mozc_cc_qt_library(
         "//ipc:named_event",
         "//protocol:config_cc_proto",
         "//protocol:renderer_cc_proto",
-        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/log",
     ],
 )

--- a/src/renderer/qt/qt_server.cc
+++ b/src/renderer/qt/qt_server.cc
@@ -35,11 +35,8 @@
 
 #include <QApplication>
 #include <QMetaType>
-#include <algorithm>
-#include <cstdint>
 #include <string>
 
-#include "absl/flags/flag.h"
 #include "absl/log/log.h"
 #include "base/system_util.h"
 #include "base/vlog.h"
@@ -51,12 +48,6 @@
 #ifndef NDEBUG
 #include "config/config_handler.h"
 #endif  // NDEBUG
-
-// By default, mozc_renderer quits when user-input continues to be
-// idle for 10min.
-ABSL_FLAG(int32_t, timeout, 10 * 60, "timeout of candidate server (sec)");
-ABSL_FLAG(bool, restricted, false,
-          "launch candidates server with restricted mode");
 
 Q_DECLARE_METATYPE(std::string);
 
@@ -77,16 +68,7 @@ std::string GetServiceName() {
 }
 }  // namespace
 
-QtServer::QtServer() : timeout_(0) {
-  if (absl::GetFlag(FLAGS_restricted)) {
-    absl::SetFlag(&FLAGS_timeout,
-                  // set 60 sec with restricted mode
-                  std::min(absl::GetFlag(FLAGS_timeout), 60));
-  }
-
-  timeout_ = 1000 * std::clamp(absl::GetFlag(FLAGS_timeout), 3, 24 * 60 * 60);
-  MOZC_VLOG(2) << "timeout is set to be : " << timeout_;
-
+QtServer::QtServer() {
 #ifndef NDEBUG
   mozc::internal::SetConfigVLogLevel(
       config::ConfigHandler::GetSharedConfig()->verbose_level());
@@ -134,8 +116,6 @@ bool QtServer::ExecCommandInternal(const commands::RendererCommand &command) {
 
   return renderer_.ExecCommand(command);
 }
-
-uint32_t QtServer::timeout() const { return timeout_; }
 
 }  // namespace renderer
 }  // namespace mozc

--- a/src/renderer/qt/qt_server.h
+++ b/src/renderer/qt/qt_server.h
@@ -30,7 +30,6 @@
 #ifndef MOZC_RENDERER_QT_QT_SERVER_H_
 #define MOZC_RENDERER_QT_QT_SERVER_H_
 
-#include <cstdint>
 #include <string>
 
 #include "renderer/qt/qt_ipc_thread.h"
@@ -63,16 +62,10 @@ class QtServer : public QObject {
   // of AsyncExecCommand()
   bool ExecCommandInternal(const commands::RendererCommand& command);
 
-  // return timeout (msec) passed by FLAGS_timeout
-  uint32_t timeout() const;
-
   QtWindowManager renderer_;
 
  private:
   QtIpcThread ipc_thread_;
-
-  // From RendererServer
-  uint32_t timeout_;
 };
 
 }  // namespace renderer

--- a/src/renderer/renderer_server.cc
+++ b/src/renderer/renderer_server.cc
@@ -29,12 +29,10 @@
 
 #include "renderer/renderer_server.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>
 
-#include "absl/flags/flag.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -58,12 +56,6 @@
 #include "base/const.h"
 #include "base/win32/win_util.h"
 #endif  // _WIN32
-
-// By default, mozc_renderer quits when user-input continues to be
-// idle for 10min.
-ABSL_FLAG(int32_t, timeout, 10 * 60, "timeout of candidate server (sec)");
-ABSL_FLAG(bool, restricted, false,
-          "launch candidates server with restricted mode");
 
 namespace mozc {
 namespace renderer {
@@ -141,7 +133,6 @@ RendererServer::RendererServer(bool for_testing)
     : IPCServer(ConstructServiceName(for_testing), kNumConnections,
                 kIPCServerTimeOut),
       renderer_interface_(nullptr),
-      timeout_(0),
       send_command_(std::make_unique<RendererServerSendCommand>()) {
   watch_dog_ = std::make_unique<ProcessWatchDog>(
       [this](ProcessWatchDog::SignalType type) {
@@ -159,14 +150,6 @@ RendererServer::RendererServer(bool for_testing)
           }
         }
       });
-  if (absl::GetFlag(FLAGS_restricted)) {
-    absl::SetFlag(&FLAGS_timeout,
-                  // set 60sec with restricted mode
-                  std::min(absl::GetFlag(FLAGS_timeout), 60));
-  }
-
-  timeout_ = 1000 * std::clamp(absl::GetFlag(FLAGS_timeout), 3, 24 * 60 * 60);
-  MOZC_VLOG(2) << "timeout is set to be : " << timeout_;
 
 #ifndef NDEBUG
   mozc::internal::SetConfigVLogLevel(
@@ -252,6 +235,5 @@ bool RendererServer::ExecCommandInternal(
   return false;
 }
 
-uint32_t RendererServer::timeout() const { return timeout_; }
 }  // namespace renderer
 }  // namespace mozc

--- a/src/renderer/renderer_server.h
+++ b/src/renderer/renderer_server.h
@@ -30,7 +30,6 @@
 #ifndef MOZC_RENDERER_RENDERER_SERVER_H_
 #define MOZC_RENDERER_RENDERER_SERVER_H_
 
-#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -88,13 +87,9 @@ class RendererServer : public IPCServer {
   // of AsyncExecCommand()
   bool ExecCommandInternal(const commands::RendererCommand& command);
 
-  // return timeout (msec) passed by FLAGS_timeout
-  uint32_t timeout() const;
-
   RendererInterface* renderer_interface_ = nullptr;
 
  private:
-  uint32_t timeout_;
   std::unique_ptr<ProcessWatchDog> watch_dog_;
   std::unique_ptr<RendererServerSendCommand> send_command_;
 };


### PR DESCRIPTION
## Description
As part of our ongoing effort to deprecate restricted mode, we are removing the `--timeout` and `--restricted` flags from `mozc_renderer`.

These flags had actually used only in Windows until recently, but with the recent commit (ca34c8df01dcc13e8600a9b80ee2215ab19eaa47) there remains no code path that specifies these flags. Therefore we can safely remove these unused flags and the related code.

## Issue IDs
 * https://github.com/google/mozc/issues/1376

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm GitHub Actions still pass
