### PR TITLE
Update GHA macOS runner from macOS 15 to macOS 26

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   build_arm64:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
-    runs-on: macos-15
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:
@@ -55,8 +55,8 @@ jobs:
           if-no-files-found: warn
 
   build_intel64:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
-    runs-on: macos-15
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:
@@ -96,8 +96,8 @@ jobs:
           if-no-files-found: warn
 
   build_universal_binary:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
-    runs-on: macos-15
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+    runs-on: macos-26
     timeout-minutes: 90
 
     steps:
@@ -137,8 +137,8 @@ jobs:
           if-no-files-found: warn
 
   test:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
-    runs-on: macos-15
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:
@@ -169,8 +169,8 @@ jobs:
   # in other jobs. Another approach would be to use "needs:".
   # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
   cache_deps:
-    # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
-    runs-on: macos-15
+    # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+    runs-on: macos-26
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Description
This commit updates GitHub Actions Runner for macOS from macos-15 to macos-26.

It should give us a newer build toolchain and test environment.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - Steps:
   1. Confirm GitHub Actions still pass.
