### PR TITLE
Let `build_qt.py` build Qt for the host arch

### DIFF
--- a/src/build_tools/build_qt.py
+++ b/src/build_tools/build_qt.py
@@ -408,7 +408,7 @@ def make_configure_options(args: argparse.Namespace) -> list[str]:
         '-platform',
         'win32-msvc',
     ]
-    if args.target_arch in ['x64', 'amd64']:
+    if args.target_arch == 'x64':
       qt_configure_options += ['-intelcet']
 
   if args.confirm_license:
@@ -490,7 +490,10 @@ def parse_args() -> argparse.Namespace:
   )
   if is_windows():
     parser.add_argument(
-        '--target_arch', help='"x64" or "arm64"', type=str, default='x64'
+        '--target_arch',
+        help='target architecture',
+        choices=['x64', 'arm64'],
+        default=normalize_win_arch(platform.uname().machine),
     )
     parser.add_argument(
         '--vcvarsall_path', help='Path of vcvarsall.bat', type=str, default=None
@@ -729,14 +732,21 @@ def normalize_win_arch(arch: str) -> str:
   """Normalize the architecture name for Windows build environment.
 
   Args:
-    arch: a string representation of a CPU architecture to be normalized.
+    arch: 'amd64', 'x64', 'arm64', or its capitalization variants.
 
   Returns:
-    String representation of a CPU architecture (e.g. 'x64' and 'arm64')
+    Either 'x64' or 'arm64'.
+
+  Raises:
+    ValueError: When the given architecture does not match any of them.
   """
-  normalized = arch.lower()
-  if normalized == 'amd64':
-    return 'x64'
+  normalized = {
+      'amd64': 'x64',
+      'x64': 'x64',
+      'arm64': 'arm64',
+  }.get(arch.lower())
+  if not normalized:
+    raise ValueError(f'Unsupported architecture: {arch}')
   return normalized
 
 


### PR DESCRIPTION
## Description
On macOS the target CPU architecture of `build_mozc.py` has already been determined based on the host CPU architecture. On Windows, however, `x64` has been the default value of `--target_arch` option.

As part of our on-going effort towards making it possible to build Mozc on Windows ARM64 machines (#1296), this commit works on this discrepancy to keep our build instructions shorter and simpler. With this commit, Qt will be built for ARM64 by default when building on ARM64 Windows machines.

Other minor improvements are:

  * `--target_arch` option is now restricted to `choices=["x64", "arm64"]`.
  * `normalize_win_arch()` is hardened to a whitelist: it maps the known inputs (`amd64`/`x64`/`arm64`) to their canonical names and raises `ValueError` on any unsupported architecture instead of silently passing it through.

If you happen to have specified `--target_arch=amd64`, please update it to `--target_arch=x64`. Other than that, there should be no impact on existing CI instances.

## Issue IDs
 * https://github.com/google/mozc/issues/1296

## Steps to test new behaviors (if any)
 - OS: Windows 25H2 ARM64
 - Steps:
   1. `python .\build_tools\build_qt.py --debug --release --confirm_license`
   2. Confirm that the Qt binaries are built for ARM64
