### PR TITLE
Remove unused `Singleton` from `mac_util.mm`

### DIFF
--- a/src/base/mac/BUILD.bazel
+++ b/src/base/mac/BUILD.bazel
@@ -90,7 +90,6 @@ mozc_objc_library(
     ],
     deps = [
         "//base:const",
-        "//base:singleton",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",

--- a/src/base/mac/mac_util.mm
+++ b/src/base/mac/mac_util.mm
@@ -41,7 +41,6 @@
 #include "absl/strings/string_view.h"
 #include "base/const.h"
 #include "base/mac/scoped_cftyperef.h"
-#include "base/singleton.h"
 
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>


### PR DESCRIPTION
## Description
`base/mac/mac_util.mm` no longer uses `Singleton`. Let's remove unnecessary include and dependency.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: GitHub Actions
 - Steps:
   1. Confirm all the GitHub Actions still pass
