### PR TITLE
Remove an optional optimization for uniprocessor

### DIFF
--- a/src/ipc/BUILD.bazel
+++ b/src/ipc/BUILD.bazel
@@ -61,7 +61,6 @@ mozc_cc_library(
     deps = [
         ":ipc_path_manager",
         "//base:const",
-        "//base:cpu_stats",
         "//base:file_util",
         "//base:singleton",
         "//base:system_util",

--- a/src/ipc/win32_ipc.cc
+++ b/src/ipc/win32_ipc.cc
@@ -36,7 +36,6 @@
 // clang-format on
 #include <wil/resource.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -46,7 +45,6 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "base/const.h"
-#include "base/cpu_stats.h"
 #include "base/singleton.h"
 #include "base/system_util.h"
 #include "base/util.h"
@@ -66,12 +64,6 @@ constexpr bool kReadTypeACK = true;
 constexpr bool kReadTypeData = false;
 constexpr bool kSendTypeData = false;
 constexpr int kMaxSuccessiveConnectionFailureCount = 5;
-
-size_t GetNumberOfProcessors() {
-  // thread-safety is not required.
-  static size_t num = CPUStats().GetNumberOfProcessors();
-  return std::max<size_t>(num, 1);
-}
 
 // Least significant bit of OVERLAPPED::hEvent can be used for special
 // purpose against GetQueuedCompletionStatus API.
@@ -694,17 +686,6 @@ void IPCClient::Init(absl::string_view name,
       continue;
     }
     std::wstring wserver_address = Utf8ToWide(server_address);
-
-    if (GetNumberOfProcessors() == 1) {
-      // When the code is running in single processor environment, sometimes
-      // IPC server has not finished the clean-up tasks for the previous IPC
-      // session here. So we intentionally call WaitNamedPipe API so that IPC
-      // server has a chance to complete clean-up tasks if necessary.
-      // NOTE: We cannot set 0 for the wait time because 0 has a special meaning
-      // as |NMPWAIT_USE_DEFAULT_WAIT|.
-      constexpr DWORD kMinWaitTimeForWaitNamedPipe = 1;
-      ::WaitNamedPipe(wserver_address.c_str(), kMinWaitTimeForWaitNamedPipe);
-    }
 
     wil::unique_hfile new_handle(
         ::CreateFile(wserver_address.c_str(), GENERIC_READ | GENERIC_WRITE, 0,


### PR DESCRIPTION
## Description
This is a preparation before further refactoring `win32_ipc.cc`, especially for removing the dependency on `Singleton` class.

This commit removes an optional optimization for uniprocessor Windows systems, which has no longer been supported since Windows 11 at least. As the optimization in `win32_ipc.cc` has been optional and Mozc should continue to work without it, let's remove it for simplicity, before further refactoring this file.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm you can still use Mozc without any observable behavior change.
