### PR TITLE
Remove legacy `config_setting`s for C++ compilers

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -41,7 +41,6 @@ load(
     "mozc_select_enable_supplemental_model",
     "mozc_select_enable_usage_rewriter",
 )
-load("//:config.bzl", "BAZEL_TOOLS_PREFIX")
 load("//:version.bzl", "DEFAULT_BUILD_LABEL_MACOS")
 load("//bazel:stubs.bzl", "bzl_library")
 
@@ -96,36 +95,14 @@ config_setting(
     },
 )
 
-alias(
-    name = "compiler",
-    actual = BAZEL_TOOLS_PREFIX + "//tools/cpp:compiler",
-    visibility = ["//:__subpackages__"],
-)
-
-config_setting(
-    name = "compiler_msvc_cl",
-    flag_values = {
-        ":compiler": "msvc-cl",
-    },
-    visibility = ["//:__subpackages__"],
-)
-
-config_setting(
-    name = "compiler_clang_cl",
-    flag_values = {
-        ":compiler": "clang-cl",
-    },
-    visibility = ["//:__subpackages__"],
-)
-
 selects.config_setting_group(
     name = "compiler_msvc_like",
     match_any = [
         # clang-cl.exe is a drop-in replacement for cl.exe.
         # Command line options are mostly compatible.
         # https://clang.llvm.org/docs/MSVCCompatibility.html
-        ":compiler_clang_cl",
-        ":compiler_msvc_cl",
+        "@rules_cc//cc/compiler:clang-cl",
+        "@rules_cc//cc/compiler:msvc-cl",
     ],
     visibility = ["//:__subpackages__"],
 )


### PR DESCRIPTION
## Description
Mozc's own `config_setting`s `compiler_msvc_cl` and `compiler_clang_cl` were introduced 2 years ago as a preparation to support Bazel for the Windows (#948) (7b65824d90df3790ba144584084acfdbe8c041db). At that time Mozc was still using `WORKSPACE.bazel` to manage external dependencies and did not depend on `rules_cc`, so the pragmatic way to detect the compiler type was to define our own `config_settings` against the `compiler` flag exposed by `bazel_tools`.

Since then, `rules_cc` has been shipping equivalent `config_setting`s under `@rules_cc//cc/compiler` as the documented public API for this exact use case. They are keyed on the same underlying compiler flag reported by the resolved C++ toolchain, and Mozc now directly depends on `rules_cc` to set up its C++ toolchains (b8786636c91acf6eb3ec1dd25a55f4131bdde715), which means the canonical `config_setting`s are always available to us.

With this commit, our hand-rolled `config_setting`s and the `compiler` alias are removed in favor of the `rules_cc` ones.

No behavior change is intended. The build artifacts should remain bit-identical.

## Issue IDs
N/A

## Steps to test new behaviors
 - OS: Windows 11 25H2
 - Steps:
   1. Confirm GitHub Actions still pass.
