### PR TITLE
Emacs: Fix candidate overlay collapse when tab-line is enabled

### DIFF
--- a/src/unix/emacs/mozc.el
+++ b/src/unix/emacs/mozc.el
@@ -662,9 +662,11 @@ This hack could be moved to mozc-posn-at-x-y in a future version."
            (+ y (window-tab-line-height) (window-header-line-height)))
           ((or (null header-line-format) (<= emacs-major-version 23))
            y)
-          (t (+ y (or mozc-cached-header-line-height
-                      (setq mozc-cached-header-line-height
-                            (mozc-header-line-height)) 0))))))
+          (t
+           (+ y (or mozc-cached-header-line-height
+                    (setq mozc-cached-header-line-height
+                          (mozc-header-line-height))
+                    0))))))
 
 (defsubst mozc-window-width (&optional window)
   "Return the width of WINDOW in pixel.

--- a/src/unix/emacs/mozc.el
+++ b/src/unix/emacs/mozc.el
@@ -643,7 +643,7 @@ In a word, this function is a fixed version of `posn-at-point'."
   "Return the y coordinate in POSITION.
 
 This function returns y offset from the top of the buffer area including
-the header line.  This definition could be changed in future.
+the header line and tab line.  This definition could be changed in future.
 
 Note: On Emacs 22 and 23, y offset, returned by `posn-at-point' and taken
 by `posn-at-x-y', is relative to the top of the buffer area including
@@ -652,15 +652,19 @@ However, on Emacs 24, y offset returned by `posn-at-point' is relative to
 the text area excluding the header line, while y offset taken by
 `posn-at-x-y' is relative to the buffer area including the header line.
 This asymmetry is by design according to GNU Emacs team.
+On Emacs 27, the tab line was added. The tab line behaves like the header
+line on Emacs 24.
 
 This function fixes the asymmetry between them on Emacs 24 and later versions.
 This hack could be moved to mozc-posn-at-x-y in a future version."
   (let ((y (cdr (posn-x-y position))))
-    (if (or (null header-line-format) (<= emacs-major-version 23))
-        y
-      (+ y (or mozc-cached-header-line-height
-               (setq mozc-cached-header-line-height (mozc-header-line-height))
-               0)))))
+    (if (<= 27 emacs-major-version)
+	(+ y (window-tab-line-height) (window-header-line-height))
+      (if (or (null header-line-format) (<= emacs-major-version 23))
+          y
+	(+ y (or mozc-cached-header-line-height
+		 (setq mozc-cached-header-line-height (mozc-header-line-height))
+		 0))))))
 
 (defsubst mozc-window-width (&optional window)
   "Return the width of WINDOW in pixel.

--- a/src/unix/emacs/mozc.el
+++ b/src/unix/emacs/mozc.el
@@ -658,13 +658,13 @@ line on Emacs 24.
 This function fixes the asymmetry between them on Emacs 24 and later versions.
 This hack could be moved to mozc-posn-at-x-y in a future version."
   (let ((y (cdr (posn-x-y position))))
-    (if (<= 27 emacs-major-version)
-	(+ y (window-tab-line-height) (window-header-line-height))
-      (if (or (null header-line-format) (<= emacs-major-version 23))
-          y
-	(+ y (or mozc-cached-header-line-height
-		 (setq mozc-cached-header-line-height (mozc-header-line-height))
-		 0))))))
+    (cond ((fboundp #'window-tab-line-height)
+           (+ y (window-tab-line-height) (window-header-line-height)))
+          ((or (null header-line-format) (<= emacs-major-version 23))
+           y)
+          (t (+ y (or mozc-cached-header-line-height
+                      (setq mozc-cached-header-line-height
+                            (mozc-header-line-height)) 0))))))
 
 (defsubst mozc-window-width (&optional window)
   "Return the width of WINDOW in pixel.


### PR DESCRIPTION
## Description
On Emacs, candidate overlay collapses with the tab line shown. This pull-request fixes the problem.

## Issue IDs
None.

## Steps to test new behaviors (if any)
 - My environment : Arch Linux 6.18.7, emacs 30.2
 - Steps:
   1. Enable mozc on Emacs. Set `mozc-candidate-style` overlay (default).
   2. Enable tab-line on Emacs, ex. `M-x global-tab-line-mode`.
   3. Input Japanese characters and show completion candidates.
   4. Confirm the candidate overlay display.

## Additional context
Mozc.el seems to support emacs >= 22, but if it drops support of emacs < 27,  the code becomes simpler. 
