### PR TITLE
Remove `TipInputModeManagerImpl::ConversionMode`

### DIFF
--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -864,6 +864,7 @@ mozc_cc_test(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":tip_input_mode_manager",
+        "//protocol:commands_cc_proto",
         "//testing:gunit_main",
     ],
 )

--- a/src/win32/tip/tip_edit_session_impl.cc
+++ b/src/win32/tip/tip_edit_session_impl.cc
@@ -419,8 +419,8 @@ HRESULT UpdatePrivateContext(TipTextService* text_service, ITfContext* context,
 
   if ((action_set & TipInputModeManager::kNotifySystemConversionMode) ==
       TipInputModeManager::kNotifySystemConversionMode) {
-    const CompositionMode mozc_mode = static_cast<CompositionMode>(
-        input_mode_manager->GetEffectiveConversionMode());
+    const CompositionMode mozc_mode =
+        input_mode_manager->GetEffectiveConversionMode();
     uint32_t native_mode = 0;
     if (ConversionModeUtil::ToNativeMode(
             mozc_mode, private_context->input_behavior().prefer_kana_input,

--- a/src/win32/tip/tip_input_mode_manager.cc
+++ b/src/win32/tip/tip_input_mode_manager.cc
@@ -46,8 +46,6 @@ namespace win32 {
 namespace tsf {
 namespace {
 
-typedef ::mozc::commands::CompositionMode CompositionMode;
-
 template <typename T>
 void Dedup(std::vector<T>* container) {
   std::sort(container->begin(), container->end());
@@ -62,7 +60,7 @@ TipInputModeManagerImpl::StatePair TipInputModeManagerImpl::GetOverriddenState(
   if (input_scopes.empty()) {
     return base_state;
   }
-  std::vector<ConversionMode> states;
+  std::vector<commands::CompositionMode> states;
   for (const auto& input_scope : input_scopes) {
     switch (input_scope) {
       // Some InputStope can be mapped to commands::Context::InputFieldType.
@@ -81,20 +79,20 @@ TipInputModeManagerImpl::StatePair TipInputModeManagerImpl::GetOverriddenState(
       case IS_TIME_HOUR:
       case IS_TIME_MINORSEC:
       case IS_ALPHANUMERIC_HALFWIDTH:
-        states.push_back(kDirect);
+        states.push_back(commands::DIRECT);
         break;
       case IS_HIRAGANA:
-        states.push_back(kHiragana);
+        states.push_back(commands::HIRAGANA);
         break;
       case IS_NUMBER_FULLWIDTH:
       case IS_ALPHANUMERIC_FULLWIDTH:
-        states.push_back(kFullAscii);
+        states.push_back(commands::FULL_ASCII);
         break;
       case IS_KATAKANA_HALFWIDTH:
-        states.push_back(kHalfKatakana);
+        states.push_back(commands::HALF_KATAKANA);
         break;
       case IS_KATAKANA_FULLWIDTH:
-        states.push_back(kFullKatakana);
+        states.push_back(commands::FULL_KATAKANA);
         break;
       default:
         break;
@@ -109,7 +107,7 @@ TipInputModeManagerImpl::StatePair TipInputModeManagerImpl::GetOverriddenState(
     // TODO(yukawa): consider this case.
     return base_state;
   }
-  if (states[0] == kDirect) {
+  if (states[0] == commands::DIRECT) {
     return StatePair(false, base_state.conversion_mode);
   }
   return StatePair(true, states[0]);
@@ -164,14 +162,14 @@ TipInputModeManager::Action TipInputModeManager::OnMoveFocusedWindow() {
 }
 
 TipInputModeManager::NotifyActionSet TipInputModeManager::OnReceiveCommand(
-    bool mozc_open_close_mode, DWORD mozc_logical_mode,
-    DWORD mozc_visible_mode) {
+    bool mozc_open_close_mode, commands::CompositionMode mozc_logical_mode,
+    commands::CompositionMode mozc_visible_mode) {
   const StatePair prev_tsf_state = tsf_state_;
 
   tsf_state_.open_close = mozc_open_close_mode;
-  tsf_state_.conversion_mode = static_cast<ConversionMode>(mozc_logical_mode);
+  tsf_state_.conversion_mode = mozc_logical_mode;
   mozc_state_.open_close = mozc_open_close_mode;
-  mozc_state_.conversion_mode = static_cast<ConversionMode>(mozc_visible_mode);
+  mozc_state_.conversion_mode = mozc_visible_mode;
 
   NotifyActionSet action_set = kNotifyNothing;
   if (prev_tsf_state.open_close != tsf_state_.open_close) {
@@ -193,9 +191,9 @@ void TipInputModeManager::OnInitialize(bool system_open_close_mode,
   if (use_global_mode_) {
     return;
   }
-  CompositionMode mozc_mode = commands::HIRAGANA;
+  commands::CompositionMode mozc_mode = commands::HIRAGANA;
   if (ConversionModeUtil::ToMozcMode(system_conversion_mode, &mozc_mode)) {
-    tsf_state_.conversion_mode = static_cast<ConversionMode>(mozc_mode);
+    tsf_state_.conversion_mode = mozc_mode;
   }
   mozc_state_.conversion_mode = tsf_state_.conversion_mode;
 }
@@ -212,10 +210,10 @@ TipInputModeManager::Action TipInputModeManager::OnSetFocus(
   Dedup(&new_input_scopes);
 
   tsf_state_.open_close = system_open_close_mode;
-  CompositionMode mozc_mode = commands::HIRAGANA;
+  commands::CompositionMode mozc_mode = commands::HIRAGANA;
   if (!use_global_mode_) {
     if (ConversionModeUtil::ToMozcMode(system_conversion_mode, &mozc_mode)) {
-      tsf_state_.conversion_mode = static_cast<ConversionMode>(mozc_mode);
+      tsf_state_.conversion_mode = mozc_mode;
     }
   }
 
@@ -251,10 +249,10 @@ TipInputModeManager::Action TipInputModeManager::OnChangeConversionMode(
     return kDoNothing;
   }
 
-  CompositionMode mozc_mode = commands::HIRAGANA;
+  commands::CompositionMode mozc_mode = commands::HIRAGANA;
   if (ConversionModeUtil::ToMozcMode(new_conversion_mode, &mozc_mode)) {
-    tsf_state_.conversion_mode = static_cast<ConversionMode>(mozc_mode);
-    mozc_state_.conversion_mode = static_cast<ConversionMode>(mozc_mode);
+    tsf_state_.conversion_mode = mozc_mode;
+    mozc_state_.conversion_mode = mozc_mode;
   }
 
   if (prev_effective.conversion_mode != mozc_state_.conversion_mode) {
@@ -294,13 +292,12 @@ bool TipInputModeManager::GetTsfOpenClose() const {
   return tsf_state_.open_close;
 }
 
-TipInputModeManagerImpl::ConversionMode
-TipInputModeManager::GetEffectiveConversionMode() const {
+commands::CompositionMode TipInputModeManager::GetEffectiveConversionMode()
+    const {
   return mozc_state_.conversion_mode;
 }
 
-TipInputModeManagerImpl::ConversionMode
-TipInputModeManager::GetTsfConversionMode() const {
+commands::CompositionMode TipInputModeManager::GetTsfConversionMode() const {
   return tsf_state_.conversion_mode;
 }
 

--- a/src/win32/tip/tip_input_mode_manager.h
+++ b/src/win32/tip/tip_input_mode_manager.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "absl/types/span.h"
+#include "protocol/commands.pb.h"
 #include "win32/base/indicator_visibility_tracker.h"
 #include "win32/base/keyboard.h"
 
@@ -47,21 +48,13 @@ namespace tsf {
 // Exposed for unit testing.
 class TipInputModeManagerImpl {
  public:
-  enum ConversionMode {
-    kDirect,
-    kHiragana,
-    kFullKatakana,
-    kHalfAscii,
-    kFullAscii,
-    kHalfKatakana,
-  };
   struct StatePair {
     StatePair() = default;
-    StatePair(bool open_close, ConversionMode conversion_mode)
+    StatePair(bool open_close, commands::CompositionMode conversion_mode)
         : open_close(open_close), conversion_mode(conversion_mode) {}
 
     bool open_close = false;
-    ConversionMode conversion_mode = kHiragana;
+    commands::CompositionMode conversion_mode = commands::HIRAGANA;
   };
 
  protected:
@@ -112,8 +105,8 @@ class TipInputModeManager : public TipInputModeManagerImpl {
 
   void OnInitialize(bool system_open_close_mode, DWORD system_conversion_mode);
   NotifyActionSet OnReceiveCommand(bool mozc_open_close_mode,
-                                   DWORD mozc_logical_mode,
-                                   DWORD mozc_visible_mode);
+                                   commands::CompositionMode mozc_logical_mode,
+                                   commands::CompositionMode mozc_visible_mode);
   Action OnSetFocus(bool system_open_close_mode, DWORD system_conversion_mode,
                     absl::Span<const InputScope> input_scopes);
   Action OnChangeOpenClose(bool new_open_close_mode);
@@ -125,9 +118,9 @@ class TipInputModeManager : public TipInputModeManagerImpl {
   // Returns an IME open/close state that is visible from TSF.
   bool GetTsfOpenClose() const;
   // Returns IME conversion mode that is visible from the Mozc session.
-  ConversionMode GetEffectiveConversionMode() const;
+  commands::CompositionMode GetEffectiveConversionMode() const;
   // Returns IME conversion mode that is visible from TSF.
-  ConversionMode GetTsfConversionMode() const;
+  commands::CompositionMode GetTsfConversionMode() const;
 
  private:
   bool use_global_mode_ = false;

--- a/src/win32/tip/tip_input_mode_manager_test.cc
+++ b/src/win32/tip/tip_input_mode_manager_test.cc
@@ -33,6 +33,7 @@
 
 #include <vector>
 
+#include "protocol/commands.pb.h"
 #include "testing/gunit.h"
 
 namespace mozc {
@@ -70,18 +71,16 @@ TEST(TipInputModeManagerImplTest, GetOverriddenState) {
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(false, TipInputModeManagerImpl::kHiragana),
-              input_scope_off);
+              StatePair(false, commands::HIRAGANA), input_scope_off);
       EXPECT_FALSE(state.open_close);
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(true, TipInputModeManagerImpl::kHiragana),
-              input_scope_off);
+              StatePair(true, commands::HIRAGANA), input_scope_off);
       EXPECT_FALSE(state.open_close) << "Should be temporarily off.";
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
   }
 
@@ -91,26 +90,23 @@ TEST(TipInputModeManagerImplTest, GetOverriddenState) {
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(false, TipInputModeManagerImpl::kHiragana),
-              input_scope_full_hiragana);
+              StatePair(false, commands::HIRAGANA), input_scope_full_hiragana);
       EXPECT_TRUE(state.open_close) << "Should be temporarily on.";
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(true, TipInputModeManagerImpl::kHiragana),
-              input_scope_full_hiragana);
+              StatePair(true, commands::HIRAGANA), input_scope_full_hiragana);
       EXPECT_TRUE(state.open_close) << "Should be temporarily on.";
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(true, TipInputModeManagerImpl::kFullAscii),
-              input_scope_full_hiragana);
+              StatePair(true, commands::FULL_ASCII), input_scope_full_hiragana);
       EXPECT_TRUE(state.open_close) << "Should be temporarily on.";
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana)
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA)
           << "Should be temporarily Hiragana";
     }
   }
@@ -123,26 +119,23 @@ TEST(TipInputModeManagerImplTest, GetOverriddenState) {
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(false, TipInputModeManagerImpl::kHiragana),
-              input_scope_invalid);
+              StatePair(false, commands::HIRAGANA), input_scope_invalid);
       EXPECT_FALSE(state.open_close);
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(true, TipInputModeManagerImpl::kHiragana),
-              input_scope_invalid);
+              StatePair(true, commands::HIRAGANA), input_scope_invalid);
       EXPECT_TRUE(state.open_close);
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kHiragana);
+      EXPECT_EQ(state.conversion_mode, commands::HIRAGANA);
     }
     {
       const StatePair state =
           TestableTipInputModeManagerImpl::GetOverriddenState(
-              StatePair(true, TipInputModeManagerImpl::kFullAscii),
-              input_scope_invalid);
+              StatePair(true, commands::FULL_ASCII), input_scope_invalid);
       EXPECT_TRUE(state.open_close);
-      EXPECT_EQ(state.conversion_mode, TipInputModeManagerImpl::kFullAscii);
+      EXPECT_EQ(state.conversion_mode, commands::FULL_ASCII);
     }
   }
 }
@@ -163,11 +156,11 @@ TEST(TipInputModeManagerTest, IgnoreConversionModeByGlobalConfig_Issue8583505) {
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 
   // On
-  input_mode_manager.OnReceiveCommand(true, TipInputModeManager::kHiragana,
-                                      TipInputModeManager::kHiragana);
+  input_mode_manager.OnReceiveCommand(true, commands::HIRAGANA,
+                                      commands::HIRAGANA);
   EXPECT_TRUE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
 
@@ -181,7 +174,7 @@ TEST(TipInputModeManagerTest, IgnoreConversionModeByGlobalConfig_Issue8583505) {
   EXPECT_EQ(action, TipInputModeManager::kDoNothing);
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 }
 
 TEST(TipInputModeManagerTest, HonorConversionMode_Issue8583505) {
@@ -200,11 +193,11 @@ TEST(TipInputModeManagerTest, HonorConversionMode_Issue8583505) {
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 
   // On
-  input_mode_manager.OnReceiveCommand(true, TipInputModeManager::kHiragana,
-                                      TipInputModeManager::kHiragana);
+  input_mode_manager.OnReceiveCommand(true, commands::HIRAGANA,
+                                      commands::HIRAGANA);
   EXPECT_TRUE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
 
@@ -218,7 +211,7 @@ TEST(TipInputModeManagerTest, HonorConversionMode_Issue8583505) {
   EXPECT_EQ(action, TipInputModeManager::kUpdateUI);
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHalfAscii);
+            commands::HALF_ASCII);
 }
 
 TEST(TipInputModeManagerTest, ChangeInputScope) {
@@ -235,7 +228,7 @@ TEST(TipInputModeManagerTest, ChangeInputScope) {
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 
   std::vector<InputScope> input_scope_full_katakana = {IS_KATAKANA_FULLWIDTH};
 
@@ -245,7 +238,7 @@ TEST(TipInputModeManagerTest, ChangeInputScope) {
   EXPECT_EQ(action, TipInputModeManager::kUpdateUI);
   EXPECT_TRUE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kFullKatakana);
+            commands::FULL_KATAKANA);
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
 
   action = input_mode_manager.OnKey(VirtualKey(), true, true);
@@ -258,7 +251,7 @@ TEST(TipInputModeManagerTest, ChangeInputScope) {
   EXPECT_EQ(action, TipInputModeManager::kUpdateUI);
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
 
   // OnKey
@@ -273,7 +266,7 @@ TEST(TipInputModeManagerTest, ChangeInputScope) {
   EXPECT_EQ(action, TipInputModeManager::kDoNothing);
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
 }
 
@@ -305,11 +298,11 @@ TEST(TipInputModeManagerTest, InputScopeOnSetFocus_GitHubIssue826) {
   EXPECT_FALSE(input_mode_manager.IsIndicatorVisible());
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 
   // On -> (On + Hiragana)
-  input_mode_manager.OnReceiveCommand(true, TipInputModeManager::kHiragana,
-                                      TipInputModeManager::kHiragana);
+  input_mode_manager.OnReceiveCommand(true, commands::HIRAGANA,
+                                      commands::HIRAGANA);
   EXPECT_TRUE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
 
@@ -320,7 +313,7 @@ TEST(TipInputModeManagerTest, InputScopeOnSetFocus_GitHubIssue826) {
   EXPECT_TRUE(input_mode_manager.IsIndicatorVisible());
   EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
   EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
-            TipInputModeManager::kHiragana);
+            commands::HIRAGANA);
 }
 
 }  // namespace

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -122,10 +122,9 @@ bool GetOpenAndMode(TipTextService* text_service, ITfContext* context,
   if (private_context) {
     prefer_kana_input = private_context->input_behavior().prefer_kana_input;
   }
-  const CompositionMode tsf_mode =
-      static_cast<CompositionMode>(input_mode_manager->GetTsfConversionMode());
-  const CompositionMode effective_mode = static_cast<CompositionMode>(
-      input_mode_manager->GetEffectiveConversionMode());
+  const CompositionMode tsf_mode = input_mode_manager->GetTsfConversionMode();
+  const CompositionMode effective_mode =
+      input_mode_manager->GetEffectiveConversionMode();
 
   const bool has_valid_logical_mode = ConversionModeUtil::ToNativeMode(
       tsf_mode, prefer_kana_input, logical_mode);

--- a/src/win32/tip/tip_ui_handler.cc
+++ b/src/win32/tip/tip_ui_handler.cc
@@ -85,8 +85,7 @@ void UpdateLanguageBarOnFocusChange(TipTextService* text_service,
       text_service->GetThreadContext()->GetInputModeManager();
   const bool open = input_mode_manager->GetEffectiveOpenClose();
   const CompositionMode mozc_mode =
-      open ? static_cast<CompositionMode>(
-                 input_mode_manager->GetEffectiveConversionMode())
+      open ? input_mode_manager->GetEffectiveConversionMode()
            : commands::DIRECT;
   text_service->UpdateLangbar(!disabled, static_cast<uint32_t>(mozc_mode));
 }
@@ -123,8 +122,8 @@ bool TipUiHandler::Update(TipTextService* text_service, ITfContext* context,
   const TipInputModeManager* input_mode_manager =
       text_service->GetThreadContext()->GetInputModeManager();
   const bool open = input_mode_manager->GetEffectiveOpenClose();
-  const CompositionMode mozc_mode = static_cast<CompositionMode>(
-      input_mode_manager->GetEffectiveConversionMode());
+  const CompositionMode mozc_mode =
+      input_mode_manager->GetEffectiveConversionMode();
   const bool result = UpdateInternal(text_service, context, read_cookie);
   if (open) {
     text_service->UpdateLangbar(true, mozc_mode);

--- a/src/win32/tip/tip_ui_handler_conventional.cc
+++ b/src/win32/tip/tip_ui_handler_conventional.cc
@@ -59,7 +59,6 @@ namespace win32 {
 namespace tsf {
 namespace {
 
-using ::mozc::commands::CompositionMode;
 using ::mozc::commands::Preedit;
 using ::mozc::renderer::win32::Win32RendererClient;
 using Segment = ::mozc::commands::Preedit_Segment;
@@ -358,8 +357,8 @@ void UpdateCommand(TipTextService* text_service, ITfContext* context,
       IndicatorInfo* info = app_info->mutable_indicator_info();
       info->mutable_status()->set_activated(
           input_mode_manager->GetEffectiveOpenClose());
-      info->mutable_status()->set_mode(static_cast<CompositionMode>(
-          input_mode_manager->GetEffectiveConversionMode()));
+      info->mutable_status()->set_mode(
+          input_mode_manager->GetEffectiveConversionMode());
     }
   }
 


### PR DESCRIPTION
## Description
When we were relying on `build_mozc.py` with 2-phase build, there was a motivation to avoid including proto-generated header files from hand-written header files, as build dependencies were not automatically tracked. This is basically why `TipInputModeManagerImpl::ConversionMode` was introduced as a synonym of `commands::CompositionMode`.

Now that Bazel keeps track of all the build dependencies including proto-generated header files, we can simply use `commands::CompositionMode` everywhere. Let's remove `TipInputModeManagerImpl::ConversionMode` for simplicity.

This is a mechanical refactoring, and there should be no functional change in the production code.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. `bazelisk test //win32/tip:tip_input_mode_manager_test -c dbg`
