### PR TITLE
Apply missing styles in Qt-based `mozc_renderer`

### DIFF
--- a/src/renderer/qt/qt_window_manager.cc
+++ b/src/renderer/qt/qt_window_manager.cc
@@ -61,8 +61,12 @@ QString QStr(absl::string_view str) {
   return QString::fromUtf8(str.data(), str.size());
 }
 
-QBrush QBrushFromColor(RendererStyle::RGBAColor rgba) {
-  return QBrush(QColor(rgba.r(), rgba.g(), rgba.b(), 255 * rgba.a()));
+QColor QColorFromColor(const RendererStyle::RGBAColor& rgba) {
+  return QColor(rgba.r(), rgba.g(), rgba.b(), 255 * rgba.a());
+}
+
+QBrush QBrushFromColor(const RendererStyle::RGBAColor& rgba) {
+  return QBrush(QColorFromColor(rgba));
 }
 
 }  // namespace
@@ -117,6 +121,27 @@ void QtWindowManager::Initialize() {
   infolist_->setColumnCount(1);
   infolist_->setRowCount(3);
   infolist_->setColumnWidth(0, kInfolistWidth);
+
+  ApplyStyleToWidgets();
+}
+
+void QtWindowManager::ApplyStyleToWidgets() {
+  const QColor background =
+      QColorFromColor(style_.candidate_style().background_color());
+  const QColor foreground =
+      QColorFromColor(style_.candidate_style().foreground_color());
+
+  for (QTableWidget* table : {candidates_, infolist_}) {
+    if (table == nullptr) {
+      continue;
+    }
+    QPalette palette = table->palette();
+    palette.setColor(QPalette::Base, background);
+    palette.setColor(QPalette::Window, background);
+    palette.setColor(QPalette::Text, foreground);
+    palette.setColor(QPalette::WindowText, foreground);
+    table->setPalette(palette);
+  }
 }
 
 void QtWindowManager::HideAllWindows() {
@@ -296,6 +321,8 @@ void FillCandidateWindow(const commands::CandidateWindow& candidate_window,
 
   const QBrush shortcut_brush =
       QBrushFromColor(style.shortcut_style().foreground_color());
+  const QBrush candidate_brush =
+      QBrushFromColor(style.candidate_style().foreground_color());
   const QBrush description_brush =
       QBrushFromColor(style.description_style().foreground_color());
   const QBrush footer_bg_brush = QBrushFromColor(style.footer_bottom_color());
@@ -315,6 +342,7 @@ void FillCandidateWindow(const commands::CandidateWindow& candidate_window,
 
     // value
     auto item1 = new QTableWidgetItem(QStr(value));
+    item1->setForeground(candidate_brush);
     table->setItem(i, 1, item1);
 
     // description
@@ -523,10 +551,13 @@ void QtWindowManager::UpdateInfolistWindow(
   int total_height = 12;                 // Heuristics margin.
 
   // Caption title
-  absl::string_view caption = style_.infolist_style().caption_string();
+  const RendererStyle::InfolistStyle& infolist_style = style_.infolist_style();
+  absl::string_view caption = infolist_style.caption_string();
   QTableWidgetItem* infolist_title = new QTableWidgetItem(QStr(caption));
-  infolist_title->setBackground(QBrush(
-      QBrushFromColor(style_.infolist_style().caption_background_color())));
+  infolist_title->setBackground(
+      QBrushFromColor(infolist_style.caption_background_color()));
+  infolist_title->setForeground(
+      QBrushFromColor(infolist_style.caption_style().foreground_color()));
   infolist_->setItem(0, 0, infolist_title);
   total_height += GetItemHeight(*infolist_title);
 
@@ -537,6 +568,10 @@ void QtWindowManager::UpdateInfolistWindow(
     const std::string desc = info.information(i).description();
     const auto qtitle = new QTableWidgetItem(QString::fromUtf8(title.c_str()));
     const auto qdesc = new QTableWidgetItem(QString::fromUtf8(desc.c_str()));
+    qtitle->setForeground(
+        QBrushFromColor(infolist_style.title_style().foreground_color()));
+    qdesc->setForeground(
+        QBrushFromColor(infolist_style.description_style().foreground_color()));
 
     const int title_height = GetItemHeight(*qtitle);
     const int desc_height =

--- a/src/renderer/qt/qt_window_manager.h
+++ b/src/renderer/qt/qt_window_manager.h
@@ -83,6 +83,11 @@ class QtWindowManager {
 
   void OnClicked(int row, int column);
 
+  // Applies the foreground / background colors of the current style_ to the
+  // candidate and infolist widgets' palettes, so that areas not covered by
+  // individual cells (e.g. the viewport) also follow the theme.
+  void ApplyStyleToWidgets();
+
  private:
   QTableWidget *candidates_ = nullptr;
   QTableWidget *infolist_ = nullptr;


### PR DESCRIPTION
## Description
In the Qt-based renderer, foreground / background colors were not applied to the candidate and infolist tables. This was the case even before our previous commit (751df904ad247a34ee657567032e4adffb3f4710), which expanded our use of `renderer_style.textproto` to the Qt-based and Win32 renderers.

This commit applies the foreground / background colors to the candidate and infolist tables as defined in `renderer_style.textproto`.

Closes #1548.

## Issue IDs

 * https://github.com/google/mozc/issues/1548

## Steps to test new behaviors (if any)
 - OS: Ubuntu 26.04
 - Steps:
   1. `bazelisk build package --config oss_linux --config release_build`
   2. `unzip bazel-bin/unix/mozc.zip -d ~/mozc-bin`
   3. `sudo rsync -a ~/mozc-bin/usr/ /usr/`
   4. `ibus restart`
   5. Add Mozc an IBus input source. Then select Mozc as the current input source.
   6. `gnome-text-editor`
   7. Select Mozc. Type something.
   8. Observe the candidate window (to be prescience, suggest window)

## Additional context
| Before | After |
| ------- | ------ | 
| <img width="228" height="110" alt="Image" src="https://github.com/user-attachments/assets/48310627-d7bd-41a0-8ae0-6e8eb231e101" /> | <img width="228" height="110" alt="Image" src="https://github.com/user-attachments/assets/fbd526a7-b8c6-4306-9dde-3348056f0d0c" /> |