### PR TITLE
Avoid unnecessary string-resizes in `wide_char.cc`

### DIFF
--- a/src/base/win32/BUILD.bazel
+++ b/src/base/win32/BUILD.bazel
@@ -209,6 +209,7 @@ mozc_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:resize_and_overwrite",
     ],
 )
 

--- a/src/base/win32/wide_char.cc
+++ b/src/base/win32/wide_char.cc
@@ -38,6 +38,7 @@
 
 #include "absl/base/casts.h"
 #include "absl/log/check.h"
+#include "absl/strings/resize_and_overwrite.h"
 #include "absl/strings/string_view.h"
 
 namespace mozc::win32 {
@@ -71,18 +72,20 @@ std::wstring Utf8ToWide(const absl::string_view input) {
     return std::wstring();
   }
 
-  size_t wchar_count = WideCharsLen(input);
+  const size_t wchar_count = WideCharsLen(input);
   std::wstring result;
   // MultiByteToWideChar doesn't null-terminate the output string when the
   // length is explicitly specified.
-  result.resize(wchar_count);
-
-  // This API call should always succeed as long as the codepage (CP_UTF8) and
-  // flag (0) are valid.
-  const int copied_wchars = ::MultiByteToWideChar(
-      CP_UTF8, 0, input.data(), input.size(), result.data(), result.size());
-  CHECK_GE(copied_wchars, 0);
-  DCHECK_EQ(wchar_count, copied_wchars);
+  absl::StringResizeAndOverwrite(
+      result, wchar_count, [&](wchar_t* buf, size_t size) {
+        // This API call should always succeed as long as the codepage
+        // (CP_UTF8) and flag (0) are valid.
+        const int copied_wchars = ::MultiByteToWideChar(
+            CP_UTF8, 0, input.data(), input.size(), buf, size);
+        CHECK_GE(copied_wchars, 0);
+        DCHECK_EQ(wchar_count, copied_wchars);
+        return absl::implicit_cast<size_t>(copied_wchars);
+      });
   return result;
 }
 
@@ -102,13 +105,15 @@ std::string WideToUtf8(const std::wstring_view input) {
   std::string result;
   // WideCharToMultiByte doesn't null-terminate the output string when the
   // length is explicitly specified.
-  result.resize(char_count);
-  const int copied_chars =
-      ::WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
-                            result.data(), result.size(), nullptr, nullptr);
-
-  CHECK_GE(copied_chars, 0);
-  DCHECK_EQ(char_count, copied_chars);
+  absl::StringResizeAndOverwrite(
+      result, char_count, [&](char* buf, size_t size) {
+        const int copied_chars =
+            ::WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(), buf,
+                                  size, nullptr, nullptr);
+        CHECK_GE(copied_chars, 0);
+        DCHECK_EQ(char_count, copied_chars);
+        return absl::implicit_cast<size_t>(copied_chars);
+      });
   return result;
 }
 


### PR DESCRIPTION
## Description
`absl::StringResizeAndOverwrite`, which was recently added in [Abseil LTS 20260107.0](https://github.com/abseil/abseil-cpp/releases/tag/20260107.0), acts as a polyfill for C++23's `std::basic_string::resize_and_overwrite`. `Utf8ToWide` and `WideToUtf8` are good showcases for this.

This is a mechanical refactor with no semantic changes. Also, the code is used only for Windows builds.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. `bazelisk test //base/win32:wide_char_test -c dbg`
