### PR TITLE
Guard FillIncognitoCandidateWords against empty incognito segments.

### DIFF
--- a/src/engine/engine_converter.cc
+++ b/src/engine/engine_converter.cc
@@ -1726,6 +1726,16 @@ void EngineConverter::FillAllCandidateWords(
 
 void EngineConverter::FillIncognitoCandidateWords(
     commands::CandidateList* candidates) const {
+  // |incognito_segments_| can be empty when the incognito prediction failed
+  // to produce suggestions (e.g. no user history in incognito mode).  Unlike
+  // FillAllCandidateWords(), this method had no bounds check and dereferenced
+  // the empty segment container.  Add the same guard as the sibling method.
+  if (segment_index_ >= incognito_segments_.conversion_segments_size()) {
+    LOG(WARNING) << "Invalid segment_index_: " << segment_index_
+                 << ", incognito_segments_size: "
+                 << incognito_segments_.conversion_segments_size();
+    return;
+  }
   const Segment& segment =
       incognito_segments_.conversion_segment(segment_index_);
   for (size_t i = 0; i < segment.candidates_size(); ++i) {

--- a/src/engine/engine_converter_test.cc
+++ b/src/engine/engine_converter_test.cc
@@ -2314,6 +2314,47 @@ TEST_F(EngineConverterTest, SuggestFillIncognitoCandidateWords) {
   }
 }
 
+TEST_F(EngineConverterTest, SuggestFillIncognitoCandidateWordsEmptySegments) {
+  Segments segments;
+  {  // Initialize mock segments for suggestion
+    Segment* segment = segments.add_segment();
+    converter::Candidate* candidate;
+    segment->set_key(kChars_Mo);
+    candidate = segment->add_candidate();
+    candidate->value = kChars_Mozukusu;
+    candidate->content_key = kChars_Mozukusu;
+    candidate = segment->add_candidate();
+    candidate->value = kChars_Momonga;
+    candidate->content_key = kChars_Momonga;
+  }
+  composer_->InsertCharacterPreedit(kChars_Mo);
+
+  // A matcher to test if the given conversion request sets incognito_mode().
+  constexpr auto IsIncognitoConversionRequest = [](bool is_incognito) {
+    return Property(&ConversionRequest::incognito_mode, Eq(is_incognito));
+  };
+  request_->set_fill_incognito_candidate_words(true);
+  auto mock_converter = std::make_shared<MockConverter>();
+  EngineConverter converter(mock_converter, request_, config_);
+
+  // Normal suggestion succeeds, but the incognito suggestion fails to produce
+  // any candidates.  In this case |incognito_segments_| is left empty even
+  // though the request asks to fill incognito candidate words.
+  // FillIncognitoCandidateWords must handle the empty container without
+  // accessing out-of-bounds segments.
+  EXPECT_CALL(*mock_converter,
+              StartPrediction(IsIncognitoConversionRequest(false), _))
+      .WillOnce(DoAll(SetArgPointee<1>(segments), Return(true)));
+  EXPECT_CALL(*mock_converter,
+              StartPrediction(IsIncognitoConversionRequest(true), _))
+      .WillOnce(Return(false));
+
+  EXPECT_TRUE(converter.Suggest(*composer_, Context::default_instance()));
+  commands::Output output;
+  converter.FillOutput(*composer_, &output);
+  EXPECT_FALSE(output.has_incognito_candidate_words());
+}
+
 TEST_F(EngineConverterTest, OnePhaseSuggestion) {
   auto mock_converter = std::make_shared<MockConverter>();
   EngineConverter converter(mock_converter, request_, config_);


### PR DESCRIPTION
## What

`EngineConverter::FillIncognitoCandidateWords()` accesses `incognito_segments_.conversion_segment(segment_index_)` without checking whether the container is non-empty.

## Root cause

When `fill_incognito_candidate_words` is set, `SuggestWithPreferences()` clears `incognito_segments_` and calls `StartPrediction()` in incognito mode. If that prediction fails (e.g. zero-query suggestion where the only candidates come from user history, which is disabled in incognito mode), the code falls through (see the existing `TODO(noriyukit): Check if fall through here is ok.`) and `incognito_segments_` stays empty. The state is still set to `SUGGESTION`, so a subsequent `FillOutput()` unconditionally calls `FillIncognitoCandidateWords()` (whenever the request flag is set), which then dereferences `conversion_segment(0)` on an empty `Segments` container. `Segments::conversion_segment()` is `*segments_[i + history_segments_size()]` with no bounds check, so this is an out-of-bounds read.

## Fix

Add the same size guard that the sibling method `FillAllCandidateWords()` already has:

```cpp
if (segment_index_ >= incognito_segments_.conversion_segments_size()) {
  LOG(WARNING) << "Invalid segment_index_: " << segment_index_
               << ", incognito_segments_size: "
               << incognito_segments_.conversion_segments_size();
  return;
}
```

## Test

Added `SuggestFillIncognitoCandidateWordsEmptySegments`, which mocks a successful normal suggestion followed by a failing incognito prediction and asserts that `FillOutput()` produces no incognito candidate words instead of crashing.