### PR TITLE
Enable Segment Heap for Windows 10 2004 and later

### DIFF
--- a/src/bazel/win32/win32_default.manifest
+++ b/src/bazel/win32/win32_default.manifest
@@ -14,4 +14,9 @@
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
     </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/gui/tool/mozc_tool.exe.manifest
+++ b/src/gui/tool/mozc_tool.exe.manifest
@@ -18,6 +18,7 @@
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/renderer/win32/mozc_renderer.exe.manifest
+++ b/src/renderer/win32/mozc_renderer.exe.manifest
@@ -18,6 +18,7 @@
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/server/mozc_server.exe.manifest
+++ b/src/server/mozc_server.exe.manifest
@@ -14,4 +14,9 @@
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
     </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
 </assembly>

--- a/src/win32/broker/mozc_broker.exe.manifest
+++ b/src/win32/broker/mozc_broker.exe.manifest
@@ -17,6 +17,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/win32/cache_service/mozc_cache_service.exe.manifest
+++ b/src/win32/cache_service/mozc_cache_service.exe.manifest
@@ -14,4 +14,9 @@
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
     </application>
   </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
## Description
Segment Heap is a modern heap implementation designed to be a successor to the NT Heap. It has been actively developed and improved since its introduction, and Win32 applications can opt into it through the application manifest since Windows 10, version 2004. There is indeed a [comment](https://devblogs.microsoft.com/cppblog/segment-heap-support-for-c-projects-in-visual-studio/?commentid=2790#comment-2790) that future hardware-based security features like memory tagging are on their roadmap.

As for our use case, simple benchmarks have shown that Segment Heap can be measurably faster than the NT Heap for `converter_main.exe` and `gen_system_dictionary_data_main.exe` built with `-c opt` running on Windows 11 25H2 (build 26200) and Intel Core i9-13900KF.

## `converter_main.exe` - proxy for mozc_server.exe conversion workload

10,000 conversion requests (the 500 hiragana keys from `data/test/quality_regression_test/oss.tsv`, repeated 20 times, fed as `s <key>` commands via stdin). The dictionary (`mozc.data`) is memory-mapped, so heap usage reflects working allocations only.

  | Metric (median, n=10)  | Segment Heap | NT Heap | Delta     |
  | ---------------------- | ------------ | ------- | --------- |
  | Wall time              | 4863 ms      | 5114 ms | -4.9%     |
  | CPU time               | 4047 ms      | 4313 ms | -6.2%     |
  | Peak working set       | 30.6 MB      | 29.5 MB | +1.0 MB   |
  | Peak commit            | 7.9 MB       | 7.0 MB  | +0.9 MB   |
  | Page faults            | 9.2 k        | 80 k    | -88%      |
  | Process startup        | ~23 ms       | ~23 ms  | no change |

The speedup correlates with the page-fault reduction: under conversion churn the NT heap keeps decommitting and recommitting pages, while Segment Heap retains them (hence ~1 MB higher watermark) and avoids the soft-fault overhead. The wall-time distributions do not overlap (Segment Heap worst case 5036 ms vs. NT heap best case 5060 ms).

## gen_system_dictionary_data_main.exe - dictionary build step

The actual `dictionary.data` genrule input (10 files of `data/dictionary_oss/dictionary*.txt`, 57.7 MB total, producing an 11.7 MB output). This tool builds the LOUDS/trie structures entirely on the heap (~0.5 GB peak), so it stresses the allocator much harder. Both variants produced byte-identical output.

  | Metric (median, n=10) | Segment Heap | NT Heap | Delta           |
  | --------------------- | ------------ | ------- | --------------- |
  | Wall time             | 2324 ms      | 2635 ms | -11.8%          |
  | CPU time              | 2266 ms      | 2578 ms | -12.1%          |
  | Peak working set      | 447 MB       | 494 MB  | -47 MB (-9.5%)  |
  | Peak commit           | 455 MB       | 513 MB  | -58 MB (-11.2%) |
  | Page faults           | 182 k        | 215 k   | -15%            |

The distributions do not overlap (worst 2420 ms vs. best 2476 ms). Enabling Segment Heap also makes the data-generation steps of the build measurably faster (~12% for this genrule), on top of the runtime benefits.

For tasks that are memory-intensive and/or have high churn, Segment Heap is expected to be measurably faster than the NT Heap.

Note that our code still runs with the legacy NT Heap in the following cases:

  * The code is compiled into `mozc_tip64.dll`, and `mozc_tip64.dll` is loaded into an NT-heap process.
  * The code is compiled into `mozc_*.exe`, and these executables are running on Windows 10 version 1909 or earlier.

That's fine as our code is agnostic to the heap implementation anyway.

Closes #1539.

## Issue IDs

 * https://github.com/google/mozc/issues/1539

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2 (x64)
 - Steps:
   1. Build `Mozc64.msi` and install it.
   2. Type something with Mozc
   3. `pwsh -NoProfile -Command "& 'C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe' -pv -pn mozc_server.exe -c '!heap; qd'"` then confirm the following lines.
```
0:000> cdb: Reading initial command '!heap; qd'
        Heap Address      NT/Segment Heap

    0000016dd2000000         Segment Heap
    0000016dd1660000              NT Heap
    0000016dd2500000         Segment Heap
    0000016dd2800000         Segment Heap
```
