### PR TITLE
Avoid clang crash when building protobuf for arm64

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -63,6 +63,11 @@ build:compiler_msvc_like --cxxopt "/utf-8" --host_cxxopt "/utf-8"
 build:compiler_gcc_like  --per_file_copt="external/.*@-w" --host_per_file_copt="external/.*@-w"
 build:compiler_msvc_like --per_file_copt="external/.*@/w" --host_per_file_copt="external/.*@/w"
 
+# Make the following workaround for llvm/llvm-project#47432 work.
+# https://github.com/protocolbuffers/protobuf/commit/0e84323cd6fba27c7834b5596f3ef14b7e69e7b8
+build:compiler_msvc_like --per_file_copt="external/protobuf[+]/upb/wire/encode.c@/D__SEH__=1"
+build:compiler_msvc_like --host_per_file_copt="external/protobuf[+]/upb/wire/encode.c@/D__SEH__=1"
+
 ## Linux specific options
 build:linux_env --build_tag_filters=-nolinux --copt "-fPIC"
 test:linux_env   --test_tag_filters=-nolinux


### PR DESCRIPTION
## Description
As part of our on-going effort towards making it possible to build Mozc on Windows ARM64 machines (#1296), this commit works around a known compiler crash issue when building protobuf for Windows Arm64 target.

On the `aarch64-pc-windows-msvc` target, clang-cl 20.1.1 crashes when building `protobuf/upb/wire/encode.c` for Windows ARM64 target. This is due to a known compiler issue (https://github.com/llvm/llvm-project/issues/47432), which protobuf has already worked around (https://github.com/protocolbuffers/protobuf/commit/0e84323cd6fba27c7834b5596f3ef14b7e69e7b8).

The remaining issue for us is that the way how protobuf worked around this assumes that `__SEH__` macro is defined, which is only true when clang is used for -windows-gnu target the upstream bug was filed against. For us who use `-windows-msvc target`, the guard never fires.

As a quick workaround on our side, let's define `__SEH__` ourselves only for `protobuf/upb/wire/encode.c` and only when building Mozc for Windows.

Note that the per-file regex uses a `[+]` character class rather than `\+` because the bazelrc tokenizer strips the backslash before the pattern reaches the matcher.

## Issue IDs

 * https://github.com/google/mozc/issues/1296
