### PR TITLE
bzlmod: Update `rules_cc` to 0.2.22

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -122,11 +122,11 @@ bazel_dep(
     repo_name = "build_bazel_apple_support",
 )
 
-# rules_cc: 0.2.17 2026-02-18
+# rules_cc: 0.2.22 2026-07-07
 # https://github.com/bazelbuild/rules_cc/
 bazel_dep(
     name = "rules_cc",
-    version = "0.2.17",
+    version = "0.2.22",
 )
 single_version_override(
     module_name = "rules_cc",
@@ -137,7 +137,7 @@ single_version_override(
         "bazel/rules_cc_windows_cc_configure.bzl.patch",
         "bazel/rules_cc_windows_cc_toolchain_config.bzl.patch",
     ],
-    version = "0.2.17",
+    version = "0.2.22",
 )
 
 cc_configure = use_extension(

--- a/src/bazel/rules_cc_windows_cc_configure.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_configure.bzl.patch
@@ -1,6 +1,6 @@
 --- cc/private/toolchain/windows_cc_configure.bzl
 +++ cc/private/toolchain/windows_cc_configure.bzl
-@@ -920,11 +920,13 @@ def configure_windows_toolchain(repository_ctx):
+@@ -924,11 +924,13 @@ def configure_windows_toolchain(repository_ctx):
 
      template_vars = dict()
      msvc_vars_x64 = _get_msvc_vars(repository_ctx, paths, "x64")

--- a/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
+++ b/src/bazel/rules_cc_windows_cc_toolchain_config.bzl.patch
@@ -1,6 +1,6 @@
 --- cc/private/toolchain/windows_cc_toolchain_config.bzl
 +++ cc/private/toolchain/windows_cc_toolchain_config.bzl
-@@ -100,7 +100,7 @@ all_link_actions = [
+@@ -103,7 +103,7 @@ lto_index_actions = [
  ]
 
  def _use_msvc_toolchain(ctx):


### PR DESCRIPTION
## Description
`rules_cc` 0.2.17 and prior are not compatible with clang-cl version 22 and later, as the output format of `-v` option has changed.

In order to use newer versions of clang-cl, we first need to update `rules_cc` to 0.2.18 or later, which contains the fix for this issue (https://github.com/bazelbuild/rules_cc/commit/333af1f613817f0ca2239a5f6183a57c1cf5630a).

This commit updates `rules_cc` to 0.2.22, which is the latest version at the time of writing.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm all GitHub Actions still pass.
