### PR TITLE
Make `MacStatsConfigUtilImpl` stateless

### DIFF
--- a/src/config/BUILD.bazel
+++ b/src/config/BUILD.bazel
@@ -136,6 +136,12 @@ mozc_cc_test(
             "//testing:mozctest",
             "//protocol:config_cc_proto",
         ],
+        macos = [
+            "//base:file_util",
+            "//base:system_util",
+            "//testing:mozctest",
+            "@com_google_absl//absl/strings",
+        ],
         windows = [
             "//base:bits",
             "//base/win32:win_api_test_helper",

--- a/src/config/stats_config_util.cc
+++ b/src/config/stats_config_util.cc
@@ -149,31 +149,28 @@ bool WinStatsConfigUtilImpl::SetEnabled(bool val) {
 #endif  // _WIN32
 
 #ifdef __APPLE__
+constinit absl::Mutex g_mutex(absl::kConstInit);
+
+std::string GetConfigFilePath() {
+  return absl::StrCat(SystemUtil::GetUserProfileDirectory(),
+                      "/.usagestats.db");  // hidden file
+}
+
 class MacStatsConfigUtilImpl : public StatsConfigUtilInterface {
  public:
-  MacStatsConfigUtilImpl();
-
   bool IsEnabled() override;
   bool SetEnabled(bool val) override;
-
- private:
-  std::string config_file_;
-  absl::Mutex mutex_;
 };
-
-MacStatsConfigUtilImpl::MacStatsConfigUtilImpl()
-    : config_file_(absl::StrCat(SystemUtil::GetUserProfileDirectory(),
-                                "/.usagestats.db"))  //  // hidden file
-{}
 
 bool MacStatsConfigUtilImpl::IsEnabled() {
 #ifdef CHANNEL_DEV
   return true;
 #else   // CHANNEL_DEV
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(g_mutex);
   constexpr bool kDefaultValue = false;
 
-  std::ifstream ifs(config_file_.c_str(), std::ios::binary | std::ios::in);
+  const std::string config_file = GetConfigFilePath();
+  std::ifstream ifs(config_file.c_str(), std::ios::binary | std::ios::in);
 
   if (!ifs.is_open()) {
     return kDefaultValue;
@@ -197,13 +194,14 @@ bool MacStatsConfigUtilImpl::SetEnabled(bool val) {
 #ifdef CHANNEL_DEV
   return true;
 #else   // CHANNEL_DEV
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(g_mutex);
   const uint32_t value = static_cast<uint32_t>(val);
 
-  if (FileUtil::FileExists(config_file_).ok()) {
-    ::chmod(config_file_.c_str(), S_IRUSR | S_IWUSR);  // read/write
+  const std::string config_file = GetConfigFilePath();
+  if (FileUtil::FileExists(config_file).ok()) {
+    ::chmod(config_file.c_str(), S_IRUSR | S_IWUSR);  // read/write
   }
-  std::ofstream ofs(config_file_,
+  std::ofstream ofs(config_file,
                     std::ios::binary | std::ios::out | std::ios::trunc);
   if (!ofs) {
     return false;
@@ -212,7 +210,7 @@ bool MacStatsConfigUtilImpl::SetEnabled(bool val) {
   if (!ofs.good()) {
     return false;
   }
-  return 0 == ::chmod(config_file_.c_str(), S_IRUSR);  // read only
+  return 0 == ::chmod(config_file.c_str(), S_IRUSR);  // read only
 #endif  // CHANNEL_DEV
 }
 #endif  // MACOSX

--- a/src/config/stats_config_util_test.cc
+++ b/src/config/stats_config_util_test.cc
@@ -38,6 +38,18 @@
 #include "testing/mozctest.h"
 #endif  // __ANDROID__
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "base/file_util.h"
+#include "base/system_util.h"
+#include "testing/mozctest.h"
+#endif  // TARGET_OS_OSX
+#endif  // __APPLE__
+
 #ifdef _WIN32
 #include <bit>
 
@@ -673,6 +685,62 @@ TEST(StatsConfigUtilTestWin, IsEnabled) {
 }
 #endif  // !CHANNEL_DEV
 #endif  // _WIN32
+
+#ifdef TARGET_OS_OSX
+class StatsConfigUtilTestMac : public ::mozc::testing::TestWithTempUserProfile {
+ protected:
+  std::string ConfigFilePath() const {
+    return absl::StrCat(SystemUtil::GetUserProfileDirectory(),
+                        "/.usagestats.db");
+  }
+};
+
+#ifdef CHANNEL_DEV
+TEST_F(StatsConfigUtilTestMac, IsEnabledIsAlwaysTrueInDevChannel) {
+  // In dev channel, IsEnabled always returns true regardless of the file's
+  // state.
+  EXPECT_TRUE(StatsConfigUtil::IsEnabled());
+  // SetEnabled is also a no-op that always returns true.
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(false));
+  EXPECT_TRUE(StatsConfigUtil::IsEnabled());
+}
+
+TEST_F(StatsConfigUtilTestMac, SetEnabledNeverWritesFileInDevChannel) {
+  // In dev channel, SetEnabled must not touch the on-disk config file.
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(true));
+  EXPECT_FALSE(FileUtil::FileExists(ConfigFilePath()).ok());
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(false));
+  EXPECT_FALSE(FileUtil::FileExists(ConfigFilePath()).ok());
+}
+#else   // !CHANNEL_DEV
+TEST_F(StatsConfigUtilTestMac, IsEnabledDefaultsToFalse) {
+  // Without a config file, IsEnabled returns false.
+  ASSERT_FALSE(FileUtil::FileExists(ConfigFilePath()).ok());
+  EXPECT_FALSE(StatsConfigUtil::IsEnabled());
+}
+
+TEST_F(StatsConfigUtilTestMac, SetEnabledTrueRoundTrip) {
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(true));
+  EXPECT_TRUE(FileUtil::FileExists(ConfigFilePath()).ok());
+  EXPECT_TRUE(StatsConfigUtil::IsEnabled());
+}
+
+TEST_F(StatsConfigUtilTestMac, SetEnabledFalseRoundTrip) {
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(false));
+  EXPECT_TRUE(FileUtil::FileExists(ConfigFilePath()).ok());
+  EXPECT_FALSE(StatsConfigUtil::IsEnabled());
+}
+
+TEST_F(StatsConfigUtilTestMac, SetEnabledOverwritesPreviousValue) {
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(true));
+  EXPECT_TRUE(StatsConfigUtil::IsEnabled());
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(false));
+  EXPECT_FALSE(StatsConfigUtil::IsEnabled());
+  EXPECT_TRUE(StatsConfigUtil::SetEnabled(true));
+  EXPECT_TRUE(StatsConfigUtil::IsEnabled());
+}
+#endif  // CHANNEL_DEV
+#endif  // TARGET_OS_OSX
 
 #ifdef __ANDROID__
 TEST(StatsConfigUtilTestAndroid, DefaultValueTest) {


### PR DESCRIPTION
## Description
This is a preparation step for removing the `Singleton<T>` dependency in `config/stats_config_util.cc`. The two member fields of `MacStatsConfigUtilImpl` were process-global state expressed as instance state (only one instance has ever existed, courtesy of Singleton<T>):

  * `config_file_` cached `"${user_profile_dir}/.usagestats.db"`. `SystemUtil::GetUserProfileDirectory()` is already called from many places, so caching its result inside this one class does not buy much. If profiling shows the call is hot, the right fix is to memoize it inside `SystemUtil` so every caller benefits.
  * `mutex_` serialized the multi-step file read/write sequence in `SetEnabled` against concurrent callers. Process-global protection is what we have had so far, so it is now a `constinit absl::Mutex` at namespace scope, matching the established pattern in `base/android_util.cc` and `renderer/win32/win32_renderer_client.cc`.

The class now holds no state, which makes the subsequent `Singleton<T>` removal mechanical. There is no observable behavioral change in production.

Note that we have had zero test coverage of `MacStatsConfigUtilImpl` for a long time. Filling the gap has been actually difficult in practice because a naive test would write to `"${HOME}/.usagestats.db"` and `chmod` it, clobbering the developer's real opt-in/out state.

Now that `SystemUtil::SetUserProfileDirectory()` takes effect immediately inside the implementation, the standard `TestWithTempUserProfile` fixture is sufficient to redirect the file into a per-test temp dir.

The new tests cover both branches of the `CHANNEL_DEV` switch for `MacStatsConfigUtilImpl`:

  * Stable (`!CHANNEL_DEV`): default-false when no file exists, the set/get round-trip for both `true` and `false`, and that `SetEnabled` can overwrite a previously-written value. The last one is load-bearing because `SetEnabled` chmods the file to read-only after writing, so a subsequent `SetEnabled` must chmod it back to writable before truncating; this test exercises that round-trip.
  * Dev channel: `IsEnabled` returns `true` regardless of file state, and `SetEnabled` is a no-op that never creates the file on disk.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
- Should be covered with CI for `GOOGLE_JAPANESE_INPUT_BUILD`.

