### PR TITLE
Honor `IS_PRIVATE` and `IBUS_INPUT_HINT_PRIVATE`

### DIFF
--- a/src/engine/engine_converter_test.cc
+++ b/src/engine/engine_converter_test.cc
@@ -3970,6 +3970,34 @@ TEST_F(EngineConverterTest, PredictWithContext) {
   EXPECT_TRUE(converter.Predict(*composer_, context));
 }
 
+TEST_F(EngineConverterTest, ConvertWithContextNoPersonalizedLearning) {
+  auto mock_converter = std::make_shared<MockConverter>();
+  EngineConverter converter(mock_converter, request_, config_);
+
+  commands::Context context;
+  context.set_no_personalized_learning(true);
+
+  EXPECT_CALL(*mock_converter, StartConversion(_, _))
+      .WillOnce([&](const ConversionRequest& req, Segments* segments) {
+        EXPECT_EQ(req.history_learning_level(), config::Config::READ_ONLY);
+        SetAiueo(segments);
+        return true;
+      });
+
+  composer_->InsertCharacterPreedit(kChars_Aiueo);
+  EXPECT_TRUE(converter.Convert(*composer_, context));
+
+  // The learning path on commit should also see the restricted level.
+  EXPECT_CALL(*mock_converter, CommitSegmentValue(_, 0, 0))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*mock_converter, FinishConversion(_, _))
+      .WillOnce([&](const ConversionRequest& req, Segments* segments) {
+        EXPECT_EQ(req.history_learning_level(), config::Config::READ_ONLY);
+        *segments = Segments();
+      });
+  converter.Commit(*composer_, context);
+}
+
 TEST_F(EngineConverterTest, FullSentenceCandidateInConversion) {
   auto mock_converter = std::make_shared<MockConverter>();
   EngineConverter converter(mock_converter, request_, config_);

--- a/src/prediction/user_history_predictor.cc
+++ b/src/prediction/user_history_predictor.cc
@@ -1439,7 +1439,7 @@ bool UserHistoryPredictor::ShouldPredict(
     return false;
   }
 
-  if (request.config().history_learning_level() == config::Config::NO_HISTORY) {
+  if (request.history_learning_level() == config::Config::NO_HISTORY) {
     MOZC_VLOG(2) << "history learning level is NO_HISTORY";
     return false;
   }
@@ -2005,10 +2005,9 @@ void UserHistoryPredictor::Finish(const ConversionRequest& request,
     return;
   }
 
-  if (request.config().history_learning_level() !=
-      config::Config::DEFAULT_HISTORY) {
+  if (request.history_learning_level() != config::Config::DEFAULT_HISTORY) {
     MOZC_VLOG(2) << "history learning level is not DEFAULT_HISTORY: "
-                 << request.config().history_learning_level();
+                 << request.history_learning_level();
     return;
   }
 

--- a/src/protocol/commands.proto
+++ b/src/protocol/commands.proto
@@ -537,6 +537,16 @@ message Context {
   // should update the revision whenever the input focus is changed.
   optional int32 revision = 5 [default = 0];
 
+  // Whether the input field being focused expects the IME not to update any
+  // personalized data with the user's input, e.g. the user conversion
+  // history. Unlike incognito mode, reading personalized data to perform
+  // conversion is still allowed. In other words, setting this field is
+  // equivalent to temporarily raising Config::history_learning_level to
+  // READ_ONLY. Converter modules need to check
+  // ConversionRequest::history_learning_level() instead of this value directly,
+  // as the effective learning level can be set in other ways.
+  optional bool no_personalized_learning = 6 [default = false];
+
   // Repeated fields to be used for experimental features.
   repeated string experimental_features = 100;
 }

--- a/src/request/conversion_request.h
+++ b/src/request/conversion_request.h
@@ -197,6 +197,19 @@ class ConversionRequest {
            request_->is_incognito_mode();
   }
 
+  // Returns the effective history learning level. Most code need to check this
+  // instead of Config::history_learning_level(), as the focused input field can
+  // restrict the learning level via Context::no_personalized_learning() (e.g. a
+  // field marked with the IS_PRIVATE input scope on Windows).
+  config::Config::HistoryLearningLevel history_learning_level() const {
+    if (context_->no_personalized_learning()) {
+      // READ_ONLY at minimum. Note that NO_HISTORY is stricter (larger).
+      return std::max(config_->history_learning_level(),
+                      config::Config::READ_ONLY);
+    }
+    return config_->history_learning_level();
+  }
+
   absl::string_view key() const ABSL_ATTRIBUTE_LIFETIME_BOUND { return key_; }
 
   // Takes the last `size` history key. return all value when size = -1.

--- a/src/request/conversion_request_test.cc
+++ b/src/request/conversion_request_test.cc
@@ -226,6 +226,42 @@ TEST(ConversionRequestTest, IncognitoModeTest) {
   }
 }
 
+TEST(ConversionRequestTest, HistoryLearningLevelTest) {
+  {
+    const ConversionRequest convreq = ConversionRequestBuilder().Build();
+    EXPECT_EQ(convreq.history_learning_level(),
+              config::Config::DEFAULT_HISTORY);
+  }
+  {
+    // The focused input field restricts the learning level to READ_ONLY.
+    commands::Context context;
+    context.set_no_personalized_learning(true);
+    const ConversionRequest convreq =
+        ConversionRequestBuilder().SetContext(context).Build();
+    EXPECT_EQ(convreq.history_learning_level(), config::Config::READ_ONLY);
+  }
+  {
+    config::Config config;
+    config.set_history_learning_level(config::Config::READ_ONLY);
+    const ConversionRequest convreq =
+        ConversionRequestBuilder().SetConfig(config).Build();
+    EXPECT_EQ(convreq.history_learning_level(), config::Config::READ_ONLY);
+  }
+  {
+    // NO_HISTORY in the config is stricter than the restriction by the
+    // context.
+    config::Config config;
+    config.set_history_learning_level(config::Config::NO_HISTORY);
+    commands::Context context;
+    context.set_no_personalized_learning(true);
+    const ConversionRequest convreq = ConversionRequestBuilder()
+                                          .SetConfig(config)
+                                          .SetContext(context)
+                                          .Build();
+    EXPECT_EQ(convreq.history_learning_level(), config::Config::NO_HISTORY);
+  }
+}
+
 TEST(ConversionRequestTest, GetSurroundingContextTest) {
   {
     commands::Context context;

--- a/src/rewriter/number_rewriter.cc
+++ b/src/rewriter/number_rewriter.cc
@@ -586,7 +586,7 @@ bool NumberRewriter::ShouldRerankCandidates(const ConversionRequest& request,
     MOZC_VLOG(2) << "incognito mode";
     return false;
   }
-  if (request.config().history_learning_level() == config::Config::NO_HISTORY) {
+  if (request.history_learning_level() == config::Config::NO_HISTORY) {
     MOZC_VLOG(2) << "history learning level is NO_HISTORY";
     return false;
   }
@@ -644,8 +644,7 @@ void NumberRewriter::Finish(const ConversionRequest& request,
     return;
   }
 
-  if (request.config().history_learning_level() !=
-      config::Config::DEFAULT_HISTORY) {
+  if (request.history_learning_level() != config::Config::DEFAULT_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is not DEFAULT_HISTORY";
     return;
   }

--- a/src/rewriter/user_boundary_history_rewriter.cc
+++ b/src/rewriter/user_boundary_history_rewriter.cc
@@ -177,8 +177,7 @@ void UserBoundaryHistoryRewriter::Finish(const ConversionRequest& request,
     return;
   }
 
-  if (request.config().history_learning_level() !=
-      config::Config::DEFAULT_HISTORY) {
+  if (request.history_learning_level() != config::Config::DEFAULT_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is not DEFAULT_HISTORY";
     return;
   }
@@ -205,7 +204,7 @@ UserBoundaryHistoryRewriter::CheckResizeSegmentsRequest(
     return std::nullopt;
   }
 
-  if (request.config().history_learning_level() == config::Config::NO_HISTORY) {
+  if (request.history_learning_level() == config::Config::NO_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is NO_HISTORY";
     return std::nullopt;
   }

--- a/src/rewriter/user_segment_history_rewriter.cc
+++ b/src/rewriter/user_segment_history_rewriter.cc
@@ -780,7 +780,7 @@ void UserSegmentHistoryRewriter::Finish(const ConversionRequest& request,
     return;
   }
 
-  if (request.config().history_learning_level() != Config::DEFAULT_HISTORY) {
+  if (request.history_learning_level() != Config::DEFAULT_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is not DEFAULT_HISTORY";
     return;
   }
@@ -933,7 +933,7 @@ bool UserSegmentHistoryRewriter::Rewrite(const ConversionRequest& request,
     return false;
   }
 
-  if (request.config().history_learning_level() == Config::NO_HISTORY) {
+  if (request.history_learning_level() == Config::NO_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is NO_HISTORY";
     return false;
   }

--- a/src/rewriter/variants_rewriter.cc
+++ b/src/rewriter/variants_rewriter.cc
@@ -569,8 +569,7 @@ bool VariantsRewriter::GenerateAlternatives(
 
 void VariantsRewriter::Finish(const ConversionRequest& request,
                               const Segments& segments) {
-  if (request.config().history_learning_level() !=
-      config::Config::DEFAULT_HISTORY) {
+  if (request.history_learning_level() != config::Config::DEFAULT_HISTORY) {
     MOZC_VLOG(2) << "history_learning_level is not DEFAULT_HISTORY";
     return;
   }

--- a/src/unix/ibus/ibus_wrapper.cc
+++ b/src/unix/ibus/ibus_wrapper.cc
@@ -254,6 +254,18 @@ void IbusEngineWrapper::GetContentType(uint* purpose, uint* hints) {
   ibus_engine_get_content_type(engine_, purpose, hints);
 }
 
+bool IbusEngineWrapper::HasPrivateInputHint() {
+#if IBUS_CHECK_VERSION(1, 5, 26)
+  uint purpose = IBUS_INPUT_PURPOSE_FREE_FORM;
+  uint hints = IBUS_INPUT_HINT_NONE;
+  GetContentType(&purpose, &hints);
+  return (hints & IBUS_INPUT_HINT_PRIVATE) != 0;
+#else   // IBUS_CHECK_VERSION(1, 5, 26)
+  // IBUS_INPUT_HINT_PRIVATE is available in IBus 1.5.26 and later.
+  return false;
+#endif  // IBUS_CHECK_VERSION(1, 5, 26)
+}
+
 void IbusEngineWrapper::CommitText(absl::string_view text) {
   IBusText* ibus_text = ibus_text_new_from_string(text.data());
   ibus_engine_commit_text(engine_, ibus_text);

--- a/src/unix/ibus/ibus_wrapper.h
+++ b/src/unix/ibus/ibus_wrapper.h
@@ -190,6 +190,13 @@ class IbusEngineWrapper {
 
   void GetContentType(uint* purpose, uint* hints);
 
+  // Returns true if the current input context has IBUS_INPUT_HINT_PRIVATE, i.e.
+  // the focused input field expects the IME not to update any personalized data
+  // with the user's input (e.g. a field in a browser's private browsing mode).
+  // Always returns false when built against IBus < 1.5.26, where
+  // IBUS_INPUT_HINT_PRIVATE is not available.
+  bool HasPrivateInputHint();
+
   void CommitText(absl::string_view text);
 
   void UpdatePreeditTextWithMode(IbusTextWrapper* text, int cursor);

--- a/src/unix/ibus/mozc_engine.cc
+++ b/src/unix/ibus/mozc_engine.cc
@@ -171,6 +171,17 @@ std::unique_ptr<client::ClientInterface> CreateAndConfigureClient() {
   return client;
 }
 
+// Returns a mozc::commands::Context that carries the state of the focused input
+// field. This context is expected to be attached to every message sent to the
+// server.
+commands::Context CreateContext(IbusEngineWrapper* engine) {
+  commands::Context context;
+  if (engine->HasPrivateInputHint()) {
+    context.set_no_personalized_learning(true);
+  }
+  return context;
+}
+
 std::optional<absl::string_view> GetMapValue(
     const absl::flat_hash_map<std::string, std::string>& map,
     absl::string_view key) {
@@ -266,7 +277,7 @@ void MozcEngine::CandidateClicked(IbusEngineWrapper* engine, uint index,
   commands::SessionCommand command;
   command.set_type(commands::SessionCommand::SELECT_CANDIDATE);
   command.set_id(id);
-  client_->SendCommand(command, &output);
+  client_->SendCommandWithContext(command, CreateContext(engine), &output);
   UpdateAll(engine, output);
 }
 
@@ -333,7 +344,8 @@ void MozcEngine::Enable(IbusEngineWrapper* engine) {
       command.set_composition_mode(mode);
     }
     commands::Output output;
-    if (!client_->SendCommand(command, &output)) {
+    if (!client_->SendCommandWithContext(command, CreateContext(engine),
+                                         &output)) {
       LOG(ERROR) << "SendCommand failed";
     }
     property_handler_->Update(engine, output);
@@ -397,7 +409,7 @@ bool MozcEngine::ProcessKeyEvent(IbusEngineWrapper* engine, uint keyval,
   key.set_activated(property_handler_->IsActivated());
   key.set_mode(property_handler_->GetOriginalCompositionMode());
 
-  commands::Context context;
+  commands::Context context = CreateContext(engine);
   SurroundingTextInfo surrounding_text_info;
   if (GetSurroundingText(engine, &surrounding_text_info)) {
     context.set_preceding_text(surrounding_text_info.preceding_text);
@@ -551,7 +563,8 @@ void MozcEngine::RevertSession(IbusEngineWrapper* engine) {
   commands::SessionCommand command;
   command.set_type(commands::SessionCommand::REVERT);
   commands::Output output;
-  if (!client_->SendCommand(command, &output)) {
+  if (!client_->SendCommandWithContext(command, CreateContext(engine),
+                                       &output)) {
     LOG(ERROR) << "RevertSession() failed";
     return;
   }
@@ -612,7 +625,8 @@ bool MozcEngine::ExecuteCallback(IbusEngineWrapper* engine,
   }
 
   commands::Output new_output;
-  if (!client_->SendCommand(session_command, &new_output)) {
+  if (!client_->SendCommandWithContext(session_command, CreateContext(engine),
+                                       &new_output)) {
     LOG(ERROR) << "Callback Command Failed";
     return false;
   }

--- a/src/unix/ibus/property_handler.cc
+++ b/src/unix/ibus/property_handler.cc
@@ -383,9 +383,14 @@ void PropertyHandler::UpdateCompositionModeIcon(
 }
 
 void PropertyHandler::SetCompositionMode(
-    commands::CompositionMode composition_mode) {
+    IbusEngineWrapper* engine, commands::CompositionMode composition_mode) {
   commands::SessionCommand command;
   commands::Output output;
+
+  commands::Context context;
+  if (engine->HasPrivateInputHint()) {
+    context.set_no_personalized_learning(true);
+  }
 
   // In the case of Mozc, there are two state values of IME, IMEOn/IMEOff and
   // composition_mode. However in IBus we can only control composition mode, not
@@ -396,11 +401,11 @@ void PropertyHandler::SetCompositionMode(
   if (is_activated_ && composition_mode == kImeOffCompositionMode) {
     command.set_type(commands::SessionCommand::TURN_OFF_IME);
     command.set_composition_mode(original_composition_mode_);
-    client_->SendCommand(command, &output);
+    client_->SendCommandWithContext(command, context, &output);
   } else {
     command.set_type(commands::SessionCommand::SWITCH_COMPOSITION_MODE);
     command.set_composition_mode(composition_mode);
-    client_->SendCommand(command, &output);
+    client_->SendCommandWithContext(command, context, &output);
   }
   DCHECK(output.has_status());
   original_composition_mode_ = output.status().mode();
@@ -455,7 +460,7 @@ void PropertyHandler::ProcessPropertyActivate(IbusEngineWrapper* engine,
       if (!entry) {
         continue;
       }
-      SetCompositionMode(entry->composition_mode);
+      SetCompositionMode(engine, entry->composition_mode);
       UpdateCompositionModeIcon(engine, entry->composition_mode);
       break;
     }

--- a/src/unix/ibus/property_handler.h
+++ b/src/unix/ibus/property_handler.h
@@ -95,7 +95,8 @@ class PropertyHandler {
   void UpdateCompositionModeIcon(
       IbusEngineWrapper* engine,
       commands::CompositionMode new_composition_mode);
-  void SetCompositionMode(commands::CompositionMode composition_mode);
+  void SetCompositionMode(IbusEngineWrapper* engine,
+                          commands::CompositionMode composition_mode);
 
   IbusPropListWrapper prop_root_;
   IbusPropertyWrapper prop_composition_mode_;

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -788,6 +788,7 @@ mozc_cc_library(
         "//win32/base:conversion_mode_util",
         "//win32/base:indicator_visibility_tracker",
         "//win32/base:keyboard",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/types:span",
     ],
 )

--- a/src/win32/tip/tip_edit_session.cc
+++ b/src/win32/tip/tip_edit_session.cc
@@ -216,7 +216,10 @@ class AsyncSwitchInputModeEditSessionImpl final
       SessionCommand command;
       command.set_type(commands::SessionCommand::TURN_OFF_IME);
       command.set_composition_mode(mozc_mode);
-      if (!private_context->GetClient()->SendCommand(command, &output)) {
+      if (!private_context->GetClient()->SendCommandWithContext(
+              command,
+              TipEditSessionImpl::CreateMozcContext(text_service_.get()),
+              &output)) {
         return E_FAIL;
       }
     } else if (!input_mode_manager->GetEffectiveOpenClose()) {
@@ -225,7 +228,10 @@ class AsyncSwitchInputModeEditSessionImpl final
       SessionCommand command;
       command.set_type(commands::SessionCommand::TURN_ON_IME);
       command.set_composition_mode(mozc_mode);
-      if (!private_context->GetClient()->SendCommand(command, &output)) {
+      if (!private_context->GetClient()->SendCommandWithContext(
+              command,
+              TipEditSessionImpl::CreateMozcContext(text_service_.get()),
+              &output)) {
         return E_FAIL;
       }
     } else {
@@ -234,7 +240,10 @@ class AsyncSwitchInputModeEditSessionImpl final
       SessionCommand command;
       command.set_type(SessionCommand::SWITCH_COMPOSITION_MODE);
       command.set_composition_mode(mozc_mode);
-      if (!private_context->GetClient()->SendCommand(command, &output)) {
+      if (!private_context->GetClient()->SendCommandWithContext(
+              command,
+              TipEditSessionImpl::CreateMozcContext(text_service_.get()),
+              &output)) {
         return E_FAIL;
       }
     }
@@ -285,7 +294,10 @@ class AsyncSessionCommandEditSessionImpl final
     if (private_context == nullptr) {
       return E_FAIL;
     }
-    if (!private_context->GetClient()->SendCommand(session_command_, &output)) {
+    if (!private_context->GetClient()->SendCommandWithContext(
+            session_command_,
+            TipEditSessionImpl::CreateMozcContext(text_service_.get()),
+            &output)) {
       return E_FAIL;
     }
     return TipEditSessionImpl::UpdateContext(
@@ -353,7 +365,9 @@ bool TurnOnImeAndTryToReconvertFromIme(TipTextService* text_service,
     SessionCommand command;
     command.set_type(SessionCommand::CONVERT_REVERSE);
     command.set_text(text_utf8);
-    if (!private_context->GetClient()->SendCommand(command, &output)) {
+    if (!private_context->GetClient()->SendCommandWithContext(
+            command, TipEditSessionImpl::CreateMozcContext(text_service),
+            &output)) {
       return false;
     }
   }
@@ -388,7 +402,9 @@ bool UndoCommint(TipTextService* text_service, ITfContext* context) {
   {
     SessionCommand command;
     command.set_type(SessionCommand::UNDO);
-    if (!private_context->GetClient()->SendCommand(command, &output)) {
+    if (!private_context->GetClient()->SendCommandWithContext(
+            command, TipEditSessionImpl::CreateMozcContext(text_service),
+            &output)) {
       return false;
     }
   }
@@ -837,7 +853,9 @@ bool TipEditSession::ReconvertFromApplicationSync(TipTextService* text_service,
   command.set_type(SessionCommand::CONVERT_REVERSE);
   command.set_text(WideToUtf8(selected_text));
   Output output;
-  if (!private_context->GetClient()->SendCommand(command, &output)) {
+  if (!private_context->GetClient()->SendCommandWithContext(
+          command, TipEditSessionImpl::CreateMozcContext(text_service),
+          &output)) {
     return false;
   }
   return OnOutputReceivedSync(text_service, context.get(), std::move(output));

--- a/src/win32/tip/tip_edit_session_impl.cc
+++ b/src/win32/tip/tip_edit_session_impl.cc
@@ -627,7 +627,8 @@ HRESULT TipEditSessionImpl::OnCompositionTerminated(
   if (private_context == nullptr) {
     return E_FAIL;
   }
-  if (!private_context->GetClient()->SendCommand(command, &output)) {
+  if (!private_context->GetClient()->SendCommandWithContext(
+          command, CreateMozcContext(text_service), &output)) {
     return E_FAIL;
   }
   const HRESULT result = DoEditSessionAfterComposition(text_service, context,
@@ -650,6 +651,17 @@ void TipEditSessionImpl::UpdateUI(TipTextService* text_service,
                                   ITfContext* context,
                                   TfEditCookie read_cookie) {
   TipUiHandler::Update(text_service, context, read_cookie);
+}
+
+commands::Context TipEditSessionImpl::CreateMozcContext(
+    TipTextService* text_service) {
+  commands::Context mozc_context;
+  TipThreadContext* thread_context = text_service->GetThreadContext();
+  mozc_context.set_revision(thread_context->GetFocusRevision());
+  if (thread_context->GetInputModeManager()->HasPrivateInputScope()) {
+    mozc_context.set_no_personalized_learning(true);
+  }
+  return mozc_context;
 }
 
 }  // namespace tsf

--- a/src/win32/tip/tip_edit_session_impl.h
+++ b/src/win32/tip/tip_edit_session_impl.h
@@ -75,6 +75,12 @@ class TipEditSessionImpl {
   // - Invokes UI update.
   static void UpdateUI(TipTextService* text_service, ITfContext* context,
                        TfEditCookie read_cookie);
+
+  // Returns a mozc::commands::Context that carries the state of the focused
+  // input field managed by the thread context, that is, the focus revision and
+  // the learning suppression expected by the IS_PRIVATE input scope. This
+  // context is expected to be attached to every message sent to the server.
+  static commands::Context CreateMozcContext(TipTextService* text_service);
 };
 
 }  // namespace tsf

--- a/src/win32/tip/tip_input_mode_manager.cc
+++ b/src/win32/tip/tip_input_mode_manager.cc
@@ -35,6 +35,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/types/span.h"
 #include "protocol/commands.pb.h"
 #include "win32/base/conversion_mode_util.h"
@@ -282,6 +283,10 @@ TipInputModeManager::Action TipInputModeManager::OnChangeInputScope(
     return kUpdateUI;
   }
   return kDoNothing;
+}
+
+bool TipInputModeManager::HasPrivateInputScope() const {
+  return absl::c_contains(input_scope_, IS_PRIVATE);
 }
 
 bool TipInputModeManager::GetEffectiveOpenClose() const {

--- a/src/win32/tip/tip_input_mode_manager.h
+++ b/src/win32/tip/tip_input_mode_manager.h
@@ -113,6 +113,11 @@ class TipInputModeManager : public TipInputModeManagerImpl {
   Action OnChangeConversionMode(DWORD new_conversion_mode);
   Action OnChangeInputScope(absl::Span<const InputScope> input_scopes);
 
+  // Returns true if the current input scopes contain IS_PRIVATE, i.e. the
+  // focused input field expects the IME not to update any personalized data
+  // with the user's input (e.g. a field in a browser's private browsing mode).
+  bool HasPrivateInputScope() const;
+
   // Returns an IME open/close state that is visible from the Mozc session.
   bool GetEffectiveOpenClose() const;
   // Returns an IME open/close state that is visible from TSF.

--- a/src/win32/tip/tip_input_mode_manager_test.cc
+++ b/src/win32/tip/tip_input_mode_manager_test.cc
@@ -316,6 +316,32 @@ TEST(TipInputModeManagerTest, InputScopeOnSetFocus_GitHubIssue826) {
             commands::HIRAGANA);
 }
 
+TEST(TipInputModeManagerTest, HasPrivateInputScope) {
+  TipInputModeManager input_mode_manager(GetThreadLocalMode());
+
+  // Initialize (Off + Hiragana)
+  input_mode_manager.OnInitialize(false, kNativeHiragana);
+  EXPECT_FALSE(input_mode_manager.HasPrivateInputScope());
+
+  // SetFocus with IS_PRIVATE (e.g. a field in private browsing mode).
+  // IS_PRIVATE should not affect the open/close mode.
+  std::vector<InputScope> input_scope_private = {IS_DEFAULT, IS_PRIVATE};
+  input_mode_manager.OnSetFocus(false, kNativeHiragana, input_scope_private);
+  EXPECT_TRUE(input_mode_manager.HasPrivateInputScope());
+  EXPECT_FALSE(input_mode_manager.GetEffectiveOpenClose());
+  EXPECT_EQ(input_mode_manager.GetEffectiveConversionMode(),
+            commands::HIRAGANA);
+
+  // InputScope change to a normal field.
+  std::vector<InputScope> input_scope_default = {IS_DEFAULT};
+  input_mode_manager.OnChangeInputScope(input_scope_default);
+  EXPECT_FALSE(input_mode_manager.HasPrivateInputScope());
+
+  // InputScope change back to a private field.
+  input_mode_manager.OnChangeInputScope(input_scope_private);
+  EXPECT_TRUE(input_mode_manager.HasPrivateInputScope());
+}
+
 }  // namespace
 }  // namespace tsf
 }  // namespace win32

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -49,6 +49,7 @@
 #include "win32/base/keyevent_handler.h"
 #include "win32/base/surrogate_pair_observer.h"
 #include "win32/tip/tip_edit_session.h"
+#include "win32/tip/tip_edit_session_impl.h"
 #include "win32/tip/tip_input_mode_manager.h"
 #include "win32/tip/tip_private_context.h"
 #include "win32/tip/tip_status.h"
@@ -138,8 +139,7 @@ void FillMozcContextCommon(TipTextService* text_service, ITfContext* context,
   if (mozc_context == nullptr) {
     return;
   }
-  mozc_context->set_revision(
-      text_service->GetThreadContext()->GetFocusRevision());
+  *mozc_context = TipEditSessionImpl::CreateMozcContext(text_service);
   wil::com_ptr_nothrow<ITfContextView> context_view;
   if (FAILED(context->GetActiveView(&context_view))) {
     return;
@@ -390,7 +390,9 @@ HRESULT OnKey(TipTextService* text_service, ITfContext* context,
     // Handle PrevPage button on the on-screen keyboard.
     SessionCommand command;
     command.set_type(SessionCommand::CONVERT_PREV_PAGE);
-    if (!private_context->GetClient()->SendCommand(command, &temporal_output)) {
+    if (!private_context->GetClient()->SendCommandWithContext(
+            command, TipEditSessionImpl::CreateMozcContext(text_service),
+            &temporal_output)) {
       *eaten = FALSE;
       return E_FAIL;
     }
@@ -400,7 +402,9 @@ HRESULT OnKey(TipTextService* text_service, ITfContext* context,
     // Handle NextPage button on the on-screen keyboard.
     SessionCommand command;
     command.set_type(SessionCommand::CONVERT_NEXT_PAGE);
-    if (!private_context->GetClient()->SendCommand(command, &temporal_output)) {
+    if (!private_context->GetClient()->SendCommandWithContext(
+            command, TipEditSessionImpl::CreateMozcContext(text_service),
+            &temporal_output)) {
       *eaten = FALSE;
       return E_FAIL;
     }


### PR DESCRIPTION
## Description
This commit aims to make use of `IS_PRIVATE`/`IBUS_INPUT_HINT_PRIVATE` signals in TSF/IBus by dynamically adjusting the learning level. To do so, a new `Context.no_personalized_learning` boolean field is introduced. The new field is interpreted as temporarily raising the effective `Config::history_learning_level` to `READ_ONLY`, so all the existing learning-suppression code paths are reused as-is.

The reason why this commit ended up introducing a new field in `Context` rather than reusing `Request.is_incognito_mode` like Mozc for Android is a bit ironic. Here is the historical context:

Mozc has supported its own "secret mode" concept long before it started supporting the Android Client. Its "secret mode" not only disables personalized learning but also disables personalized features such as user dictionary and history-based suggestions. On the other hand, `IME_FLAG_NO_PERSONALIZED_LEARNING` in Android IME API does not require the IME to disable all the personalized features. Its only request for the IME is to disable personalized learning, which is what I deliberately intended when designing the API (https://github.com/aosp-mirror/platform_frameworks_base/commit/5959af13d069e77ff2b2ac729225e7d248b83a79). The API was designed to keep Android API vendor-neutral and independent of app-specific concepts like "incognito" mode, which could have been changed at any time.

When the Chrome for Android team started using it in its "Incognito" mode (https://github.com/chromium/chromium/commit/5c08787e71f7f758001542e6cc2f87f50bf12064), Mozc for Android mapped `IME_FLAG_NO_PERSONALIZED_LEARNING` to its own "secret mode". The same behavior has also been inherited by Gboard.

Now that similar signals are available in TSF/IBus, the assumption here is that disabling personalized learning alone may be more appropriate than automatically enabling "secret mode" for existing desktop Mozc users for the following reasons:

 - What MS-IME does for `IS_PRIVATE` is actually to disable personalized learning while keeping other personalized features intact.
 - There is no visual indicator when the "secret mode" is enabled in the desktop renderer. Users would have no idea why conversion results are different only on the incognito mode in Chromium-based browsers and private-browsing mode in Firefox-based browsers.
 - `mozc.commands.Request` has been implemented as a handler-global state, not per-session state. `SessionHandler::SetRequest` ignores the session id and pushes the new request onto every live session. Sent from one Windows app, `is_incognito_mode` would have leaked into all other apps' sessions on the shared `mozc_server`, which is not a desirable behavior.

With the above considerations, it seems more appropriate to interpret `IS_PRIVATE`/`IBUS_INPUT_HINT_PRIVATE` as a "no personalized learning" signal like how `IME_FLAG_NO_PERSONALIZED_LEARNING` is defined, even if Mozc for Android interpreted it as the "secret mode" signal instead.

## Issue IDs
N/A

## Steps to test new behaviors (if any)
 - OS: Windows 11 25H2 / Chrome 152.0.7977.65
 - Steps:
   1. Open a Chrome tab with Incognito mode enabled
   2. Enable Mozc
   3. Type "ちょうしんせいざんがい" then convert it to "超新星残骸"
   4. Type "ちょうしんせい" again
   5. Make sure that "超新星残骸" is not suggested

