### PR TITLE
Upload failing test logs in GitHub Actions

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -68,4 +68,18 @@ jobs:
       - name: bazel test
         working-directory: ./src
         run: |
-          bazelisk test ... -c dbg
+          bazelisk test ... -c dbg --build_tests_only --build_event_json_file=bep.jsonl
+
+      - name: Collect failing test logs
+        if: failure()
+        working-directory: ./src
+        run: |
+          python3 build_tools/collect_test_logs.py --bep bep.jsonl --out "${GITHUB_WORKSPACE}/test_logs"
+
+      - name: Upload failing test logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-logs-${{ runner.os }}
+          path: test_logs
+          if-no-files-found: ignore

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -163,7 +163,21 @@ jobs:
       - name: bazel test
         working-directory: ./src
         run: |
-          bazelisk test ... --build_tests_only -c dbg
+          bazelisk test ... -c dbg --build_tests_only --build_event_json_file=bep.jsonl
+
+      - name: Collect failing test logs
+        if: failure()
+        working-directory: ./src
+        run: |
+          python3 build_tools/collect_test_logs.py --bep bep.jsonl --out "${GITHUB_WORKSPACE}/test_logs"
+
+      - name: Upload failing test logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-logs-${{ runner.os }}
+          path: test_logs
+          if-no-files-found: ignore
 
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -203,7 +203,22 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk test ... -c dbg --build_tests_only
+          bazelisk test ... -c dbg --build_tests_only --build_event_json_file=bep.jsonl
+
+      - name: Collect failing test logs
+        if: failure()
+        shell: cmd
+        working-directory: .\src
+        run: |
+          python build_tools\collect_test_logs.py --bep bep.jsonl --out "%GITHUB_WORKSPACE%\test_logs"
+
+      - name: Upload failing test logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-logs-${{ runner.os }}
+          path: test_logs
+          if-no-files-found: ignore
 
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".

--- a/src/build_tools/collect_test_logs.py
+++ b/src/build_tools/collect_test_logs.py
@@ -1,0 +1,141 @@
+# Copyright 2010-2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Collects artifacts (logs) from failing tests with a Bazel BEP JSONL file.
+
+Reads the Build Event Protocol stream written by
+`bazel test --build_event_json_file=<path>` and copies the outputs of every
+non-passing test attempt into a destination directory, preserving the
+`<package>/<target>` layout so the result can be uploaded as a CI artifact.
+
+Despite the `--build_event_json_file` flag name, the output is JSONL (a.k.a.
+newline-delimited JSON): one self-contained JSON event object per line, *not* a
+single JSON array. It is therefore parsed line by line with `json.loads()`;
+calling `json.loads()` on the whole file would fail.
+
+This intentionally resolves the absolute `file://` URIs recorded in each
+`testResult` event instead of walking the `bazel-testlogs` convenience symlink:
+that symlink is not produced reliably when the test command triggers platform
+transitions, and its location depends on the compilation mode. The URIs in the
+BEP are always correct for the run that produced them, so this works the same
+on Linux, macOS and Windows.
+"""
+
+import argparse
+import json
+import pathlib
+import shutil
+from urllib import parse
+from urllib import request
+
+
+def _relative_dest(src: pathlib.Path, label: str) -> pathlib.Path:
+  """Computes the destination path under the output dir for a source file.
+
+  Prefers the segment after `testlogs/` (e.g. `base/update_util_test/test.log`)
+  so the layout matches what `bazel-testlogs` would have produced. Falls back to
+  deriving it from the target label if `testlogs` is somehow absent.
+
+  Args:
+    src: Absolute path to the source test output file (e.g. a `test.log`).
+    label: Bazel target label of the test (e.g. `//base:update_util_test`),
+      used only as a fallback when `src` has no `testlogs` segment.
+
+  Returns:
+    The path, relative to the output directory, at which `src` should be
+    copied.
+  """
+  parts = src.parts
+  if "testlogs" in parts:
+    return pathlib.Path(*parts[parts.index("testlogs") + 1:])
+  return pathlib.Path(label.lstrip("/").replace(":", "/")) / src.name
+
+
+def collect(bep_path: pathlib.Path, out_dir: pathlib.Path) -> int:
+  """Copies failing-test outputs referenced by `bep_path` into `out_dir`.
+
+  Args:
+    bep_path: Path to the JSONL Build Event Protocol file produced by
+      `bazel test --build_event_json_file=<path>`.
+    out_dir: Destination directory into which the collected logs are copied.
+      Parent directories are created as needed.
+
+  Returns:
+    The number of test log files copied into `out_dir`.
+  """
+  copied = 0
+  with open(bep_path, encoding="utf-8") as stream:
+    # The BEP output is JSONL: one independent JSON event per line. Parse each
+    # line on its own rather than the whole file at once.
+    for line in stream:
+      line = line.strip()
+      if not line:
+        continue
+      event = json.loads(line)
+      result = event.get("testResult")
+      if result is None or result.get("status") == "PASSED":
+        continue
+      label = event.get("id", {}).get("testResult", {}).get("label", "")
+      for output in result.get("testActionOutput", []):
+        if output.get("name") not in ("test.log", "test.xml"):
+          continue
+        uri = output.get("uri")
+        if not uri:
+          continue
+        src = pathlib.Path(request.url2pathname(parse.urlparse(uri).path))
+        if not src.is_file():
+          continue
+        dest = out_dir / _relative_dest(src, label)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        copied += 1
+  return copied
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+      "--bep", required=True, type=pathlib.Path,
+      help="Path to the --build_event_json_file output (JSONL).")
+  parser.add_argument(
+      "--out", required=True, type=pathlib.Path,
+      help="Destination directory for the collected logs.")
+  args = parser.parse_args()
+
+  if not args.bep.is_file():
+    # No BEP means the test command never ran; nothing to collect.
+    print(f"BEP file {args.bep} not found; nothing to collect.")
+    return
+
+  copied = collect(args.bep, args.out)
+  print(f"Collected {copied} test log file(s) into {args.out}")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Description
This follows up on the flaky test failure (#1518), which we have recently fixed (#1522).

One thing that had contributed to the long time to fix the issue was that the test failure log files had not been uploaded as artifacts in GitHub Actions, which made it hard to investigate the root cause of the issue. To avoid similar situations in the future, let's make it possible to upload the log files as artifacts when there is any test failure in GitHub Actions.

To do so, this commit adds a new Python script `collect_test_logs.py` that collects failing test logs into the given directory so that the directory can be uploaded as a single artifact.

The core idea here is to rely on the [Build Event Protocol](https://bazel.build/remote/bep) (BEP) to retrieve the insight into a Bazel invocation. Unlike convenient symlinks such as `bazel-testlogs`, which for example cannot abstract away the complexity behind platform transitions while running all the tests in a single bazel invocation, the BEP gives the complete picture of the test execution including the absolute paths to the test log files. Let's use this opportunity to demonstrate how Bazel is powerful and flexible with the BEP.

This commit also adds `--build_tests_only` to the Linux test invocation so that it is consistent with the macOS and Windows workflows, which already pass that flag.

No artifact will be uploaded if there is no test failure.

## Issue IDs
 * https://github.com/google/mozc/issues/1518

## Steps to test new behaviors
 - OS: All
 - Steps:
   1. Explicitly trigger test failure in GitHub Actions
   2. Confirm that test failure logs were uploaded
