### PR TITLE
Remove `Singleton` from `client.cc`

### DIFF
--- a/src/client/BUILD.bazel
+++ b/src/client/BUILD.bazel
@@ -84,7 +84,6 @@ mozc_cc_library(
         "//base:file_util",
         "//base:process",
         "//base:run_level",
-        "//base:singleton",
         "//base:system_util",
         "//base:version",
         "//base:vlog",

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -48,7 +48,6 @@
 #include "base/file_stream.h"
 #include "base/file_util.h"
 #include "base/process.h"
-#include "base/singleton.h"
 #include "base/system_util.h"
 #include "base/version.h"
 #include "base/vlog.h"
@@ -926,19 +925,14 @@ bool Client::OpenBrowser(absl::string_view url) {
 }
 
 namespace {
-class DefaultClientFactory : public ClientFactoryInterface {
- public:
-  std::unique_ptr<ClientInterface> NewClient() override {
-    return std::make_unique<Client>();
-  }
-};
 
 ClientFactoryInterface *g_client_factory = nullptr;
+
 }  // namespace
 
 std::unique_ptr<ClientInterface> ClientFactory::NewClient() {
   if (g_client_factory == nullptr) {
-    return Singleton<DefaultClientFactory>::get()->NewClient();
+    return std::make_unique<Client>();
   } else {
     return g_client_factory->NewClient();
   }


### PR DESCRIPTION
## Description
As part of our ongoing efforts to remove the dependency on `Singleton`, this commit rewrites `client/client.cc` without the `Singleton` class dependency.

This is purely mechanical refactoring. There must be no observable behavioral change in production.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass
