### PR TITLE
Work around QTBUG-145239 with a local patch

### DIFF
--- a/src/build_tools/build_qt.py
+++ b/src/build_tools/build_qt.py
@@ -840,6 +840,36 @@ def extract_qt_src(args: argparse.Namespace) -> None:
           f.extractall(path=qt_src_dir, filter=filter)
       else:
         f.extractall(path=qt_src_dir, members=qt_extract_filter(f))
+  # TODO: https://github.com/google/mozc/issues/1457 - Remove this.
+  apply_patch_to_qt_src(qt_src_dir, args.dryrun)
+
+
+def apply_patch_to_qt_src(
+    qt_src_dir: pathlib.Path,
+    dryrun: bool = False,
+) -> None:
+  """Apply local patches to the extracted Qt source.
+
+  Args:
+    qt_src_dir: The root directory of the extracted Qt source.
+    dryrun: True to skip actual file modifications.
+  """
+  # Workaround for QTBUG-145239: qyieldcpu.h fails to compile with
+  # macOS 26.4 SDK on Apple Silicon.
+  # https://qt-project.atlassian.net/browse/QTBUG-145239
+  # https://codereview.qt-project.org/c/qt/qtbase/+/724619
+  qyieldcpu_h = qt_src_dir.joinpath('src', 'corelib', 'thread', 'qyieldcpu.h')
+  if dryrun:
+    print(f'dryrun: patching {qyieldcpu_h} for QTBUG-145239')
+    return
+  content = qyieldcpu_h.read_text(encoding='utf-8')
+  content = content.replace(
+      '#if __has_builtin(__yield)\n',
+      '#if __has_builtin(__builtin_arm_yield)\n'
+      '    __builtin_arm_yield();\n'
+      '#elif __has_builtin(__yield)\n',
+  )
+  qyieldcpu_h.write_text(content, encoding='utf-8')
 
 
 def main():


### PR DESCRIPTION
## Description
This commit implements a quick workaround for [QTBUG-145239](https://qt-project.atlassian.net/browse/QTBUG-145239), which causes build failure when building Qt 6.9.1 with XCode 26.4.

Ideally we should switch to Qt 6.11.1 or lather that has [the fix for QTBUG-145239](https://codereview.qt-project.org/c/qt/qtbase/+/724619), but doing so requires us to bump the minimum supported OS version to macOS 13 (#1458), which is also a non-trivial change.

At the same time, macos-26 image in the GitHub Actions Runners GitHub is going to switch to XCode 26.4.1 in the week of May 11, 2026 (https://github.com/actions/runner-images/issues/14001). We need some stopgap solution here.

Let's patch the code in question locally in `build_qt.py`.

Closes #1455.

## Issue IDs

 * https://github.com/google/mozc/issues/1455

## Steps to test new behaviors (if any)
A clear and concise description about how to verify new behaviors (if any).
 - OS: macOS 26.4.1
 - Steps:
   1. Make sure XCode 26.4.1 is installed
   2. Confirm `python3 build_tools/build_qt.py --release --confirm_license` finishes without any error
