### PR TITLE
Fix bounds check in `CandidateList::MoveToPageIndex`

### DIFF
--- a/src/engine/candidate_list.cc
+++ b/src/engine/candidate_list.cc
@@ -304,7 +304,8 @@ bool CandidateList::MoveToId(const int base_id) {
 
 bool CandidateList::MoveToPageIndex(const size_t page_index) {
   const auto [begin, end] = GetPageRange(focused_index_);
-  if (begin + page_index > end) {
+  // Note: |end| is exclusive, i.e. the valid index range is [begin, end).
+  if (begin + page_index >= end) {
     return false;
   }
   focused_index_ = begin + page_index;

--- a/src/engine/candidate_list_test.cc
+++ b/src/engine/candidate_list_test.cc
@@ -227,6 +227,16 @@ TEST_F(CandidateListTest, MoveToPageIndex) {
   // main12
   EXPECT_TRUE(main_list_->MoveToId(10));
 
+  // main12 (id 10) is at page index 3 of the last page, whose valid page
+  // indexes are [0, 4) as the list has 13 elements in total.
+  EXPECT_TRUE(main_list_->MoveToPageIndex(3));
+  EXPECT_EQ(main_list_->focused_id(), 10);
+
+  // Regression test for https://github.com/google/mozc/issues/1543.
+  // Boundary check: page index 4 points to one past the last candidate.
+  EXPECT_FALSE(main_list_->MoveToPageIndex(4));
+  EXPECT_EQ(main_list_->focused_id(), 10);
+
   // invalid index
   EXPECT_FALSE(main_list_->MoveToPageIndex(7));
 }


### PR DESCRIPTION
## Description
It turned out that the root cause of the flaky test failure in `//session:session_handler_stress_test` was the off-by-one range check in `CandidateList::MoveToPageIndex`.

This commit fixes it with a regression test.

Closes #1543.

## Issue IDs

 * https://github.com/google/mozc/issues/1543

## Steps to test new behaviors (if any)
 - OS: All
 - Steps:
   1. `bazelisk test //engine:candidate_list_test`
