### PR TITLE
Remove unused `Singleton` from `codec.cc`

### DIFF
--- a/src/dictionary/system/BUILD.bazel
+++ b/src/dictionary/system/BUILD.bazel
@@ -46,7 +46,6 @@ mozc_cc_library(
     ],
     deps = [
         ":words_info",
-        "//base:singleton",
         "//base:util",
         "//base:vlog",
         "//dictionary:dictionary_token",

--- a/src/dictionary/system/codec.cc
+++ b/src/dictionary/system/codec.cc
@@ -39,7 +39,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "base/singleton.h"
 #include "base/util.h"
 #include "base/vlog.h"
 #include "dictionary/dictionary_token.h"


### PR DESCRIPTION
## Description
`dictionary/system/codec.cc` no longer uses `Singleton`. Let's remove unnecessary include and dependency.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. Confirm all the GitHub Actions still pass.
