### PR TITLE
Make clang-cl toolchains host-agnostic

### DIFF
--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -1,6 +1,6 @@
 --- cc/private/toolchain/BUILD.windows.tpl
 +++ cc/private/toolchain/BUILD.windows.tpl
-@@ -85,6 +85,7 @@ cc_toolchain_suite(
+@@ -85,6 +85,7 @@
          "x64_windows|mingw-gcc": ":cc-compiler-x64_windows_mingw",
          "x64_x86_windows|mingw-gcc": ":cc-compiler-x64_x86_windows_mingw",
          "x64_windows|clang-cl": ":cc-compiler-x64_windows-clang-cl",
@@ -8,11 +8,26 @@
          "x64_windows_msys": ":cc-compiler-x64_windows_msys",
          "x64_windows": ":cc-compiler-x64_windows",
          "x64_x86_windows": ":cc-compiler-x64_x86_windows",
-@@ -670,6 +671,75 @@ toolchain(
-     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+@@ -644,6 +645,7 @@
+         "strip": "wrapper/bin/msvc_nop.bat",
+     },
+     archiver_flags = ["/MACHINE:X64"],
++    default_compile_flags = ["--target=x86_64-pc-windows-msvc"],
+     default_link_flags = ["/MACHINE:X64"],
+     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x64}",
+     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x64}",
+@@ -658,7 +660,6 @@
+ toolchain(
+     name = "cc-toolchain-x64_windows-clang-cl",
+     exec_compatible_with = [
+-        "@platforms//cpu:x86_64",
+         "@platforms//os:windows",
+         "@rules_cc//cc/private/toolchain:clang-cl",
+     ],
+@@ -671,6 +672,74 @@
  )
  
-+cc_toolchain(
+ cc_toolchain(
 +    name = "cc-compiler-x64_x86_windows-clang-cl",
 +    toolchain_identifier = "clang_cl_x64_x86",
 +    toolchain_config = ":clang_cl_x64_x86",
@@ -59,7 +74,7 @@
 +        "strip": "wrapper/bin/msvc_nop.bat",
 +    },
 +    archiver_flags = ["/MACHINE:X86"],
-+    default_compile_flags = ["-m32"],
++    default_compile_flags = ["--target=i686-pc-windows-msvc"],
 +    default_link_flags = ["/MACHINE:X86"],
 +    dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x86}",
 +    fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x86}",
@@ -69,7 +84,6 @@
 +toolchain(
 +    name = "cc-toolchain-x64_x86_windows-clang-cl",
 +    exec_compatible_with = [
-+        "@platforms//cpu:x86_64",
 +        "@platforms//os:windows",
 +        "@rules_cc//cc/private/toolchain:clang-cl",
 +    ],
@@ -81,10 +95,11 @@
 +    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 +)
 +
- cc_toolchain(
++cc_toolchain(
      name = "cc-compiler-arm64_windows-clang-cl",
      toolchain_identifier = "clang_cl_arm64",
-@@ -719,6 +789,7 @@
+     toolchain_config = ":clang_cl_arm64",
+@@ -717,6 +786,7 @@
          "strip": "wrapper/bin/msvc_nop.bat",
      },
      archiver_flags = ["/MACHINE:ARM64"],


### PR DESCRIPTION
## Description
As part of our on-going effort towards making it possible to build Mozc on Windows Arm64 machines (#1296), this commit further updates our local patches for rules_cc to make its clang-cl toolchains host-agnostic.

  * Add an explicit `--target=` to the x64 and x86 configs. Without it the Arm64-native clang-cl would fall back to its host default (aarch64) and miscompile the x64/x86 targets. The arm64 config already did this.
  * Drop the `@platforms//cpu:x86_64` `exec_compatible_with` pin from the x64 and x86 toolchains, matching what the arm64 toolchain already does, so they resolve on any Windows clang-cl host.

Above changes are relevant only when building Mozc on Windows Arm64 machines. There should be no observable changes in existing build pipelines running on Windows x64 hosts.

## Issue IDs

 * https://github.com/google/mozc/issues/1296
