### PR TITLE
Avoid unnecessary string-resizes in `file_util.cc`

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -435,10 +435,12 @@ mozc_cc_library(
         ":mmap",
         ":port",
         "//base/strings:pfchar",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:resize_and_overwrite",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
     ] + mozc_select(

--- a/src/base/file_util.cc
+++ b/src/base/file_util.cc
@@ -43,9 +43,11 @@
 #include <system_error>  // NOLINT(build/c++11)
 #include <utility>
 
+#include "absl/base/casts.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/resize_and_overwrite.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_replace.h"
@@ -625,8 +627,11 @@ absl::StatusOr<std::string> FileUtil::GetContents(
   ifs.seekg(0, std::ios_base::beg);
   std::string content;
   if (mode & std::ios::binary) {
-    content.resize(size);
-    ifs.read(content.data(), size);
+    absl::StringResizeAndOverwrite(
+        content, size, [&](char* buf, size_t buf_size) {
+          ifs.read(buf, buf_size);
+          return absl::implicit_cast<size_t>(ifs.gcount());
+        });
   } else {
     // In the text mode, the read size can be smaller than the file size as
     // "\r\n" can be translated to "\n" on Windows. Therefore, we just reserve a


### PR DESCRIPTION
## Description
`absl::StringResizeAndOverwrite`, which was recently added in [Abseil LTS 20260107.0](https://github.com/abseil/abseil-cpp/releases/tag/20260107.0), acts as a polyfill for C++23's `std::basic_string::resize_and_overwrite`. `FileUtil::GetContents` is a good showcase for this.

This is a mechanical refactor with no semantic changes.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. `bazelisk test //base:file_util_test -c dbg`
