### PR TITLE
Split `win_util` from `system_util` target

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -474,16 +474,8 @@ mozc_cc_test(
 
 mozc_cc_library(
     name = "system_util",
-    # TODO(b/269889028): win_util has cyclic dependency between this library.
-    # Solve it and make them independent libraries.
-    srcs = ["system_util.cc"] +
-           mozc_select(
-               windows = ["//base/win32:win_util_cc"],
-           ),
-    hdrs = ["system_util.h"] +
-           mozc_select(
-               windows = ["//base/win32:win_util_h"],
-           ),
+    srcs = ["system_util.cc"],
+    hdrs = ["system_util.h"],
     local_defines = mozc_select(
         linux = [
             'MOZC_DOCUMENT_DIR=\\"' + LINUX_MOZC_DOCUMENT_DIR + '\\"',
@@ -496,7 +488,6 @@ mozc_cc_library(
         ":file_util",
         ":port",
         ":util",
-        "//bazel/win32:aux_ulib",  # win_util
         "//bazel/win32:imm32",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -511,9 +502,8 @@ mozc_cc_library(
         android = [":android_util"],
         apple = ["//base/mac:mac_util"],
         windows = [
-            ":vlog",
             "//base/win32:wide_char",
-            "@com_microsoft_wil//:wil",
+            "//base/win32:win_util",
         ],
     ),
 )

--- a/src/base/system_util.cc
+++ b/src/base/system_util.cc
@@ -64,11 +64,11 @@
 #include <windows.h>
 #include <lmcons.h>
 #include <sddl.h>
-#include <shlobj.h>
 #include <versionhelpers.h>
 // clang-format on
 
 #include <memory>  // for unique_ptr
+#include <optional>
 
 #include "base/win32/wide_char.h"
 #include "base/win32/win_util.h"
@@ -167,125 +167,6 @@ void UserProfileDirectoryImpl::SetDir(const std::string& dir) {
   dir_ = dir;
 }
 
-#ifdef _WIN32
-// TODO(yukawa): Use API wrapper so that unit test can emulate any case.
-class LocalAppDataDirectoryCache {
- public:
-  static LocalAppDataDirectoryCache *GetInstance() {
-    static absl::NoDestructor<LocalAppDataDirectoryCache> impl;
-    return impl.get();
-  }
-  HRESULT result() const { return result_; }
-  const bool succeeded() const { return SUCCEEDED(result_); }
-  const std::string& path() const { return path_; }
-
- private:
-  friend class absl::NoDestructor<LocalAppDataDirectoryCache>;
-
-  LocalAppDataDirectoryCache() : result_(E_FAIL) {
-    result_ = SafeTryGetLocalAppData(&path_);
-  }
-
-  // b/5707813 implies that TryGetLocalAppData causes an exception and makes
-  // Singleton<LocalAppDataDirectoryCache> invalid state which results in an
-  // infinite spin loop in call_once. To prevent this, the constructor of
-  // LocalAppDataDirectoryCache must be exception free.
-  // Note that __try and __except does not guarantees that any destruction
-  // of internal C++ objects when a non-C++ exception occurs except that
-  // /EHa compiler option is specified.
-  // Do not use /EHs option, otherwise we must admit potential
-  // memory leakes when any non-C++ exception occues in TryGetLocalAppData.
-  // See http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
-  static HRESULT __declspec(nothrow) SafeTryGetLocalAppData(std::string* dir) {
-    __try {
-      return TryGetLocalAppData(dir);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-      return E_UNEXPECTED;
-    }
-  }
-
-  static HRESULT TryGetLocalAppData(std::string* dir) {
-    if (dir == nullptr) {
-      return E_FAIL;
-    }
-    dir->clear();
-
-    bool in_app_container = false;
-    if (!WinUtil::IsProcessInAppContainer(::GetCurrentProcess(),
-                                          &in_app_container)) {
-      return E_FAIL;
-    }
-    if (in_app_container) {
-      return TryGetLocalAppDataForAppContainer(dir);
-    }
-    return TryGetLocalAppDataLow(dir);
-  }
-
-  static HRESULT TryGetLocalAppDataForAppContainer(std::string* dir) {
-    // User profiles for processes running under AppContainer seem to be as
-    // follows, while the scheme is not officially documented.
-    //   "%LOCALAPPDATA%\Packages\<package sid>\..."
-    // Note: You can also obtain this path by GetAppContainerFolderPath API.
-    // http://msdn.microsoft.com/en-us/library/windows/desktop/hh448543.aspx
-    // Anyway, here we use heuristics to obtain "LocalLow" folder path.
-    // TODO(yukawa): Establish more reliable way to obtain the path.
-    wchar_t config[MAX_PATH] = {};
-    const HRESULT result = ::SHGetFolderPathW(
-        nullptr, CSIDL_LOCAL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, &config[0]);
-    if (FAILED(result)) {
-      return result;
-    }
-    std::wstring path = config;
-    const std::wstring::size_type local_pos = path.find(L"\\Packages\\");
-    if (local_pos == std::wstring::npos) {
-      return E_FAIL;
-    }
-    path.erase(local_pos);
-    path += L"Low";
-    *dir = win32::WideToUtf8(path);
-    if (dir->empty()) {
-      return E_FAIL;
-    }
-    return S_OK;
-  }
-
-  static HRESULT TryGetLocalAppDataLow(std::string* dir) {
-    if (dir == nullptr) {
-      return E_FAIL;
-    }
-    dir->clear();
-
-    wchar_t* task_mem_buffer = nullptr;
-    const HRESULT result = ::SHGetKnownFolderPath(FOLDERID_LocalAppDataLow, 0,
-                                                  nullptr, &task_mem_buffer);
-    if (FAILED(result)) {
-      if (task_mem_buffer != nullptr) {
-        ::CoTaskMemFree(task_mem_buffer);
-      }
-      return result;
-    }
-
-    if (task_mem_buffer == nullptr) {
-      return E_UNEXPECTED;
-    }
-
-    std::wstring wpath = task_mem_buffer;
-    ::CoTaskMemFree(task_mem_buffer);
-
-    const std::string path = win32::WideToUtf8(wpath);
-    if (path.empty()) {
-      return E_UNEXPECTED;
-    }
-
-    *dir = path;
-    return S_OK;
-  }
-
-  HRESULT result_;
-  std::string path_;
-};
-#endif  // _WIN32
-
 std::string UserProfileDirectoryImpl::GetUserProfileDirectory() const {
   if constexpr (port::IsChromeos()) {
     // TODO(toka): Must use passed in user profile dir which passed in. If mojo
@@ -309,8 +190,10 @@ std::string UserProfileDirectoryImpl::GetUserProfileDirectory() const {
     return FileUtil::JoinPath({MacUtil::GetCachesDirectory(), kProductPrefix});
 
 #elif defined(_WIN32)
-    DCHECK(SUCCEEDED(LocalAppDataDirectoryCache::GetInstance()->result()));
-    std::string dir = LocalAppDataDirectoryCache::GetInstance()->path();
+    const std::optional<std::string>& local_app_data =
+        WinUtil::GetLocalAppDataPath();
+    DCHECK(local_app_data.has_value());
+    std::string dir = local_app_data.value_or("");
 
 #ifdef GOOGLE_JAPANESE_INPUT_BUILD
     dir = FileUtil::JoinPath(dir, kCompanyNameInEnglish);
@@ -395,71 +278,6 @@ void SystemUtil::SetUserProfileDirectory(const std::string& path) {
 
 #ifdef _WIN32
 namespace {
-// TODO(yukawa): Use API wrapper so that unit test can emulate any case.
-class ProgramFilesX86Cache {
- public:
-  static ProgramFilesX86Cache *GetInstance() {
-    static absl::NoDestructor<ProgramFilesX86Cache> impl;
-    return impl.get();
-  }
-  const bool succeeded() const { return SUCCEEDED(result_); }
-  const HRESULT result() const { return result_; }
-  const std::string& path() const { return path_; }
-
- private:
-  friend class absl::NoDestructor<ProgramFilesX86Cache>;
-
-  ProgramFilesX86Cache() : result_(E_FAIL) {
-    result_ = SafeTryProgramFilesPath(&path_);
-  }
-
-  // b/5707813 implies that the Shell API causes an exception in some cases.
-  // In order to avoid potential infinite loops in call_once. the constructor
-  // of ProgramFilesX86Cache must be exception free.
-  // Note that __try and __except does not guarantees that any destruction
-  // of internal C++ objects when a non-C++ exception occurs except that
-  // /EHa compiler option is specified.
-  // Do not use /EHs option, otherwise we must admit potential
-  // memory leakes when any non-C++ exception occues in TryProgramFilesPath.
-  // See http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
-  static HRESULT __declspec(nothrow) SafeTryProgramFilesPath(
-      std::string* path) {
-    __try {
-      return TryProgramFilesPath(path);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-      return E_UNEXPECTED;
-    }
-  }
-
-  static HRESULT TryProgramFilesPath(std::string* path) {
-    if (path == nullptr) {
-      return E_FAIL;
-    }
-    path->clear();
-
-    wchar_t program_files_path_buffer[MAX_PATH] = {};
-    // For historical reasons Mozc executables have been installed under
-    // %ProgramFiles(x86)%.
-    // TODO(https://github.com/google/mozc/issues/1086): Stop using "(x86)".
-    const HRESULT result =
-        ::SHGetFolderPathW(nullptr, CSIDL_PROGRAM_FILESX86, nullptr,
-                           SHGFP_TYPE_CURRENT, program_files_path_buffer);
-    if (FAILED(result)) {
-      return result;
-    }
-
-    const std::string program_files =
-        win32::WideToUtf8(program_files_path_buffer);
-    if (program_files.empty()) {
-      return E_FAIL;
-    }
-    *path = program_files;
-    return S_OK;
-  }
-  HRESULT result_;
-  std::string path_;
-};
-
 constexpr wchar_t kMozcTipClsid[] =
     L"SOFTWARE\\Classes\\CLSID\\"
 #ifdef GOOGLE_JAPANESE_INPUT_BUILD
@@ -504,15 +322,15 @@ std::string SystemUtil::GetServerDirectory() {
   if (!install_dir_from_registry.empty()) {
     return install_dir_from_registry;
   }
-  DCHECK(SUCCEEDED(ProgramFilesX86Cache::GetInstance()->result()));
+  const std::optional<std::string>& program_files =
+      WinUtil::GetProgramFilesX86Path();
+  DCHECK(program_files.has_value());
 #if defined(GOOGLE_JAPANESE_INPUT_BUILD)
   return FileUtil::JoinPath(
-      FileUtil::JoinPath(ProgramFilesX86Cache::GetInstance()->path(),
-                         kCompanyNameInEnglish),
+      FileUtil::JoinPath(program_files.value_or(""), kCompanyNameInEnglish),
       kProductNameInEnglish);
 #else   // GOOGLE_JAPANESE_INPUT_BUILD
-  return FileUtil::JoinPath(ProgramFilesX86Cache::GetInstance()->path(),
-                            kProductNameInEnglish);
+  return FileUtil::JoinPath(program_files.value_or(""), kProductNameInEnglish);
 #endif  // GOOGLE_JAPANESE_INPUT_BUILD
 
 #elif defined(__APPLE__)
@@ -776,55 +594,10 @@ std::string SystemUtil::GetDesktopNameAsString() {
 }
 
 #ifdef _WIN32
-namespace {
-
-// TODO(yukawa): Use API wrapper so that unit test can emulate any case.
-class SystemDirectoryCache {
- public:
-  static SystemDirectoryCache *GetInstance() {
-    static absl::NoDestructor<SystemDirectoryCache> impl;
-    return impl.get();
-  }
-  const bool succeeded() const { return system_dir_ != nullptr; }
-  const wchar_t* system_dir() const { return system_dir_; }
-
- private:
-  friend class absl::NoDestructor<SystemDirectoryCache>;
-
-  SystemDirectoryCache() : system_dir_(nullptr) {
-    const UINT copied_len_wo_null_if_success =
-        ::GetSystemDirectory(path_buffer_, std::size(path_buffer_));
-    if (copied_len_wo_null_if_success >= std::size(path_buffer_)) {
-      // Function failed.
-      return;
-    }
-    DCHECK_EQ(L'\0', path_buffer_[copied_len_wo_null_if_success]);
-    system_dir_ = path_buffer_;
-  }
-
-  wchar_t path_buffer_[MAX_PATH];
-  wchar_t* system_dir_;
-};
-
-}  // namespace
-
-// TODO(team): Support other platforms.
-bool SystemUtil::EnsureVitalImmutableDataIsAvailable() {
-  if (!SystemDirectoryCache::GetInstance()->succeeded()) {
-    return false;
-  }
-  if (!ProgramFilesX86Cache::GetInstance()->succeeded()) {
-    return false;
-  }
-  if (!LocalAppDataDirectoryCache::GetInstance()->succeeded()) {
-    return false;
-  }
-  return true;
-}
-
 const wchar_t* SystemUtil::GetSystemDir() {
-  DCHECK(SystemDirectoryCache::GetInstance()->succeeded());
-  return SystemDirectoryCache::GetInstance()->system_dir();
+  const std::optional<std::wstring>& dir = WinUtil::GetSystem32Path();
+  DCHECK(dir.has_value());
+  return dir.has_value() ? dir->c_str() : nullptr;
 }
 #endif  // _WIN32
 

--- a/src/base/system_util.h
+++ b/src/base/system_util.h
@@ -102,24 +102,6 @@ class SystemUtil {
   static std::string GetDesktopNameAsString();
 
 #ifdef _WIN32
-  // From an early stage of the development of Mozc, we have somehow abused
-  // CHECK macro assuming that any failure of fundamental APIs like
-  // ::SHGetFolderPathW or ::SHGetKnownFolderPathis is worth being notified
-  // as a crash.  But the circumstances have been changed.  As filed as
-  // b/3216603, increasing number of instances of various applications begin
-  // to use their own sandbox technology, where these kind of fundamental APIs
-  // are far more likely to fail with an unexpected error code.
-  // EnsureVitalImmutableDataIsAvailable is a simple fail-fast mechanism to
-  // this situation.  This function simply returns false instead of making
-  // the process crash if any of following functions cannot work as expected.
-  // - SystemDirectoryCache
-  // - ProgramFilesX86Cache
-  // - LocalAppDataDirectoryCache
-  // TODO(taku,yukawa): Implement more robust and reliable mechanism against
-  //   sandboxed environment, where such kind of fundamental APIs are far more
-  //   likely to fail.  See b/3216603.
-  static bool EnsureVitalImmutableDataIsAvailable();
-
   // return system directory. If failed, return nullptr.
   // You need not to delete the returned pointer.
   // This function is thread safe.

--- a/src/base/win32/BUILD.bazel
+++ b/src/base/win32/BUILD.bazel
@@ -147,6 +147,7 @@ mozc_cc_test(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        ":win_util",
         ":win_util_test_dll",  # fixdeps: keep
         "//base:system_util",
         "//testing:gunit_main",
@@ -162,7 +163,7 @@ mozc_cc_binary(
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],
     win_def_file = "win_util_test_dll.def",
-    deps = ["//base:system_util"],
+    deps = [":win_util"],
 )
 
 mozc_cc_library(
@@ -186,16 +187,24 @@ mozc_cc_library(
     ],
 )
 
-# TODO(b/269889028): Change these filegroup rules to mozc_cc_library after
-# fixing cyclic dependency with base:system_util.
-filegroup(
-    name = "win_util_h",
-    srcs = ["win_util.h"],
-)
-
-filegroup(
-    name = "win_util_cc",
+mozc_cc_library(
+    name = "win_util",
     srcs = ["win_util.cc"],
+    hdrs = ["win_util.h"],
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":wide_char",
+        "//base:vlog",
+        "//bazel/win32:aux_ulib",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:no_destructor",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_microsoft_wil//:wil",
+    ],
 )
 
 mozc_cc_library(

--- a/src/base/win32/win_util.cc
+++ b/src/base/win32/win_util.cc
@@ -36,21 +36,25 @@
 #include <aux_ulib.h>
 #include <psapi.h>
 #include <shellapi.h>
+#include <shlobj.h>
 #include <stringapiset.h>
 #include <wil/resource.h>
 #include <winternl.h>
 
 #include <clocale>
 #include <cstdint>
+#include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
 #include "absl/base/call_once.h"
+#include "absl/base/no_destructor.h"
+#include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "base/system_util.h"
 #include "base/vlog.h"
 #include "base/win32/wide_char.h"
 
@@ -88,6 +92,143 @@ bool IsProcessSandboxedImpl() {
 // TODO(b/290998032): Remove this.
 constexpr std::wstring_view to_wstring_view(const wchar_t* ptr) {
   return ptr == nullptr ? std::wstring_view() : std::wstring_view(ptr);
+}
+
+HRESULT TryGetLocalAppDataForAppContainer(std::string* dir) {
+  // User profiles for processes running under AppContainer seem to be as
+  // follows, while the scheme is not officially documented.
+  //   "%LOCALAPPDATA%\Packages\<package sid>\..."
+  // Note: You can also obtain this path by GetAppContainerFolderPath API.
+  // http://msdn.microsoft.com/en-us/library/windows/desktop/hh448543.aspx
+  // Anyway, here we use heuristics to obtain "LocalLow" folder path.
+  wchar_t config[MAX_PATH] = {};
+  const HRESULT result = ::SHGetFolderPathW(
+      nullptr, CSIDL_LOCAL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, &config[0]);
+  if (FAILED(result)) {
+    return result;
+  }
+  std::wstring path = config;
+  const std::wstring::size_type local_pos = path.find(L"\\Packages\\");
+  if (local_pos == std::wstring::npos) {
+    return E_FAIL;
+  }
+  path.erase(local_pos);
+  *dir = win32::WideToUtf8(path);
+  if (dir->empty()) {
+    return E_FAIL;
+  }
+  absl::StrAppend(dir, "Low");
+  return S_OK;
+}
+
+HRESULT TryGetLocalAppDataLow(std::string* dir) {
+  if (dir == nullptr) {
+    return E_FAIL;
+  }
+  dir->clear();
+
+  wchar_t* task_mem_buffer = nullptr;
+  const HRESULT result = ::SHGetKnownFolderPath(FOLDERID_LocalAppDataLow, 0,
+                                                nullptr, &task_mem_buffer);
+  if (FAILED(result)) {
+    if (task_mem_buffer != nullptr) {
+      ::CoTaskMemFree(task_mem_buffer);
+    }
+    return result;
+  }
+
+  if (task_mem_buffer == nullptr) {
+    return E_UNEXPECTED;
+  }
+
+  std::wstring wpath = task_mem_buffer;
+  ::CoTaskMemFree(task_mem_buffer);
+
+  const std::string path = win32::WideToUtf8(wpath);
+  if (path.empty()) {
+    return E_UNEXPECTED;
+  }
+
+  *dir = path;
+  return S_OK;
+}
+
+HRESULT TryGetLocalAppData(std::string* dir) {
+  if (dir == nullptr) {
+    return E_FAIL;
+  }
+  dir->clear();
+
+  bool in_app_container = false;
+  if (!WinUtil::IsProcessInAppContainer(::GetCurrentProcess(),
+                                        &in_app_container)) {
+    return E_FAIL;
+  }
+  if (in_app_container) {
+    return TryGetLocalAppDataForAppContainer(dir);
+  }
+  return TryGetLocalAppDataLow(dir);
+}
+
+// b/5707813 implies that TryGetLocalAppData causes an exception in some cases.
+// To prevent that from putting the cached value into an invalid state (which
+// historically resulted in an infinite spin loop in call_once), the value must
+// be computed by an exception-free function.
+// Note that __try and __except does not guarantees that any destruction
+// of internal C++ objects when a non-C++ exception occurs except that
+// /EHa compiler option is specified.
+// Do not use /EHs option, otherwise we must admit potential
+// memory leakes when any non-C++ exception occues in TryGetLocalAppData.
+// See http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
+HRESULT __declspec(nothrow) SafeTryGetLocalAppData(std::string* dir) {
+  __try {
+    return TryGetLocalAppData(dir);
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return E_UNEXPECTED;
+  }
+}
+
+HRESULT TryProgramFilesPath(std::string* path) {
+  if (path == nullptr) {
+    return E_FAIL;
+  }
+  path->clear();
+
+  wchar_t program_files_path_buffer[MAX_PATH] = {};
+  // For historical reasons Mozc executables have been installed under
+  // %ProgramFiles(x86)%.
+  // TODO(https://github.com/google/mozc/issues/1086): Stop using "(x86)".
+  const HRESULT result =
+      ::SHGetFolderPathW(nullptr, CSIDL_PROGRAM_FILESX86, nullptr,
+                         SHGFP_TYPE_CURRENT, program_files_path_buffer);
+  if (FAILED(result)) {
+    return result;
+  }
+
+  const std::string program_files =
+      win32::WideToUtf8(program_files_path_buffer);
+  if (program_files.empty()) {
+    return E_FAIL;
+  }
+  *path = program_files;
+  return S_OK;
+}
+
+// b/5707813 implies that the Shell API causes an exception in some cases.
+// In order to avoid potential infinite loops in call_once, the cached value
+// must be computed by an exception-free function.
+// Note that __try and __except does not guarantees that any destruction
+// of internal C++ objects when a non-C++ exception occurs except that
+// /EHa compiler option is specified.
+// Do not use /EHs option, otherwise we must admit potential
+// memory leaks when any non-C++ exception occurs in TryProgramFilesPath.
+// See http://msdn.microsoft.com/en-us/library/1deeycx5.aspx
+HRESULT __declspec(nothrow) SafeTryProgramFilesPath(std::string* path) {
+  __try {
+    return TryProgramFilesPath(path);
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    return E_UNEXPECTED;
+  }
 }
 
 }  // namespace
@@ -413,11 +554,53 @@ bool WinUtil::IsProcessSandboxed() {
   return sandboxed;
 }
 
+const std::optional<std::wstring>& WinUtil::GetSystem32Path() {
+  static const absl::NoDestructor<std::optional<std::wstring>> dir(
+      []() -> std::optional<std::wstring> {
+        wchar_t path_buffer[MAX_PATH] = {};
+        const UINT copied_len_wo_null_if_success =
+            ::GetSystemDirectory(path_buffer, std::size(path_buffer));
+        if (copied_len_wo_null_if_success >= std::size(path_buffer)) {
+          // Function failed.
+          return std::nullopt;
+        }
+        DCHECK_EQ(L'\0', path_buffer[copied_len_wo_null_if_success]);
+        return std::wstring(path_buffer);
+      }());
+  return *dir;
+}
+
+const std::optional<std::string>& WinUtil::GetProgramFilesX86Path() {
+  static const absl::NoDestructor<std::optional<std::string>> path(
+      []() -> std::optional<std::string> {
+        std::string program_files;
+        if (SUCCEEDED(SafeTryProgramFilesPath(&program_files))) {
+          return program_files;
+        }
+        return std::nullopt;
+      }());
+  return *path;
+}
+
+const std::optional<std::string>& WinUtil::GetLocalAppDataPath() {
+  static const absl::NoDestructor<std::optional<std::string>> dir(
+      []() -> std::optional<std::string> {
+        std::string path;
+        if (SUCCEEDED(SafeTryGetLocalAppData(&path))) {
+          return path;
+        }
+        return std::nullopt;
+      }());
+  return *dir;
+}
+
 bool WinUtil::ShellExecuteInSystemDir(const wchar_t* verb, const wchar_t* file,
                                       const wchar_t* parameters) {
+  const std::optional<std::wstring>& system_dir = GetSystem32Path();
   const auto result =
       static_cast<uint32_t>(reinterpret_cast<uintptr_t>(::ShellExecuteW(
-          0, verb, file, parameters, SystemUtil::GetSystemDir(), SW_SHOW)));
+          nullptr, verb, file, parameters,
+          system_dir.has_value() ? system_dir->c_str() : nullptr, SW_SHOW)));
   LOG_IF(ERROR, result <= 32)
       << "ShellExecute failed." << ", error:" << result
       << ", verb: " << win32::WideToUtf8(to_wstring_view(verb))

--- a/src/base/win32/win_util.h
+++ b/src/base/win32/win_util.h
@@ -34,6 +34,7 @@
 #include <windows.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -128,6 +129,18 @@ class WinUtil {
 
   // Returns true if the current process is restricted or in AppContainer.
   static bool IsProcessSandboxed();
+
+  // Returns the Windows system directory (e.g. "C:\\Windows\\System32"), or
+  // std::nullopt on failure. The result is computed once and cached.
+  static const std::optional<std::wstring>& GetSystem32Path();
+
+  // Returns the (x86) Program Files directory as UTF-8, or std::nullopt if it
+  // cannot be determined. The result is computed once and cached.
+  static const std::optional<std::string>& GetProgramFilesX86Path();
+
+  // Returns the LocalLow application data directory as UTF-8, or std::nullopt
+  // if it cannot be determined. The result is computed once and cached.
+  static const std::optional<std::string>& GetLocalAppDataPath();
 
   // Execute ShellExecute API with given parameters on the system directory,
   // which is expected to be more appropriate than tha directory where the

--- a/src/ipc/win32_ipc.cc
+++ b/src/ipc/win32_ipc.cc
@@ -51,7 +51,6 @@
 #include "base/vlog.h"
 #include "base/win32/wide_char.h"
 #include "base/win32/win_sandbox.h"
-#include "base/win32/win_util.h"
 #include "ipc/ipc.h"
 #include "ipc/ipc_path_manager.h"
 


### PR DESCRIPTION
## Description
This commit breaks the `system_util` <-> `win_util` cyclic dependency (`win_util` no longer references `SystemUtil`), so `win_util` is promoted from inlined filegroups into a standalone `mozc_cc_library` that `system_util` depends on.

To do so `base/system_util.cc` is modified by replacing the `SystemDirectoryCache`, `ProgramFilesX86Cache`, and
`LocalAppDataDirectoryCache` classes with cached
`std::optional`-returning functions, then move them to `base/win32/win_util.cc` as `WinUtil` methods:
  - `WinUtil::GetSystem32Path()`
  - `WinUtil::GetProgramFilesX86Path()`
  - `WinUtil::GetLocalAppDataPath()`

`std::optional models` "a cached path, or nothing" more directly than the previous `HRESULT` plumbing, whose error code was only ever `DCHECK`'d. The SEH (`__try`/`__except`) boundary is preserved in exception-free helper functions.

Also remove the now-unused
`SystemUtil::EnsureVitalImmutableDataIsAvailable()` and a dead `win_util.h` include in `ipc/win32_ipc.cc`.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. GitHub Actions still pass
