### PR TITLE
Fix the loop condition in `SortAndVerifyUnique`

### DIFF
--- a/src/base/container/flat_internal.h
+++ b/src/base/container/flat_internal.h
@@ -80,7 +80,7 @@ template <class T, class Compare = std::less<>>
 constexpr void SortAndVerifyUnique(absl::Span<T> span,
                                    const Compare &cmp = Compare()) {
   std::sort(span.begin(), span.end(), cmp);
-  for (int i = 0; i + i < span.size(); ++i) {
+  for (int i = 0; i + 1 < span.size(); ++i) {
     if (!cmp(span[i], span[i + 1]) && !cmp(span[i + 1], span[i])) {
       DuplicateEntryFound();
     }

--- a/src/base/container/flat_set_test.cc
+++ b/src/base/container/flat_set_test.cc
@@ -69,5 +69,25 @@ TEST(FlatSetTest, CustomCompare) {
   EXPECT_FALSE(kSet.contains("six"));
 }
 
+TEST(FlatSetTest, SingleElement) {
+  // The uniqueness verification used to read past the end of the array for a
+  // single-element set, which failed the constant evaluation.
+  constexpr auto kSet = CreateFlatSet<int>({42});
+
+  EXPECT_TRUE(kSet.contains(42));
+  EXPECT_FALSE(kSet.contains(0));
+}
+
+#if defined(EXPECT_DEATH)
+TEST(FlatSetDeathTest, DuplicateEntries) {
+  // Runtime construction with duplicate entries hits LOG(FATAL). Compile-time
+  // construction with duplicate entries fails the build instead.
+  EXPECT_DEATH(CreateFlatSet<int>({1, 1, 2, 3, 4}), "Duplicate entry found");
+  // The uniqueness verification used to stop at the middle of the sorted
+  // array, missing duplicates in the second half.
+  EXPECT_DEATH(CreateFlatSet<int>({1, 2, 3, 4, 4}), "Duplicate entry found");
+}
+#endif  // defined(EXPECT_DEATH)
+
 }  // namespace
 }  // namespace mozc


### PR DESCRIPTION
## Description
The loop condition in `SortAndVerifyUnique()` was `i + i < span.size()` where `i + 1` was intended.

The good news is that there has been no immediate security impact, because the function is only evaluated at compile time, and we have never specified duplicate entries in the flat containers. So this commit is a preventive fix for future code that may use the flat containers with duplicate entries.

Here are the consequences of the bug:

- The duplicate check stopped at the middle of the sorted array, so duplicate entries in the second half were silently accepted.
- Constructing a `FlatSet` or `FlatMap` with a single entry read past the end of the array, which failed the constant evaluation and did not compile at all.

This change fixes the loop condition and adds regression tests for both cases. All the existing usages of the flat containers were verified to have no duplicate entries that the fixed check would newly reject.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. `bazelisk test //base/container:flat_set_test`
