### PR TITLE
Define `NO_SHLWAPI_STRFCNS` to not define `StrCat`

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -222,6 +222,7 @@ cc_library(
             "_ATL_NO_HOSTING",
             "ID_TRACE_LEVEL=1",
             "_MIDL_USE_GUIDDEF_",
+            "NO_SHLWAPI_STRFCNS",
             "PSAPI_VERSION=2",
             "UNICODE",
             "_UNICODE",

--- a/src/base/file/recursive.cc
+++ b/src/base/file/recursive.cc
@@ -63,8 +63,6 @@
 #include <ftw.h>
 #endif  // __ANDROID__ || TARGET_OS_IPHONE
 
-#undef StrCat
-
 namespace mozc::file {
 
 #ifdef _WIN32

--- a/src/base/win32/win_util.cc
+++ b/src/base/win32/win_util.cc
@@ -54,11 +54,6 @@
 #include "base/vlog.h"
 #include "base/win32/wide_char.h"
 
-// Disable StrCat macro to use absl::StrCat.
-#ifdef StrCat
-#undef StrCat
-#endif  // StrCat
-
 namespace mozc {
 namespace {
 

--- a/src/renderer/win32/win32_image_util_test.cc
+++ b/src/renderer/win32/win32_image_util_test.cc
@@ -35,8 +35,6 @@
 
 #include <cstdlib>
 
-#undef StrCat
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/renderer/win32/win32_renderer_util_test.cc
+++ b/src/renderer/win32/win32_renderer_util_test.cc
@@ -33,8 +33,6 @@
 #include <atltypes.h>
 #include <windows.h>
 
-#undef StrCat  // b/328804050
-
 #include <bit>
 #include <cstdint>
 #include <memory>

--- a/src/win32/custom_action/custom_action.cc
+++ b/src/win32/custom_action/custom_action.cc
@@ -36,8 +36,6 @@
 #include <wow64apiset.h>
 // clang-format on
 
-#undef StrCat  // NOLINT: TODO: triggers clang-tidy, defined by windows.h.
-
 #include <cstdarg>
 #include <cstddef>
 #include <memory>


### PR DESCRIPTION
## Description
This is a mechanical cleanup to avoid defining `StrCat` in `shlwapi.h`, which often requires us to `undef StrCat` before using `absl::StrCat`.

There must be no functional change in the final executables.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
