### PR TITLE
Unify XML namespace style in Win32 manifest files

### DIFF
--- a/src/bazel/win32/win32_default.manifest
+++ b/src/bazel/win32/win32_default.manifest
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/src/gui/tool/mozc_tool.exe.manifest
+++ b/src/gui/tool/mozc_tool.exe.manifest
@@ -1,32 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-        PerMonitorV2
-      </dpiAwareness>
-    </asmv3:windowsSettings>
-  </asmv3:application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/renderer/win32/mozc_renderer.exe.manifest
+++ b/src/renderer/win32/mozc_renderer.exe.manifest
@@ -1,32 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-        PerMonitorV2
-      </dpiAwareness>
-    </asmv3:windowsSettings>
-  </asmv3:application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/server/mozc_server.exe.manifest
+++ b/src/server/mozc_server.exe.manifest
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/src/win32/broker/mozc_broker.exe.manifest
+++ b/src/win32/broker/mozc_broker.exe.manifest
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
-    </asmv3:windowsSettings>
-  </asmv3:application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/win32/cache_service/mozc_cache_service.exe.manifest
+++ b/src/win32/cache_service/mozc_cache_service.exe.manifest
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <!--
-    The namespace alias 'compat' below is added as a workaround for b/3034589.
-    If there is no alias, Manifest Tool version 6.1.7716.0 may add multiple
-    xmlns declarations, which might cause a heap corruption in sxs.dll on
-    Windows XP SP2 as shown in http://support.microsoft.com/kb/921337
-  -->
-  <compat:compatibility
-       xmlns:compat="urn:schemas-microsoft-com:compatibility.v1">
-    <compat:application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
       <!--The ID below indicates application support for Windows 10 -->
-      <compat:supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
       <!--The ID below indicates application support for Windows 8.1 -->
-      <compat:supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates application support for Windows 8 -->
-      <compat:supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!--The ID below indicates application support for Windows 7 -->
-      <compat:supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!--The ID below indicates application support for Windows Vista -->
-      <compat:supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-    </compat:application>
-  </compat:compatibility>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
## Description
As a preparation for the upcoming change to opt-in Segment Heap (#1539) by adding a new entry to the Win32 manifest files, this commit unifies the XML namespace style.

With this commit, each element will be declared with its own default XML namespace instead of using namespace prefix aliases, following the style used in the current Microsoft manifest documentation. The prefix aliases were a workaround for a Manifest Tool bug that could corrupt the heap in sxs.dll on Windows XP SP2, which is no longer relevant. Also write the `dpiAwareness` element on a single line for consistency with the other settings.

No behavior change is intended.

## Issue IDs

 * https://github.com/google/mozc/issues/1539

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Build `Mozc64.msi` and install it.
   2. Enable Mozc to type something.
   3. Make sure that "Operating System Context" , "UAC Virtualization", and "DPI Awareness" shown in the task manager remain unchanged for those without this commit.
