### PR TITLE
Embed Win32 manifest into tests and build tools

### DIFF
--- a/src/bazel/win32/BUILD.bazel
+++ b/src/bazel/win32/BUILD.bazel
@@ -32,10 +32,22 @@
 #  - Windows SDK library link options.
 #  - (that's it for now)
 
+load("//:build_defs.bzl", "MOZC_TAGS", "mozc_win32_resource")
 load("//bazel:stubs.bzl", "bzl_library")
 load("//bazel/win32:internal.bzl", "mozc_win32_lib")
 
 package(default_visibility = ["//:__subpackages__"])
+
+# A linker input to embed the default Win32 manifest settings (e.g. the
+# supported OS versions) that all the production binaries specify. This is
+# added to all the executables built with mozc_cc_test and mozc_cc_binary
+# unless opted out explicitly.
+mozc_win32_resource(
+    name = "win32_default_manifest",
+    manifests = ["win32_default.manifest"],
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+)
 
 bzl_library(
     name = "build_defs_bzl",

--- a/src/bazel/win32/win32_default.manifest
+++ b/src/bazel/win32/win32_default.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <!--
+    The namespace alias 'compat' below is added as a workaround for b/3034589.
+    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
+    xmlns declarations, which might cause a heap corruption in sxs.dll on
+    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
+  -->
+  <compat:compatibility
+       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
+    <compat:application>
+      <!--The ID below indicates application support for Windows 10 -->
+      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!--The ID below indicates application support for Windows 8.1 -->
+      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--The ID below indicates application support for Windows 8 -->
+      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--The ID below indicates application support for Windows 7 -->
+      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--The ID below indicates application support for Windows Vista -->
+      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </compat:application>
+  </compat:compatibility>
+</assembly>

--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -74,6 +74,13 @@ def _copts_unsigned_char():
         "//conditions:default": ["-funsigned-char"],
     })
 
+def _win32_default_manifest_deps():
+    """Returns deps to embed the default Win32 manifest settings on Windows."""
+    return select({
+        "@platforms//os:windows": ["//bazel/win32:win32_default_manifest"],
+        "//conditions:default": [],
+    })
+
 def _update_visibility(visibility = None):
     """
     Returns updated visibility. This is temporarily used for the code location migration.
@@ -100,12 +107,28 @@ register_extension_info(
     label_regex_for_dep = "{extension_name}",
 )
 
-def mozc_cc_binary(deps = [], copts = [], linkopts = [], **kwargs):
+def mozc_cc_binary(deps = [], copts = [], linkopts = [], enable_win32_default_manifest = True, **kwargs):
+    """cc_binary wrapper adding default dependecies such as '//:macro'.
+
+    Args:
+      deps: deps for cc_binary.  //:macro is added.
+      copts: copts for cc_binary.
+      linkopts: linkopts for cc_binary.
+      enable_win32_default_manifest: optional. If True (default), embed the
+          default Win32 manifest settings on Windows. Ignored for shared
+          libraries, where an application manifest is not applicable.
+      **kwargs: other args for cc_binary.
     """
-    cc_binary wrapper adding //:macro dependecny.
-    """
+    win32_default_manifest_deps = []
+
+    # Skip shared libraries (linkshared = True). An application manifest is
+    # embedded as the RT_MANIFEST resource with ID 1, which the loader honors
+    # only for the executable (.exe), not for DLLs, so embedding it into a
+    # shared library would have no effect.
+    if enable_win32_default_manifest and not kwargs.get("linkshared"):
+        win32_default_manifest_deps = _win32_default_manifest_deps()
     cc_binary(
-        deps = deps + ["//:macro"],
+        deps = deps + ["//:macro"] + win32_default_manifest_deps,
         copts = copts + _copts_unsigned_char(),
         linkopts = linkopts + mozc_select(
             wasm = [
@@ -137,7 +160,7 @@ def mozc_cc_test(name, tags = [], deps = [], copts = [], **kwargs):
     cc_test(
         name = name,
         tags = tags,
-        deps = deps + ["//:macro"],
+        deps = deps + ["//:macro"] + _win32_default_manifest_deps(),
         copts = copts + _copts_unsigned_char(),
         **kwargs
     )
@@ -411,6 +434,9 @@ def mozc_win32_cc_prod_binary(
         srcs = srcs,
         defines = defines,
         deps = deps,
+        # Production binaries control their own manifests through
+        # mozc_win32_resource_from_template.
+        enable_win32_default_manifest = False,
         features = features,
         # '/CETCOMPAT' is available only on x86/x64 architectures.
         linkopts = modified_linkopts + select({


### PR DESCRIPTION
## Description
Currently unit tests and intermediate executables used during the build have no Win32 manifest at all, while production binaries specify the supported OS versions in their manifests. This means that tests run under a different OS compatibility context from production binaries, and executables without any manifest are also subject to the UAC installer-detection heuristic.

This is partly a regression from the GYP to Bazel migration. The GYP build linked every executable, including unit tests, with the `link_embed` rule (`gyp-win-tool link-with-manifests <arch> True ...`), which embedded a default manifest declaring
`requestedExecutionLevel="asInvoker"` into every executable. Note that the supported OS versions section was specified only for production binaries even in the GYP build though.

To fix the discrepancy, embed a default manifest, which consists of the compatibility section shared by all the production manifests, into all the executables built with `mozc_cc_test` and `mozc_cc_binary` on Windows.

The default manifest itself only carries the compatibility section and does not declare a `trustInfo` section, exactly like the production manifests. The execution level is still embedded: whenever a manifest is embedded into an executable (`/MANIFEST:EMBED`), the linker adds its default `trustInfo` section with `requestedExecutionLevel="asInvoker"`. As a result every test and intermediate executable now ends up with the same `asInvoker` level that both the production binaries and the old GYP build embed, restoring parity without having to spell it out in the manifest source.

Production binaries opt out and keep controlling their own manifests through `mozc_win32_resource_from_template`. Shared libraries are also skipped as an application manifest is not applicable to them.

Closes #1528.

## Issue IDs
 * https://github.com/google/mozc/issues/1528

## Steps to test new behaviors (if any)
 - OS: Windows 25H2
 - Steps:
   1. `bazelisk build //base:bits_test -c dbg`
   2. Confirm `bazel-bin/base/bits_test.exe` embeds Win32 manifest in its resource section.

