### PR TITLE
Resolve the Windows SDK tool dir on an Arm64 host

### DIFF
--- a/src/bazel/windows_sdk_repository.bzl
+++ b/src/bazel/windows_sdk_repository.bzl
@@ -115,10 +115,21 @@ def _windows_sdk_impl(repo_ctx):
         )
         return
 
-    # Hopefully "x86" and "arm64" should just work, but we need to check later.
-    arch = repo_ctx.os.arch
-    if arch == "amd64" or arch == "x86_64":
-        arch = "x64"
+    # Normalizes repo_ctx.os.arch to the Windows SDK's bin/<ver>/<arch> layout.
+    arch = {
+        "amd64": "x64",
+        "x86_64": "x64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(repo_ctx.os.arch.lower())
+    if not arch:
+        repo_ctx.file("BUILD.bazel", "")
+        repo_ctx.template(
+            "windows_sdk_rules.bzl",
+            repo_ctx.path(Label("@//bazel:windows_sdk_rules.noop.template.bzl")),
+            executable = False,
+        )
+        return
 
     winsdk_path = repo_ctx.path(winsdk_dir)
     repo_ctx.symlink(winsdk_path.get_child("bin/" + winsdk_ver + "/" + arch), "bin")


### PR DESCRIPTION
## Description
As part of our on-going effort towards making it possible to build Mozc on Windows ARM64 machines (#1296), this makes sure that `repo_ctx.os.arch` can be correctly mapped to the CPU arch name used by the Windows SDK directory structure even for Windows Arm64 build environment.

This commit also makes it clear that Windows 32-bit x86 environment is no longer supported to build Mozc for Windows.

Other than that, there must be no observable behavior change for developers who build Mozc on Windows x64 machines.

## Issue IDs

 * https://github.com/google/mozc/issues/1296

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2 (x64)
 - Steps:
   1. Confirm that the existing GitHub Actions still pass

