### PR TITLE
Allow building Mozc with Visual Studio 2026

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -45,7 +45,12 @@ Building Mozc on Windows requires the following software.
 *   `.NET 6` or later (for `dotnet` command).
 *   [Bazelisk](https://github.com/bazelbuild/bazelisk)
 
-> [!NOTE] Bazelisk is a wrapper of [Bazel](https://bazel.build) that allows you
+> [!TIP]
+> Visual Studio 2026 Community Edition is also supported to build Mozc. When
+> both VS 2022 and 2026 are installed, VS 2022 will be used.
+
+> [!NOTE]
+> Bazelisk is a wrapper of [Bazel](https://bazel.build) that allows you
 > to use a specific version of Bazel.
 
 ### Download the repository from GitHub

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -39,6 +39,7 @@ build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows
 build:windows_env --extra_toolchains=@local_config_cc//:cc-toolchain-x64_x86_windows-clang-cl
 build:windows_env --host_platform=//:host-windows-clang-cl
 build:windows_env --repo_env=BAZEL_WIN32_WINNT=/D_WIN32_WINNT=0x0A00
+build:windows_env --action_env=BAZEL_VC
 
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like

--- a/src/build_tools/vs_util.py
+++ b/src/build_tools/vs_util.py
@@ -77,7 +77,7 @@ def get_vcvarsall(
         r' --vcvarsall_path=C:\VS\VC\Auxiliary\Build\vcvarsall.bat'
     )
 
-  cmd = [
+  base_cmd = [
       str(vswhere_path),
       '-products',
       'Microsoft.VisualStudio.Product.Enterprise',
@@ -86,41 +86,43 @@ def get_vcvarsall(
       'Microsoft.VisualStudio.Product.BuildTools',
       '-find',
       'VC/Auxiliary/Build/vcvarsall.bat',
-      '-version',
-      '[17,18)',  # See https://github.com/microsoft/vswhere/wiki/Versions
       '-latest',
       '-utf8',
-  ]
-  cmd += [
       '-requires',
       'Microsoft.VisualStudio.Component.VC.Redist.14.Latest',
   ]
   if arch.endswith('arm64'):
-    cmd += ['Microsoft.VisualStudio.Component.VC.Tools.ARM64']
+    base_cmd += ['Microsoft.VisualStudio.Component.VC.Tools.ARM64']
 
-  process = subprocess.Popen(
-      cmd,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
-      shell=False,
-      text=True,
-      encoding='utf-8',
-  )
-  stdout, stderr = process.communicate()
-  exitcode = process.wait()
-  if exitcode != 0:
-    msgs = ['Failed to execute vswhere.exe']
-    if stdout:
-      msgs += ['-----stdout-----', stdout]
-    if stderr:
-      msgs += ['-----stderr-----', stderr]
-    raise ChildProcessError('\n'.join(msgs))
+  # Try Visual Studio 2022 first, then fall back to Visual Studio 2026 when
+  # VS 2022 is not installed. This keeps VS 2022 as the default on machines
+  # that have both versions installed.
+  # See https://github.com/microsoft/vswhere/wiki/Versions
+  for version_filter in ('[17,18)', '[18,19)'):
+    cmd = base_cmd + ['-version', version_filter]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+        text=True,
+        encoding='utf-8',
+    )
+    stdout, stderr = process.communicate()
+    exitcode = process.wait()
+    if exitcode != 0:
+      msgs = ['Failed to execute vswhere.exe']
+      if stdout:
+        msgs += ['-----stdout-----', stdout]
+      if stderr:
+        msgs += ['-----stderr-----', stderr]
+      raise ChildProcessError('\n'.join(msgs))
 
-  lines = stdout.splitlines()
-  if len(lines) > 0:
-    vcvarsall = pathlib.Path(lines[0])
-    if vcvarsall.exists():
-      return vcvarsall
+    lines = stdout.splitlines()
+    if len(lines) > 0:
+      vcvarsall = pathlib.Path(lines[0])
+      if vcvarsall.exists():
+        return vcvarsall
 
   msg = 'Could not find vcvarsall.bat.'
   if arch.endswith('arm64'):

--- a/src/win32/installer/BUILD.bazel
+++ b/src/win32/installer/BUILD.bazel
@@ -117,6 +117,7 @@ genrule(
         "--wxs_path=$(location " + _WXS_FILE + ")",
         "--wix_path=$(location @wix//:wix.exe)",
         "--branding=" + BRANDING,
+        "--vs_install_dir=\"$$BAZEL_VC\"",
     ]) + select({
         ":build_arm64_binaries": " " + " ".join([
             "--mozc_tip64arm=$(location //win32/tip:mozc_tip64arm)",

--- a/src/win32/installer/build_installer.py
+++ b/src/win32/installer/build_installer.py
@@ -78,13 +78,30 @@ def run_wix4(args) -> None:
   """
   arch = args.arch
 
+  vcvarsall_hint = None
+  if args.vs_install_dir:
+    vcvarsall_hint = str(
+        pathlib.Path(args.vs_install_dir).joinpath(
+            'Auxiliary', 'Build', 'vcvarsall.bat'
+        )
+    )
+
   # 'VCTOOLSREDISTDIR' environment variable is the same among x86, x64 and arm64
   # architectures, so just using 'x64' should be fine here.
-  redist_root = pathlib.Path(
-      vs_util.get_vs_env_vars('x64')['VCTOOLSREDISTDIR']
-  ).resolve()
+  vs_env = vs_util.get_vs_env_vars('x64', vcvarsall_hint)
+  redist_root = pathlib.Path(vs_env['VCTOOLSREDISTDIR']).resolve()
 
-  redist_64bit = redist_root.joinpath(arch).joinpath('Microsoft.VC143.CRT')
+  # The CRT redist subfolder is named after the platform toolset, not the
+  # MSVC compiler version: VS 2022 ships 'Microsoft.VC143.CRT' (toolset v143,
+  # MSVC 14.3x/14.4x) while VS 2026 ships 'Microsoft.VC145.CRT' (toolset
+  # v145, MSVC 14.50+). v144 was skipped. Pick the subfolder by reading the
+  # MSVC compiler minor version that vcvarsall.bat exports as
+  # 'VCTOOLSVERSION'.
+  vc_tools_minor = int(vs_env['VCTOOLSVERSION'].split('.')[1])
+  crt_subdir = (
+      'Microsoft.VC145.CRT' if vc_tools_minor >= 50 else 'Microsoft.VC143.CRT'
+  )
+  redist_64bit = redist_root.joinpath(arch).joinpath(crt_subdir)
   version_file = pathlib.Path(args.version_file).resolve()
   version = mozc_version.MozcVersion(version_file)
   credit_file = pathlib.Path(args.credit_file).resolve()
@@ -193,6 +210,12 @@ def main():
       dest='enable_win_universal_installer',
       default=False,
       action='store_true',
+  )
+  parser.add_argument(
+      '--vs_install_dir',
+      type=str,
+      default='',
+      help='Path to the Visual Studio VC directory (same as BAZEL_VC).',
   )
 
   args = parser.parse_args()


### PR DESCRIPTION
## Description
This makes Mozc build on machines where only Visual Studio 2026 is installed, while keeping Visual Studio 2022 as the default toolchain on machines where VS 2022 is available. GitHub Actions runners stay on VS 2022 for the time being; explicit opt-in to VS 2026 when both versions are present can be added in a subsequent commit.

Three coordinated changes make this work:

1. Have `vs_util.py` call `vswhere` twice when the first call returns nothing: `[17,18)` first to find VS 2022, then `[18,19)` to find VS 2026. Combined with `-latest`, the resulting matrix is:
   * Only VS 2022 installed -> picks VS 2022 (no behavior change).
   * Only VS 2026 installed -> picks VS 2026.
   * Both installed         -> picks VS 2022 (no behavior change).

2. Pass `BAZEL_VC` into the installer `genrule`'s command line as `--vs_install_dir`, derive `vcvarsall.bat` from it inside
   `build_installer.py`, and feed it to `vs_util` as the path hint. Add `--action_env=BAZEL_VC` under `config:windows_env` so Bazel propagates the value into action environments. Without this, `build_installer.py` would run its own `vswhere` lookup and could pick a different VS than Bazel did, especially on machines with multiple installs.

3. Pick the CRT redist subfolder dynamically. The subfolder is named after the platform toolset, not the MSVC compiler version: VS 2022 stayed on toolset v143 even after MSVC ticked into the 14.4x range (to avoid breaking existing project files / CI pipelines), so its redist lives under `Microsoft.VC143.CRT`. VS 2026 jumped the toolset to v145 (matching MSVC 14.50), skipping v144 entirely; its redist lives under `Microsoft.VC145.CRT`. Read `VCTOOLSVERSION` (which `vcvarsall.bat` exports next to `VCTOOLSREDISTDIR`) and pick the v145 subfolder when the minor component is >=50, otherwise v143.

Closes #1487.

## Issue IDs

 * https://github.com/google/mozc/issues/1487

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm GitHub Actions still pass
 - Steps:
   1. Install both Visual Studio 2022 and Visual Studio 2026
   2. `python build_tools/build_qt.py --release --confirm_license`
   3. `bazelisk build --config release_build package`
   5. Confirm that Mozc still is built with Visual Studio 2022
