### PR TITLE
Update GitHub Actions deps to the latest major ver

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get update
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -47,7 +47,7 @@ jobs:
           bazelisk build --config oss_android package --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: native_libs.zip
           path: src/bazel-bin/android/jni/native_libs.zip
@@ -60,13 +60,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Checkout without submodules to exclude third_party code from lint check
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
@@ -39,7 +39,7 @@ jobs:
           bazelisk build package --config release_build
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mozc.zip
           path: src/bazel-bin/unix/mozc.zip
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload failing test logs
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ runner.os }}
           path: test_logs

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -48,7 +48,7 @@ jobs:
           bazelisk build package --macos_cpus=arm64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc_arm64.pkg
           path: src/bazel-bin/mac/Mozc.pkg
@@ -61,13 +61,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -89,7 +89,7 @@ jobs:
           bazelisk build package --macos_cpus=x86_64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc_intel64.pkg
           path: src/bazel-bin/mac/Mozc.pkg
@@ -102,13 +102,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -130,7 +130,7 @@ jobs:
           bazelisk build package --macos_cpus=x86_64,arm64 --config release_build
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc_universal_binary.pkg
           path: src/bazel-bin/mac/Mozc.pkg
@@ -143,13 +143,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload failing test logs
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ runner.os }}
           path: test_logs
@@ -189,13 +189,13 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -60,7 +60,7 @@ jobs:
           bazelisk build package --config release_build
 
       - name: upload Mozc64_x64.msi
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc64_x64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
@@ -73,13 +73,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -113,7 +113,7 @@ jobs:
           bazelisk build package --config release_build --config win_universal_installer
 
       - name: upload Mozc64_universal.msi
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc64_universal.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
@@ -126,13 +126,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -166,7 +166,7 @@ jobs:
           bazelisk build package --config release_build
 
       - name: upload Mozc64_arm64.msi
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Mozc64_arm64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
@@ -179,13 +179,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload failing test logs
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ runner.os }}-${{ runner.arch }}
           path: test_logs
@@ -227,13 +227,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload failing test logs
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-${{ runner.os }}-${{ runner.arch }}
           path: test_logs
@@ -278,13 +278,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
@@ -306,13 +306,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: false
           persist-credentials: false
 
       - name: Try to restore update_deps cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: src/third_party_cache
           key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}


### PR DESCRIPTION
## Description
This commit updates the actions used in the GitHub Actions workflows as follows.

 * actions/checkout: v6 -> v7
 * actions/cache: v5 -> v6
 * actions/upload-artifact: v6 -> v7

There should be no impact on the workflow behavior, as the only behavioral change in the above updates is that actions/checkout v7 blocks checking out fork PRs under pull_request_target and workflow_run triggers, which are not used in our workflows.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. All GitHub Actions still pass.
