### PR TITLE
Use `windows-11-arm` runner to build Arm64 package

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_x64:
+  build_on_x64:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
     runs-on: windows-2025
     timeout-minutes: 120
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -57,7 +57,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build --config release_build package
+          bazelisk build package --config release_build
 
       - name: upload Mozc64_x64.msi
         uses: actions/upload-artifact@v6
@@ -66,7 +66,7 @@ jobs:
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
 
-  build_universal:
+  build_universal_on_x64:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
     runs-on: windows-2025
     timeout-minutes: 120
@@ -82,7 +82,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -110,7 +110,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build --config release_build --config win_universal_installer package
+          bazelisk build package --config release_build --config win_universal_installer
 
       - name: upload Mozc64_universal.msi
         uses: actions/upload-artifact@v6
@@ -119,9 +119,9 @@ jobs:
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
 
-  build_arm64:
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
-    runs-on: windows-2025
+  build_on_arm64:
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+    runs-on: windows-11-arm
     timeout-minutes: 120
 
     steps:
@@ -135,7 +135,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -144,11 +144,11 @@ jobs:
         run: |
           python build_tools/update_deps.py
 
-      - name: Build Qt (arm64)
+      - name: Build Qt
         shell: cmd
         working-directory: .\src
         run: |
-          python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
+          python build_tools/build_qt.py --release --confirm_license
 
       # This is needed only for GitHub Actions where free disk space is quite limited.
       - name: Delete Qt src to save disk space
@@ -163,7 +163,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build package --config release_build --platforms=//:windows-arm64
+          bazelisk build package --config release_build
 
       - name: upload Mozc64_arm64.msi
         uses: actions/upload-artifact@v6
@@ -172,7 +172,7 @@ jobs:
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
 
-  test:
+  test_on_x64:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
     runs-on: windows-2025
     timeout-minutes: 120
@@ -188,7 +188,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -216,14 +216,62 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: test-logs-${{ runner.os }}
+          name: test-logs-${{ runner.os }}-${{ runner.arch }}
+          path: test_logs
+          if-no-files-found: ignore
+
+  test_on_arm64:
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v5
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py
+
+      - name: runtests
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk test ... -c dbg --build_tests_only --build_event_json_file=bep.jsonl
+
+      - name: Collect failing test logs
+        if: failure()
+        shell: cmd
+        working-directory: .\src
+        run: |
+          python build_tools\collect_test_logs.py --bep bep.jsonl --out "%GITHUB_WORKSPACE%\test_logs"
+
+      - name: Upload failing test logs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-logs-${{ runner.os }}-${{ runner.arch }}
           path: test_logs
           if-no-files-found: ignore
 
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".
   # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
-  cache_deps:
+  cache_deps_on_x64:
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
     runs-on: windows-2025
     timeout-minutes: 15
@@ -239,7 +287,35 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py --cache_only
+
+  # actions/cache works without this job, but having this would increase the likelihood of cache hit
+  # in other jobs. Another approach would be to use "needs:".
+  # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
+  cache_deps_on_arm64:
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+    runs-on: windows-11-arm
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v5
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd

--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -15,7 +15,7 @@ cd mozc\src
 
 python build_tools/update_deps.py
 python build_tools/build_qt.py --release --confirm_license
-bazelisk build --config release_build package
+bazelisk build package --config release_build
 
 python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 ```
@@ -29,9 +29,6 @@ python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 
 64-bit Windows 10 or later.
 
-> [!IMPORTANT] Building Mozc on a Windows ARM64 environment is not yet supported
-> ([#1296](https://github.com/google/mozc/issues/1296)).
-
 ### Software Requirements
 
 Building Mozc on Windows requires the following software.
@@ -40,10 +37,18 @@ Building Mozc on Windows requires the following software.
     with the following components.
     *   Windows 11 SDK
     *   MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
+    *   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
     *   C++ ATL for latest v143 build tools (x86 & x64)
+    *   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 *   Python 3.12 or later.
 *   `.NET 6` or later (for `dotnet` command).
 *   [Bazelisk](https://github.com/bazelbuild/bazelisk)
+
+> [!TIP]
+> The following Visual Studio components can be skipped if you do not build Mozc
+> for ARM64.
+>  *   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
+>  *   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 
 > [!TIP]
 > Visual Studio 2026 Community Edition is also supported to build Mozc. When
@@ -93,7 +98,7 @@ Assuming `bazelisk` is in your `%PATH%`, run the following command to build Mozc
 for Windows.
 
 ```
-bazelisk build --config oss_windows --config release_build package
+bazelisk build package --config release_build
 ```
 
 #### Install Mozc
@@ -116,36 +121,31 @@ start ms-settings:appsfeatures-app
 
 Then, uninstall `Mozc` from the list of installed applications.
 
-### Build `Mozc64.msi` for ARM64
+### Cross compilation
 
-To compile executables for ARM64, the following Visual Studio components also
-need to be installed:
+By default, `Mozc64.msi` is built for the host CPU architecture. To explicitly
+specify the target CPU architecture, specify build options as follows:
 
-*   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
-*   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
+#### To build x64 installer
 
-To build `Mozc64.msi` for ARM64, run the following commands:
+```
+python build_tools/build_qt.py --release --confirm_license --target_arch=x64
+bazelisk build package --config release_build --platforms=//:windows-x86_64
+```
+
+#### To build ARM64 installer
 
 ```
 python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
-bazelisk build --config oss_windows --config release_build package --platforms=//:windows-arm64
+bazelisk build package --config release_build --platforms=//:windows-arm64
 ```
 
-### Build `Mozc64.msi` for both X64 and ARM64
-
-To built a X64 installer that is also compatible with ARM64 machines, run the
-following commands:
+#### To build a universal installer for both X64 and ARM64
 
 ```
-python build_tools/build_qt.py --release --confirm_license
-bazelisk build --config oss_windows --config release_build --config win_universal_installer package
+python build_tools/build_qt.py --release --confirm_license --target_arch=x64
+bazelisk build package --config release_build --platforms=//:windows-x86_64 --config win_universal_installer
 ```
-
-To build the above installer, the following Visual Studio components also need
-to be installed:
-
-*   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
-*   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 
 ## Bazel command examples
 
@@ -158,7 +158,7 @@ to be installed:
 ### Run all tests
 
 ```
-bazelisk test ... --config oss_windows --build_tests_only -c dbg
+bazelisk test ... --build_tests_only -c dbg
 ```
 
 > [!NOTE] `...` means all targets under the current and subdirectories.


### PR DESCRIPTION
## Description
Now that it is possible to build Mozc on Windows on Arm (Arm64) natively, we can switch a GitHub Actions job to build the Arm64 package from x64 cross-compilation to native compilation.

Other than that this commit includes the following minor changes:

  * Updated GitHub Actions cache name to avoid cache collision between x64 and Arm64 builds.
  * Updated job names in `windows.yaml` to clarify which runner is used.
  * Updated `build_mozc_in_windows.md` to simplify build instructions around cross-compilation.
  * Also fixed style issues in `build_mozc_in_windows.md`.

Closes #1296

## Issue IDs
 * https://github.com/google/mozc/issues/1296

## Steps to test new behaviors (if any)
 - OS: GitHub Actions
 - Steps:
   1. Confirm all GitHub Actions job succeed.
